### PR TITLE
Move fbpcf to fbcode/ - Update remaining includes and cleanup

### DIFF
--- a/docker/CMakeLists.txt
+++ b/docker/CMakeLists.txt
@@ -20,7 +20,6 @@ file(GLOB_RECURSE fbpcf_src
   fbpcf/**.h
   fbpcf/**.hpp)
 list(FILTER fbpcf_src EXCLUDE REGEX ".*\/test\/.*") # Exclude test files
-list(FILTER fbpcf_src EXCLUDE REGEX ".*\/example\/.*") # Exclude example files
 
 add_library(${NAME} STATIC
   ${fbpcf_src})

--- a/example/millionaire/MillionaireApp.cpp
+++ b/example/millionaire/MillionaireApp.cpp
@@ -3,7 +3,7 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
 #include "folly/Random.h"
 

--- a/example/millionaire/MillionaireApp.h
+++ b/example/millionaire/MillionaireApp.h
@@ -3,20 +3,21 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
 #pragma once
 
 #include <emp-sh2pc/emp-sh2pc.h>
 
-#include "../../mpc/EmpApp.h"
 #include "./MillionaireGame.h"
+#include "fbpcf/mpc/EmpApp.h"
 
 namespace fbpcf {
 class MillionaireApp : public EmpApp<MillionaireGame<emp::NetIO>, int, bool> {
  public:
   MillionaireApp(Party party, const std::string& serverIp, uint16_t port)
       : EmpApp<MillionaireGame<emp::NetIO>, int, bool>{party, serverIp, port} {}
+
  protected:
   int getInputData() override;
   void putOutputData(const bool& output) override;

--- a/example/millionaire/MillionaireGame.h
+++ b/example/millionaire/MillionaireGame.h
@@ -3,12 +3,12 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
 #include <memory>
 
+#include "fbpcf/mpc/EmpGame.h"
 #include "folly/logging/xlog.h"
-#include "../../mpc/EmpGame.h"
 
 namespace fbpcf {
 // define the classic millionaire game

--- a/example/millionaire/main.cpp
+++ b/example/millionaire/main.cpp
@@ -12,8 +12,8 @@
 #include "folly/init/Init.h"
 #include "folly/logging/xlog.h"
 
-#include "../../exception/ExceptionBase.h"
 #include "./MillionaireApp.h"
+#include "fbpcf/exception/ExceptionBase.h"
 
 DEFINE_int32(role, 1, "1 = Alice, 2 = Bob");
 DEFINE_string(server_ip, "", "Server's IP address");
@@ -32,11 +32,7 @@ int main(int argc, char* argv[]) {
   auto role = static_cast<fbpcf::Party>(FLAGS_role);
 
   try {
-    fbpcf::MillionaireApp(
-        role,
-        FLAGS_server_ip,
-        FLAGS_port)
-        .run();
+    fbpcf::MillionaireApp(role, FLAGS_server_ip, FLAGS_port).run();
   } catch (const fbpcf::ExceptionBase& e) {
     XLOGF(ERR, "Some error occured: {}", e.what());
     return 1;

--- a/example/millionaire/test/MillionaireAppTest.cpp
+++ b/example/millionaire/test/MillionaireAppTest.cpp
@@ -3,7 +3,7 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
 #include <future>
 

--- a/example/millionaire/test/MillionaireGameTest.cpp
+++ b/example/millionaire/test/MillionaireGameTest.cpp
@@ -3,16 +3,16 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
 #include <memory>
 
 #include <emp-sh2pc/emp-sh2pc.h>
 #include <gtest/gtest.h>
 
-#include "../../../system/CpuUtil.h"
-#include "../../../mpc/EmpTestUtil.h"
 #include "../MillionaireGame.h"
+#include "fbpcf/mpc/EmpTestUtil.h"
+#include "fbpcf/system/CpuUtil.h"
 
 namespace fbpcf {
 TEST(MillionaireGame, AliceIsRicher) {

--- a/fbpcf/aws/AwsSdk.cpp
+++ b/fbpcf/aws/AwsSdk.cpp
@@ -3,7 +3,7 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
 #include "AwsSdk.h"
 

--- a/fbpcf/aws/AwsSdk.h
+++ b/fbpcf/aws/AwsSdk.h
@@ -3,7 +3,7 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
 #pragma once
 

--- a/fbpcf/aws/MockS3Client.h
+++ b/fbpcf/aws/MockS3Client.h
@@ -3,7 +3,7 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
 #pragma once
 

--- a/fbpcf/aws/S3Util.cpp
+++ b/fbpcf/aws/S3Util.cpp
@@ -25,7 +25,7 @@
 #include <folly/Uri.h>
 #include <re2/re2.h>
 
-#include "../exception/AwsException.h"
+#include "fbpcf/exception/AwsException.h"
 #include "folly/Range.h"
 
 namespace fbpcf::aws {

--- a/fbpcf/aws/S3Util.h
+++ b/fbpcf/aws/S3Util.h
@@ -3,7 +3,7 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
 #pragma once
 

--- a/fbpcf/aws/test/AwsSdkTest.cpp
+++ b/fbpcf/aws/test/AwsSdkTest.cpp
@@ -3,9 +3,9 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
-#include "../AwsSdk.h"
+#include "fbpcf/aws/AwsSdk.h"
 
 #include <aws/s3/S3Client.h>
 #include <gtest/gtest.h>

--- a/fbpcf/aws/test/MockS3ClientTest.cpp
+++ b/fbpcf/aws/test/MockS3ClientTest.cpp
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "../MockS3Client.h"
-#include "../AwsSdk.h"
+#include "fbpcf/aws/MockS3Client.h"
+#include "fbpcf/aws/AwsSdk.h"
 
 #include <aws/s3/S3Client.h>
 #include <gmock/gmock.h>

--- a/fbpcf/aws/test/S3UtilTest.cpp
+++ b/fbpcf/aws/test/S3UtilTest.cpp
@@ -5,14 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "../S3Util.h"
+#include "fbpcf/aws/S3Util.h"
 
 #include <stdexcept>
 #include <string>
 
 #include <gtest/gtest.h>
 
-#include "../../exception/AwsException.h"
+#include "fbpcf/exception/AwsException.h"
 
 namespace fbpcf {
 TEST(S3Util, uriToObjectReference) {

--- a/fbpcf/common/FunctionalUtil.h
+++ b/fbpcf/common/FunctionalUtil.h
@@ -4,7 +4,7 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
 #pragma once
 

--- a/fbpcf/common/VectorUtil.h
+++ b/fbpcf/common/VectorUtil.h
@@ -3,7 +3,7 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
 #pragma once
 
@@ -40,7 +40,7 @@ std::vector<T> Add(const std::vector<T>& a, const std::vector<T>& b) {
 }
 
 template <typename T>
-    std::vector<T> Xor(const std::vector<T>& a, const std::vector<T>& b) {
-      return apply<T>(a, b, [](const T& x, const T& y) { return x ^ y; });
-    }
+std::vector<T> Xor(const std::vector<T>& a, const std::vector<T>& b) {
+  return apply<T>(a, b, [](const T& x, const T& y) { return x ^ y; });
+}
 } // namespace fbpcf::vector

--- a/fbpcf/common/test/FunctionalUtilTest.cpp
+++ b/fbpcf/common/test/FunctionalUtilTest.cpp
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "../FunctionalUtil.h"
+#include "fbpcf/common/FunctionalUtil.h"
 
 #include <stdexcept>
 #include <string>

--- a/fbpcf/common/test/VectorUtilTest.cpp
+++ b/fbpcf/common/test/VectorUtilTest.cpp
@@ -3,7 +3,7 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
 #include <stdexcept>
 #include <string>
@@ -11,7 +11,7 @@
 
 #include <gtest/gtest.h>
 
-#include "../VectorUtil.h"
+#include "fbpcf/common/VectorUtil.h"
 
 namespace fbpcf::vector {
 TEST(FunctionalUtilTest, TestVectorAdd) {

--- a/fbpcf/exception/AwsException.h
+++ b/fbpcf/exception/AwsException.h
@@ -3,7 +3,7 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
 #pragma once
 
@@ -13,6 +13,7 @@ namespace fbpcf {
 class AwsException : public ExceptionBase {
  public:
   explicit AwsException(const std::string& error) : ExceptionBase{error} {}
-  explicit AwsException(const std::exception& exception) : ExceptionBase{exception} {}
+  explicit AwsException(const std::exception& exception)
+      : ExceptionBase{exception} {}
 };
 } // namespace fbpcf

--- a/fbpcf/exception/ExceptionBase.cpp
+++ b/fbpcf/exception/ExceptionBase.cpp
@@ -3,7 +3,7 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
 #include "ExceptionBase.h"
 

--- a/fbpcf/exception/ExceptionBase.h
+++ b/fbpcf/exception/ExceptionBase.h
@@ -3,7 +3,7 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
 #pragma once
 
@@ -14,7 +14,8 @@ namespace fbpcf {
 class ExceptionBase : public std::exception {
  public:
   explicit ExceptionBase(const std::string& error) : error_{error} {}
-  explicit ExceptionBase(const std::exception& exception) : error_{exception.what()} {}
+  explicit ExceptionBase(const std::exception& exception)
+      : error_{exception.what()} {}
 
   const char* what() const noexcept override;
 

--- a/fbpcf/exception/PcfException.h
+++ b/fbpcf/exception/PcfException.h
@@ -3,7 +3,7 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
 #pragma once
 
@@ -13,6 +13,7 @@ namespace fbpcf {
 class PcfException : public ExceptionBase {
  public:
   explicit PcfException(const std::string& error) : ExceptionBase{error} {}
-  explicit PcfException(const std::exception& exception) : ExceptionBase{exception} {}
+  explicit PcfException(const std::exception& exception)
+      : ExceptionBase{exception} {}
 };
 } // namespace fbpcf

--- a/fbpcf/io/FileManagerUtil.cpp
+++ b/fbpcf/io/FileManagerUtil.cpp
@@ -3,13 +3,13 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
 #include "FileManagerUtil.h"
 
-#include "../aws/S3Util.h"
 #include "LocalFileManager.h"
 #include "S3FileManager.h"
+#include "fbpcf/aws/S3Util.h"
 
 namespace fbpcf::io {
 std::unique_ptr<IInputStream> getInputStream(const std::string& fileName) {
@@ -32,7 +32,8 @@ FileType getFileType(const std::string& fileName) {
   return fileName.find("https://", 0) == 0 ? FileType::S3 : FileType::Local;
 }
 
-std::unique_ptr<fbpcf::IFileManager> getFileManager(const std::string& fileName) {
+std::unique_ptr<fbpcf::IFileManager> getFileManager(
+    const std::string& fileName) {
   auto type = getFileType(fileName);
   if (type == FileType ::S3) {
     return std::make_unique<S3FileManager>(

--- a/fbpcf/io/FileManagerUtil.h
+++ b/fbpcf/io/FileManagerUtil.h
@@ -3,7 +3,7 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
 #pragma once
 
@@ -24,5 +24,6 @@ void write(const std::string& fileName, const std::string& data);
 
 FileType getFileType(const std::string& fileName);
 
-std::unique_ptr<fbpcf::IFileManager> getFileManager(const std::string& fileName);
+std::unique_ptr<fbpcf::IFileManager> getFileManager(
+    const std::string& fileName);
 } // namespace fbpcf::io

--- a/fbpcf/io/IFileManager.h
+++ b/fbpcf/io/IFileManager.h
@@ -3,13 +3,13 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
 #pragma once
 
 #include <istream>
-#include <string>
 #include <memory>
+#include <string>
 
 #include "IInputStream.h"
 
@@ -18,7 +18,8 @@ class IFileManager {
  public:
   virtual ~IFileManager() {}
 
-  virtual std::unique_ptr<IInputStream> getInputStream(const std::string& fileName) = 0;
+  virtual std::unique_ptr<IInputStream> getInputStream(
+      const std::string& fileName) = 0;
 
   virtual std::string read(const std::string& fileName) = 0;
 

--- a/fbpcf/io/IInputStream.h
+++ b/fbpcf/io/IInputStream.h
@@ -3,7 +3,7 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
 #pragma once
 

--- a/fbpcf/io/LocalFileManager.cpp
+++ b/fbpcf/io/LocalFileManager.cpp
@@ -3,7 +3,7 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
 #include "LocalFileManager.h"
 
@@ -14,8 +14,8 @@
 
 #include "folly/Format.h"
 
-#include "../exception/PcfException.h"
 #include "LocalInputStream.h"
+#include "fbpcf/exception/PcfException.h"
 
 namespace fbpcf {
 std::unique_ptr<IInputStream> LocalFileManager::getInputStream(

--- a/fbpcf/io/LocalFileManager.h
+++ b/fbpcf/io/LocalFileManager.h
@@ -3,7 +3,7 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
 #pragma once
 
@@ -14,7 +14,8 @@
 namespace fbpcf {
 class LocalFileManager : public IFileManager {
  public:
-  std::unique_ptr<IInputStream> getInputStream(const std::string& fileName) override;
+  std::unique_ptr<IInputStream> getInputStream(
+      const std::string& fileName) override;
 
   std::string read(const std::string& fileName) override;
 

--- a/fbpcf/io/LocalInputStream.cpp
+++ b/fbpcf/io/LocalInputStream.cpp
@@ -3,7 +3,7 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
 #include "LocalInputStream.h"
 

--- a/fbpcf/io/LocalInputStream.h
+++ b/fbpcf/io/LocalInputStream.h
@@ -3,7 +3,7 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
 #pragma once
 

--- a/fbpcf/io/MockFileManager.h
+++ b/fbpcf/io/MockFileManager.h
@@ -3,7 +3,7 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
 #pragma once
 

--- a/fbpcf/io/S3FileManager.cpp
+++ b/fbpcf/io/S3FileManager.cpp
@@ -3,7 +3,7 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
 #include "S3FileManager.h"
 
@@ -13,9 +13,9 @@
 #include <aws/s3/model/GetObjectRequest.h>
 #include <aws/s3/model/PutObjectRequest.h>
 
-#include "../aws/S3Util.h"
-#include "../exception/AwsException.h"
 #include "S3InputStream.h"
+#include "fbpcf/aws/S3Util.h"
+#include "fbpcf/exception/AwsException.h"
 
 namespace fbpcf {
 

--- a/fbpcf/io/S3FileManager.h
+++ b/fbpcf/io/S3FileManager.h
@@ -3,7 +3,7 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
 #pragma once
 
@@ -19,7 +19,8 @@ class S3FileManager : public IFileManager {
   explicit S3FileManager(std::unique_ptr<Aws::S3::S3Client> client)
       : s3Client_{std::move(client)} {}
 
-   std::unique_ptr<IInputStream> getInputStream(const std::string& fileName) override;
+  std::unique_ptr<IInputStream> getInputStream(
+      const std::string& fileName) override;
 
   std::string read(const std::string& fileName) override;
 

--- a/fbpcf/io/S3InputStream.cpp
+++ b/fbpcf/io/S3InputStream.cpp
@@ -3,7 +3,7 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
 #include "S3InputStream.h"
 

--- a/fbpcf/io/S3InputStream.h
+++ b/fbpcf/io/S3InputStream.h
@@ -3,7 +3,7 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
 #pragma once
 
@@ -16,7 +16,8 @@
 namespace fbpcf {
 class S3InputStream : public IInputStream {
  public:
-  explicit S3InputStream(Aws::S3::Model::GetObjectResult r) : r_{std::move(r)} {}
+  explicit S3InputStream(Aws::S3::Model::GetObjectResult r)
+      : r_{std::move(r)} {}
 
   std::istream& get() override;
 

--- a/fbpcf/io/test/FileManagerUtilTest.cpp
+++ b/fbpcf/io/test/FileManagerUtilTest.cpp
@@ -3,12 +3,12 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
 #include <gtest/gtest.h>
 
-#include "../FileManagerUtil.h"
-#include "../S3FileManager.h"
+#include "fbpcf/io/FileManagerUtil.h"
+#include "fbpcf/io/S3FileManager.h"
 
 namespace fbpcf::io {
 TEST(FileManagerUtilTest, TestGetS3FileType) {

--- a/fbpcf/io/test/LocalFileManagerTest.cpp
+++ b/fbpcf/io/test/LocalFileManagerTest.cpp
@@ -3,7 +3,7 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
 #include <cstdio>
 #include <stdexcept>
@@ -14,8 +14,8 @@
 #include "folly/Format.h"
 #include "folly/Random.h"
 
-#include "../../exception/PcfException.h"
-#include "../LocalFileManager.h"
+#include "fbpcf/exception/PcfException.h"
+#include "fbpcf/io/LocalFileManager.h"
 
 namespace fbpcf {
 class LocalFileManagerTest : public ::testing::Test {

--- a/fbpcf/io/test/S3FileManagerTest.cpp
+++ b/fbpcf/io/test/S3FileManagerTest.cpp
@@ -11,11 +11,11 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include "../../aws/AwsSdk.h"
-#include "../../aws/MockS3Client.h"
-#include "../../exception/AwsException.h"
-#include "../MockFileManager.h"
-#include "../S3FileManager.h"
+#include "fbpcf/aws/AwsSdk.h"
+#include "fbpcf/aws/MockS3Client.h"
+#include "fbpcf/exception/AwsException.h"
+#include "fbpcf/io/MockFileManager.h"
+#include "fbpcf/io/S3FileManager.h"
 
 using ::testing::_;
 

--- a/fbpcf/mpc/EmpApp.h
+++ b/fbpcf/mpc/EmpApp.h
@@ -3,7 +3,7 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
 #pragma once
 

--- a/fbpcf/mpc/EmpGame.h
+++ b/fbpcf/mpc/EmpGame.h
@@ -3,7 +3,7 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
 #pragma once
 
@@ -26,11 +26,8 @@ enum class Visibility {
 template <class IOChannel, class InputDataType, class OutputDataType>
 class EmpGame : public IMpcGame<InputDataType, OutputDataType> {
  public:
-  EmpGame(
-      std::unique_ptr<IOChannel> ioChannel,
-      Party party)
-      : party_{party},
-        ioChannel_{std::move(ioChannel)} {
+  EmpGame(std::unique_ptr<IOChannel> ioChannel, Party party)
+      : party_{party}, ioChannel_{std::move(ioChannel)} {
     emp::setup_semi_honest(ioChannel_.get(), static_cast<int>(party));
   }
 

--- a/fbpcf/mpc/EmpTestUtil.cpp
+++ b/fbpcf/mpc/EmpTestUtil.cpp
@@ -3,11 +3,11 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
 #include "EmpTestUtil.h"
 
-#include "../system/CpuUtil.h"
+#include "fbpcf/system/CpuUtil.h"
 
 namespace fbpcf::mpc {
 bool isTestable() {

--- a/fbpcf/mpc/EmpTestUtil.h
+++ b/fbpcf/mpc/EmpTestUtil.h
@@ -18,9 +18,9 @@
 
 #include "folly/Synchronized.h"
 
-#include "../system/CpuUtil.h"
 #include "EmpGame.h"
 #include "QueueIO.h"
+#include "fbpcf/system/CpuUtil.h"
 
 namespace fbpcf::mpc {
 template <class EmpGameClass, class InputDataType, class OutputDataType>

--- a/fbpcf/mpc/EmpVector.h
+++ b/fbpcf/mpc/EmpVector.h
@@ -14,8 +14,8 @@
 
 #include <emp-sh2pc/emp-sh2pc.h>
 
-#include "../common/FunctionalUtil.h"
-#include "../exception/PcfException.h"
+#include "fbpcf/common/FunctionalUtil.h"
+#include "fbpcf/exception/PcfException.h"
 
 namespace fbpcf {
 template <typename EmpType>

--- a/fbpcf/mpc/IMpcGame.h
+++ b/fbpcf/mpc/IMpcGame.h
@@ -3,13 +3,13 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
 #pragma once
 
 #include <functional>
 
-#include "../perf/PerfUtil.h"
+#include "fbpcf/perf/PerfUtil.h"
 
 namespace fbpcf {
 template <class InputDataType, class OutputDataType>

--- a/fbpcf/mpc/QueueIO.cpp
+++ b/fbpcf/mpc/QueueIO.cpp
@@ -3,7 +3,7 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
 #include "QueueIO.h"
 

--- a/fbpcf/mpc/QueueIO.h
+++ b/fbpcf/mpc/QueueIO.h
@@ -3,7 +3,7 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
 #pragma once
 
@@ -18,10 +18,8 @@ namespace fbpcf {
 class QueueIO : public emp::IOChannel<QueueIO> {
  public:
   QueueIO(
-      const std::shared_ptr<folly::Synchronized<std::queue<char>>>
-          inQueue,
-      const std::shared_ptr<folly::Synchronized<std::queue<char>>>
-          outQueue)
+      const std::shared_ptr<folly::Synchronized<std::queue<char>>> inQueue,
+      const std::shared_ptr<folly::Synchronized<std::queue<char>>> outQueue)
       : inQueue_{inQueue}, outQueue_{outQueue} {}
 
   void send_data(const void* data, int64_t len);

--- a/fbpcf/mpc/test/EmpVectorTest.cpp
+++ b/fbpcf/mpc/test/EmpVectorTest.cpp
@@ -9,13 +9,13 @@
 
 #include <gtest/gtest.h>
 
-#include "../../common/FunctionalUtil.h"
-#include "../../exception/PcfException.h"
-#include "../EmpGame.h"
-#include "../EmpTestUtil.h"
-#include "../EmpVector.h"
-#include "../QueueIO.h"
-#include "../../system/CpuUtil.h"
+#include "fbpcf/common/FunctionalUtil.h"
+#include "fbpcf/exception/PcfException.h"
+#include "fbpcf/mpc/EmpGame.h"
+#include "fbpcf/mpc/EmpTestUtil.h"
+#include "fbpcf/mpc/EmpVector.h"
+#include "fbpcf/mpc/QueueIO.h"
+#include "fbpcf/system/CpuUtil.h"
 
 namespace fbpcf {
 class EmpVectorTest
@@ -52,8 +52,8 @@ TEST(EmpVectorTest, TestMap) {
 
   std::vector<int64_t> expectedRes{0, 0, 0};
 
-  auto res =
-      fbpcf::mpc::test<EmpVectorTest, std::vector<int64_t>, std::vector<int64_t>>(
+  auto res = fbpcf::mpc::
+      test<EmpVectorTest, std::vector<int64_t>, std::vector<int64_t>>(
           std::vector<int64_t>{1, 2, 3}, std::vector<int64_t>{1, 2, 3});
 
   EXPECT_EQ(expectedRes, res.first);

--- a/fbpcf/mpc/test/MpcAppExecutorTest.cpp
+++ b/fbpcf/mpc/test/MpcAppExecutorTest.cpp
@@ -12,8 +12,8 @@
 
 #include "folly/Random.h"
 
+#include "fbpcf/mpc/MpcAppExecutor.h"
 #include "test_apps/millionaire/MillionaireApp.h"
-#include "../MpcAppExecutor.h"
 
 namespace fbpcf {
 class MpcAppExecutorTest : public ::testing::Test {

--- a/fbpcf/mpc/test/QueueIOTest.cpp
+++ b/fbpcf/mpc/test/QueueIOTest.cpp
@@ -3,7 +3,7 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
 #include <array>
 #include <memory>
@@ -12,7 +12,7 @@
 
 #include <gtest/gtest.h>
 
-#include "../QueueIO.h"
+#include "fbpcf/mpc/QueueIO.h"
 
 namespace fbpcf {
 TEST(QueueIOTest, ReadAndWrite) {

--- a/fbpcf/mpc/test/test_apps/millionaire/MillionaireApp.cpp
+++ b/fbpcf/mpc/test/test_apps/millionaire/MillionaireApp.cpp
@@ -3,7 +3,7 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
 #include "folly/Random.h"
 

--- a/fbpcf/mpc/test/test_apps/millionaire/MillionaireApp.h
+++ b/fbpcf/mpc/test/test_apps/millionaire/MillionaireApp.h
@@ -3,20 +3,21 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
 #pragma once
 
 #include <emp-sh2pc/emp-sh2pc.h>
 
-#include "../../../EmpApp.h"
 #include "./MillionaireGame.h"
+#include "fbpcf/mpc/EmpApp.h"
 
 namespace fbpcf {
 class MillionaireApp : public EmpApp<MillionaireGame<emp::NetIO>, int, bool> {
  public:
   MillionaireApp(Party party, const std::string& serverIp, uint16_t port)
       : EmpApp<MillionaireGame<emp::NetIO>, int, bool>{party, serverIp, port} {}
+
  protected:
   int getInputData() override;
   void putOutputData(const bool& output) override;

--- a/fbpcf/mpc/test/test_apps/millionaire/MillionaireGame.h
+++ b/fbpcf/mpc/test/test_apps/millionaire/MillionaireGame.h
@@ -3,12 +3,12 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
 #include <memory>
 
+#include "fbpcf/mpc/EmpGame.h"
 #include "folly/logging/xlog.h"
-#include "../../../EmpGame.h"
 
 namespace fbpcf {
 // define the classic millionaire game

--- a/fbpcf/perf/PerfUtil.h
+++ b/fbpcf/perf/PerfUtil.h
@@ -3,7 +3,7 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
 #pragma once
 

--- a/fbpcf/perf/test/PerfUtilTest.cpp
+++ b/fbpcf/perf/test/PerfUtilTest.cpp
@@ -3,11 +3,11 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
 #include <gtest/gtest.h>
 
-#include "../PerfUtil.h"
+#include "fbpcf/perf/PerfUtil.h"
 
 namespace fbpcf::perf {
 class TestClass {

--- a/fbpcf/system/CpuUtil.cpp
+++ b/fbpcf/system/CpuUtil.cpp
@@ -3,7 +3,7 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
 #include "CpuUtil.h"
 

--- a/fbpcf/system/CpuUtil.h
+++ b/fbpcf/system/CpuUtil.h
@@ -3,7 +3,7 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
-*/
+ */
 
 #pragma once
 

--- a/fbpcf/test/emp/EMPOperator.hpp
+++ b/fbpcf/test/emp/EMPOperator.hpp
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "../../mpc/EmpGame.h"
-#include "../../mpc/QueueIO.h"
+#include "fbpcf/mpc/EmpGame.h"
+#include "fbpcf/mpc/QueueIO.h"
 
 namespace fbpcf {
 

--- a/fbpcf/test/emp/EMPOperatorTest.cpp
+++ b/fbpcf/test/emp/EMPOperatorTest.cpp
@@ -14,10 +14,10 @@
 
 #include "folly/logging/xlog.h"
 
-#include "../../mpc/EmpTestUtil.h"
-#include "../../system/CpuUtil.h"
 #include "EMPOperator.hpp"
 #include "EMPOperatorTestConfig.hpp"
+#include "fbpcf/mpc/EmpTestUtil.h"
+#include "fbpcf/system/CpuUtil.h"
 
 namespace fbpcf {
 


### PR DESCRIPTION
Summary:
- Update includes in fbpcf to use absolute paths
- Move example back to root (public_tld)
- Some formatting cleanup
- Delete left over files at `private_measurement/pcf/oss/`

Differential Revision: D29371730

