### PR TITLE
Fix the bug that containers can only get access to the buckets in the same region

### DIFF
--- a/fbpcf/io/FileManagerUtil.cpp
+++ b/fbpcf/io/FileManagerUtil.cpp
@@ -36,9 +36,10 @@ std::unique_ptr<fbpcf::IFileManager> getFileManager(
     const std::string& fileName) {
   auto type = getFileType(fileName);
   if (type == FileType ::S3) {
+    const auto& ref = fbpcf::aws::uriToObjectReference(fileName);
+    // Other options have to be set via environment variables
     return std::make_unique<S3FileManager>(
-        // options have to be set via environment variables
-        fbpcf::aws::createS3Client(fbpcf::aws::S3ClientOption{}));
+        fbpcf::aws::createS3Client(fbpcf::aws::S3ClientOption{.region = ref.region}));
   } else {
     return std::make_unique<LocalFileManager>();
   }


### PR DESCRIPTION
Summary:
as title.

We got error:  ``error msg: Unable to parse ExceptionName: PermanentRedirect Message: The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint. with address : 52.218.224.65 with address : 52.218.224.65 `` when containers and s3 buckets are not in the same regioin.

Differential Revision: D30172389

