### PR TITLE
Minor fixes to test script and Github workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,7 @@ jobs:
         ./build-docker.sh -u
 
     - name: Sanity check fbpcf library
+      timeout-minutes: 3
       run: |
         ./run-millionaire-sample.sh -u
 
@@ -32,5 +33,6 @@ jobs:
         ./build-docker.sh -c
 
     - name: Sanity check fbpcf library
+      timeout-minutes: 3
       run: |
         ./run-millionaire-sample.sh -c

--- a/run-millionaire-sample.sh
+++ b/run-millionaire-sample.sh
@@ -30,9 +30,9 @@ shift "$((OPTIND - 1))"
 
 FBPCF_IMAGE=fbpcf/${IMAGE_PREFIX}:latest
 if docker image inspect ${FBPCF_IMAGE} > /dev/null 2>&1; then
-  printf "Found %s docker image..." ${FBPCF_IMAGE}
+  printf "Found %s docker image... \n" ${FBPCF_IMAGE}
 else
-  printf "\nERROR: Unable to find docker image %s. Please run build-docker.sh " ${FBPCF_IMAGE}
+  printf "ERROR: Unable to find docker image %s. Please run build-docker.sh \n" ${FBPCF_IMAGE}
   exit 1
 fi
 
@@ -48,7 +48,7 @@ if docker run --rm \
         millionaire \
         --role=2 \
         --port=5000 \
-        --server_ip=127.0.0.1 | grep -q "connected"; then
+        --server_ip=127.0.0.1; then
   printf "Millionaire ran successfully! "
 else
   printf "Something went wrong. You may want to check the logs above."


### PR DESCRIPTION
Summary:
- Updated `run-millionaire-sample.sh` to be less fragile. It now relies on the Millionaire exit code directly
- Added timeout to test step in GitHub workflow. This helps save time if something goes wrong and partner can't connect to publisher
- Updated butterfly rule to warning if fbpcf diff is not exported

Differential Revision: D28761905

