### PR TITLE
Fix a bug that no exception thrown when a file was not written correctly

### DIFF
--- a/fbpcf/io/LocalFileManager.cpp
+++ b/fbpcf/io/LocalFileManager.cpp
@@ -3,7 +3,7 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
 #include "LocalFileManager.h"
 
@@ -41,6 +41,10 @@ void LocalFileManager::write(
     const std::string& fileName,
     const std::string& data) {
   std::ofstream os{fileName};
+  if (!os.is_open()) {
+    throw PcfException{folly::sformat("Failed to open file {}", fileName)};
+  }
+
   os << data;
 }
 } // namespace fbpcf

--- a/fbpcf/io/test/LocalFileManagerTest.cpp
+++ b/fbpcf/io/test/LocalFileManagerTest.cpp
@@ -3,7 +3,7 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
 #include <cstdio>
 #include <stdexcept>
@@ -39,5 +39,11 @@ TEST_F(LocalFileManagerTest, testReadWrite) {
 TEST_F(LocalFileManagerTest, testReadException) {
   LocalFileManager fileManager;
   EXPECT_THROW(fileManager.read("./fakedfile"), PcfException);
+}
+
+TEST_F(LocalFileManagerTest, testWriteException) {
+  LocalFileManager fileManager;
+  EXPECT_THROW(
+      fileManager.write("./fakedfolder/fakedfile", testData_), PcfException);
 }
 } // namespace fbpcf


### PR DESCRIPTION
Summary: leegross found this bug during testing. PCF didn't throw any error when the directory didn't exist so the file was not really created. It's pretty bad because it's so hard to debug for this kind of issue.

Differential Revision: D29353671

