### PR TITLE
Fix typo in build instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ sudo apt-get install -y libcurl4-openssl-dev libssl-dev uuid-dev zlib1g-dev libp
 # TODO: add version control
 git clone https://github.com/aws/aws-sdk-cpp.git
 cd aws-sdk-cpp || exit
-mkdir builds
+mkdir build
 cd build || exit
 # -DCUSTOM_MEMORY_MANAGEMENT=0 is added to avoid Aws::String and std::string issue
 # ref: https://github.com/aws/aws-sdk-cpp/issues/416


### PR DESCRIPTION
The instructions to install the AWS SDK failed because of a mismatch between "build" and its plural, "builds". This fixes that by using "build", which is consistent with the gflags installation.