### PR TITLE
Force cmake to version 3.11.4 for CentOS (3.18.2 is broken)

### DIFF
--- a/docker/Dockerfile.centos
+++ b/docker/Dockerfile.centos
@@ -17,6 +17,11 @@ FROM centos:centos${os_release} as dev
 # Required Packages for pcf
 # install EPEL and PowerTools for CentOS (required for g* libs and doubleconv)
 RUN echo "assumeyes=1" >> /etc/yum.conf
+
+# Temporary workaround until Centos 8 upgrades to cmake 3.20.3
+COPY docker/centos-cmake-fix.sh .
+RUN ./centos-cmake-fix.sh
+
 RUN yum -y install \
     epel-release \
     dnf-plugins-core \
@@ -24,7 +29,7 @@ RUN yum -y install \
     && yum -y install \
     boost-devel \
     ca-certificates \
-    cmake \
+    # cmake - Temporary Bug in 3.18.2-9.el8 (current centos cmake) - See Above
     double-conversion-devel \
     gcc \
     gcc-c++ \
@@ -40,6 +45,9 @@ RUN yum -y install \
     re2-devel \
     zlib-devel \
     && yum clean all
+
+
+
 RUN mkdir -p /root/build/fbpcf
 WORKDIR /root/build/fbpcf
 

--- a/docker/aws-s3-core/Dockerfile.centos
+++ b/docker/aws-s3-core/Dockerfile.centos
@@ -9,7 +9,7 @@ ARG aws_release="1.8.177"
 # Base development environment
 RUN yum -y install \
     ca-certificates \
-    cmake \
+    # cmake - Temporary Bug in 3.18.2-9.el8 (current centos cmake) - See Below
     gcc \
     gcc-c++ \
     git \
@@ -18,6 +18,11 @@ RUN yum -y install \
     openssl-devel \
     zlib-devel \
     && yum clean all
+
+# Temporary workaround until Centos 8 upgrades to cmake 3.20.3
+COPY docker/centos-cmake-fix.sh .
+RUN ./centos-cmake-fix.sh
+
 RUN mkdir /root/build
 WORKDIR /root/build
 

--- a/docker/centos-cmake-fix.sh
+++ b/docker/centos-cmake-fix.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# This is a temporary fix that installs the previous cmake 3.11.4
+# until Centos 8 upgrades from 3.18.2 to 3.20.3
+set -e
+
+yum -y install \
+    emacs-filesystem \
+    wget \
+    libuv \
+    && yum clean all
+wget https://rpmfind.net/linux/centos/8.3.2011/AppStream/x86_64/os/Packages/cmake-3.11.4-7.el8.x86_64.rpm
+wget https://rpmfind.net/linux/centos/8.3.2011/AppStream/x86_64/os/Packages/cmake-data-3.11.4-7.el8.noarch.rpm
+wget https://rpmfind.net/linux/centos/8.3.2011/AppStream/x86_64/os/Packages/cmake-filesystem-3.11.4-7.el8.x86_64.rpm
+wget https://rpmfind.net/linux/centos/8.3.2011/AppStream/x86_64/os/Packages/cmake-rpm-macros-3.11.4-7.el8.noarch.rpm
+rpm -i ./*.rpm
+rm ./*.rpm
+rm ./centos-cmake-fix.sh

--- a/docker/emp/Dockerfile.centos
+++ b/docker/emp/Dockerfile.centos
@@ -8,13 +8,18 @@ FROM centos:centos${os_release} AS dev-environment
 # Base development environment
 RUN yum -y install \
     ca-certificates \
-    cmake \
+    # cmake - Temporary Bug in 3.18.2-9.el8 (current centos cmake) - See Below
     gcc \
     gcc-c++ \
     git \
     gmp-devel \
     make \
     && yum clean all
+
+# Temporary workaround until Centos 8 upgrades to cmake 3.20.3
+COPY docker/centos-cmake-fix.sh .
+RUN ./centos-cmake-fix.sh
+
 RUN mkdir /root/build
 WORKDIR /root/build
 

--- a/docker/folly/Dockerfile.centos
+++ b/docker/folly/Dockerfile.centos
@@ -11,12 +11,17 @@ ARG folly_release="2021.03.29.00"
 # Required Packages for all builds
 RUN yum -y install \
     ca-certificates \
-    cmake \
+    # cmake - Temporary Bug in 3.18.2-9.el8 (current centos cmake) - See Below
     gcc \
     gcc-c++ \
     git \
     make \
     && yum clean all
+
+# Temporary workaround until Centos 8 upgrades to cmake 3.20.3
+COPY docker/centos-cmake-fix.sh .
+RUN ./centos-cmake-fix.sh
+
 RUN mkdir /root/build
 WORKDIR /root/build
 


### PR DESCRIPTION
Summary: For some reason CentOS does not "lock" their versions for releases and recently upgraded cmake to version 3.18.2 (which has a bug throwing the error `cmake: symbol lookup error: cmake: undefined symbol: archive_write_add_filter_zstd`

Reviewed By: ajaybhargavb

Differential Revision: D28911701

