### PR TITLE
Enable use of ghcr.io image for aws, emp, and folly

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -12,10 +12,11 @@ EMP_RELEASE="0.1"
 AWS_RELEASE="1.8.177"
 FMT_RELEASE="7.1.3"
 FOLLY_RELEASE="2021.03.29.00"
+GITHUB_PACKAGES="ghcr.io/facebookresearch"
 
 PROG_NAME=$0
 usage() {
-  cat << EOF >&2
+  cat <<EOF >&2
 Usage: $PROG_NAME [-u | -c] [-f]
 
 -c: builds the docker images aginsts centos
@@ -26,66 +27,72 @@ EOF
 }
 
 IMAGE_PREFIX="ubuntu"
-OS_RELEASE=${UBUNTU_RELEASE}
+OS_RELEASE="${UBUNTU_RELEASE}"
 DOCKER_EXTENSION=".ubuntu"
 FORCE_REBUILD=false
 while getopts u,c,f o; do
   case $o in
-    (u) IMAGE_PREFIX="ubuntu"
-        OS_RELEASE=${UBUNTU_RELEASE}
-        DOCKER_EXTENSION=".ubuntu";;
-    (c) IMAGE_PREFIX="centos"
-        OS_RELEASE=${CENTOS_RELEASE}
-        DOCKER_EXTENSION=".centos";;
-    (f) FORCE_REBUILD=true;;
-    (*) usage
+  u)
+    IMAGE_PREFIX="ubuntu"
+    OS_RELEASE="${UBUNTU_RELEASE}"
+    DOCKER_EXTENSION=".ubuntu"
+    ;;
+  c)
+    IMAGE_PREFIX="centos"
+    OS_RELEASE="${CENTOS_RELEASE}"
+    DOCKER_EXTENSION=".centos"
+    ;;
+  f) FORCE_REBUILD=true ;;
+  *) usage ;;
   esac
 done
 shift "$((OPTIND - 1))"
 
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 # Docker build must run from this script build dir, so all the relative paths work inside the Dockerfile's
 cd "$SCRIPT_DIR" || exit
 
+build_dep_image() {
+  local IMAGE=$1
+  local DOCKER_DIR=$2
+  local BUILD_ARGS=$3
+  if [ "${FORCE_REBUILD}" == false ] && docker image inspect "${IMAGE}" >/dev/null 2>&1; then
+    printf "%s docker image already exists. To force a rebuild please use '-f' flag...\n" "${IMAGE}"
+  else
+    printf "attempting to pull image %s from %s...\n" "${IMAGE}" "${GITHUB_PACKAGES}"
+    if [ "${FORCE_REBUILD}" == false ] && docker pull "${GITHUB_PACKAGES}/${IMAGE}" 2>/dev/null; then
+      # Use the external ghcr.io image (if a local image doesn't exist) instead of building locally...
+      IMAGE="${GITHUB_PACKAGES}/${IMAGE}"
+      printf "successfully pulled image %s\n\n" "${IMAGE}"
+    else
+      printf "%s/%s did not exist or '-f' flag was specifed\n" "${GITHUB_PACKAGES}" "${IMAGE}"
+      printf "\nBuilding %s docker image...\n" "${IMAGE}"
+      # shellcheck disable=SC2086
+      docker build \
+        ${BUILD_ARGS} \
+        -t "${IMAGE}" -f "docker/${DOCKER_DIR}/Dockerfile${DOCKER_EXTENSION}" .
+    fi
+  fi
+  RETURN="${IMAGE}"
+}
+
 EMP_IMAGE="fbpcf/${IMAGE_PREFIX}-emp:${EMP_RELEASE}"
-if [ $FORCE_REBUILD == false ] && docker image inspect ${EMP_IMAGE} > /dev/null 2>&1; then
-  printf "%s docker image already exists. To force a rebuild please use '-f' flag...\n" ${EMP_IMAGE}
-else
-  printf "\nBuilding %s docker image...\n" ${EMP_IMAGE}
-  docker build \
-      --build-arg os_release=${OS_RELEASE} \
-      --build-arg emp_release=${EMP_RELEASE} \
-      -t ${EMP_IMAGE} -f docker/emp/Dockerfile${DOCKER_EXTENSION} .
-fi
+build_dep_image "${EMP_IMAGE}" "emp" "--build-arg os_release=${OS_RELEASE} --build-arg emp_release=${EMP_RELEASE}"
+EMP_IMAGE="${RETURN}"
 
 AWS_IMAGE="fbpcf/${IMAGE_PREFIX}-aws-s3-core:${AWS_RELEASE}"
