### PR TITLE
Build a common utility to wrap GTEST

### DIFF
--- a/pcf/mpc/EmpTestUtil.h
+++ b/pcf/mpc/EmpTestUtil.h
@@ -3,7 +3,7 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
 #pragma once
 
@@ -13,6 +13,8 @@
 #include <thread>
 #include <utility>
 #include <vector>
+
+#include <emp-sh2pc/emp-sh2pc.h>
 
 #include "folly/Synchronized.h"
 
@@ -38,7 +40,7 @@ std::pair<OutputDataType, OutputDataType> test(
       return game.perfPlay(input);
     } catch (const std::exception& e) {
       std::cout << "Exception occured. " << e.what() << endl;
-      exit(-1);
+      exit(EXIT_FAILURE);
     }
   };
 
@@ -49,6 +51,32 @@ std::pair<OutputDataType, OutputDataType> test(
   auto resBob = futureBob.get();
 
   return std::make_pair(resAlice, resBob);
+}
+
+template <class GTest>
+void wrapTest(GTest gTest) {
+  auto queueA = std::make_shared<folly::Synchronized<std::queue<char>>>();
+  auto queueB = std::make_shared<folly::Synchronized<std::queue<char>>>();
+
+  auto lambda = [&queueA, &queueB, &gTest](Party party) {
+    auto io = std::make_unique<QueueIO>(
+        party == Party::Alice ? QueueIO{queueA, queueB}
+                              : QueueIO{queueB, queueA});
+    emp::setup_semi_honest(io.get(), static_cast<int>(party));
+
+    try {
+      gTest();
+    } catch (const std::exception& e) {
+      std::cout << "Exception occured. " << e.what() << endl;
+      exit(EXIT_FAILURE);
+    }
+  };
+
+  auto futureAlice = std::async(lambda, Party::Alice);
+  auto futureBob = std::async(lambda, Party::Bob);
+
+  futureAlice.wait();
+  futureBob.wait();
 }
 
 bool isTestable();


### PR DESCRIPTION
Summary: Following discussion in D29114588, we want to build a generic utility for running any tests built on top of EMP. pcf::mpc::test is purposed to test EMP games only. We can rename it. This utility is to test lower level operations.

Differential Revision: D29225148