-if [ $FORCE_REBUILD == false ] && docker image inspect ${AWS_IMAGE} > /dev/null 2>&1; then
-  printf "%s docker image already exists. To force a rebuild please use '-f' flag...\n" ${AWS_IMAGE}
-else
-  printf "\nBuilding %s docker image...\n" ${AWS_IMAGE}
-  docker build  \
-      --build-arg os_release=${OS_RELEASE} \
-      --build-arg aws_release=${AWS_RELEASE} \
-      -t ${AWS_IMAGE} -f docker/aws-s3-core/Dockerfile${DOCKER_EXTENSION} .
-fi
+build_dep_image "${AWS_IMAGE}" "aws-s3-core" "--build-arg os_release=${OS_RELEASE} --build-arg aws_release=${AWS_RELEASE}"
+AWS_IMAGE="${RETURN}"
 
 FOLLY_IMAGE="fbpcf/${IMAGE_PREFIX}-folly:${FOLLY_RELEASE}"
-if [ $FORCE_REBUILD == false ] && docker image inspect ${FOLLY_IMAGE} > /dev/null 2>&1; then
-  printf "%s docker image already exists. To force a rebuild please use '-f' flag...\n" ${FOLLY_IMAGE}
-else
-  printf "\nBuilding %s docker image...\n" ${FOLLY_IMAGE}
-  docker build  \
-      --build-arg os_release=${OS_RELEASE} \
-      --build-arg folly_release=${FOLLY_RELEASE} \
-      --build-arg fmt_release=${FMT_RELEASE} \
-      -t fbpcf/${IMAGE_PREFIX}-folly:${FOLLY_RELEASE} -f docker/folly/Dockerfile${DOCKER_EXTENSION} .
-fi
+build_dep_image "${FOLLY_IMAGE}" "folly" "--build-arg os_release=${OS_RELEASE} --build-arg folly_release=${FOLLY_RELEASE} --build-arg fmt_release=${FMT_RELEASE}"
+FOLLY_IMAGE="${RETURN}"
 
 printf "\nBuilding fbpcf/%s docker image...\n" ${IMAGE_PREFIX}
-docker build  \
-    --build-arg os_release=${OS_RELEASE} \
-    --build-arg emp_release=${EMP_RELEASE} \
-    --build-arg aws_release=${AWS_RELEASE} \
-    --build-arg folly_release=${FOLLY_RELEASE} \
-    --compress \
-    -t fbpcf/${IMAGE_PREFIX}:latest -f docker/Dockerfile${DOCKER_EXTENSION} .
+docker build \
+  --build-arg os_release="${OS_RELEASE}" \
+  --build-arg emp_image="${EMP_IMAGE}" \
+  --build-arg aws_image="${AWS_IMAGE}" \
+  --build-arg folly_image="${FOLLY_IMAGE}" \
+  --compress \
+  -t "fbpcf/${IMAGE_PREFIX}:latest" -f "docker/Dockerfile${DOCKER_EXTENSION}" .

--- a/docker/Dockerfile.centos
+++ b/docker/Dockerfile.centos
@@ -4,13 +4,13 @@
 # LICENSE file in the root directory of this source tree.
 
 ARG os_release="latest"
-ARG emp_release="0.1"
-ARG aws_release="1.8.177"
-ARG folly_release="2021.03.29.00"
+ARG emp_image="fbpcf/centos-emp:0.1"
+ARG aws_image="fbpcf/centos-aws:1.8.177"
+ARG folly_image="fbpcf/centos-folly:2021.03.29.00"
 
-FROM fbpcf/centos-emp:${emp_release} as emp
-FROM fbpcf/centos-aws-s3-core:${aws_release} as aws
-FROM fbpcf/centos-folly:${folly_release} as folly
+FROM ${emp_image} as emp
+FROM ${aws_image} as aws
+FROM ${folly_image} as folly
 
 FROM centos:centos${os_release} as dev
 

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -4,13 +4,13 @@
 # LICENSE file in the root directory of this source tree.
 
 ARG os_release="latest"
-ARG emp_release="0.1"
-ARG aws_release="1.8.177"
-ARG folly_release="2021.03.29.00"
+ARG emp_image="fbpcf/ubuntu-emp:0.1"
+ARG aws_image="fbpcf/ubuntu-aws:1.8.177"
+ARG folly_image="fbpcf/ubuntu-folly:2021.03.29.00"
 
-FROM fbpcf/ubuntu-emp:${emp_release} as emp
-FROM fbpcf/ubuntu-aws-s3-core:${aws_release} as aws
-FROM fbpcf/ubuntu-folly:${folly_release} as folly
+FROM ${emp_image} as emp
+FROM ${aws_image} as aws
+FROM ${folly_image} as folly
 
 FROM ubuntu:${os_release} as dev
 


### PR DESCRIPTION
Instead of building all our dependent images locally, we can pull the images form ghcr.io and drastically reduce build times.

The -f options still works and will override pulling ghcr.io...

Pull Request resolved: #21

Test Plan:
Built all images successfully the following ways:
Ubuntu locally with -f option
Ubuntu using ghcr.io (no options)
Centos locally with and without -f option (since the centos images do not exist in ghcr.io yet)