### PR TITLE
Enable copyright and license header Linter rule

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-
 # Copyright (c) Facebook, Inc. and its affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
+
 set -e
 
 UBUNTU_RELEASE="20.04"

--- a/docker/cmake/fbpcf.cmake
+++ b/docker/cmake/fbpcf.cmake
@@ -1,4 +1,3 @@
-
 # Copyright (c) Facebook, Inc. and its affiliates.
 #
 # This source code is licensed under the MIT license found in the

--- a/fbpcf/common/FunctionalUtil.h
+++ b/fbpcf/common/FunctionalUtil.h
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *

--- a/run-millionaire-sample.sh
+++ b/run-millionaire-sample.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 # Copyright (c) Facebook, Inc. and its affiliates.
 #
 # This source code is licensed under the MIT license found in the


### PR DESCRIPTION
Summary:
Similar to Olivia-liu's diff, D30141706
Followed instruction below to enable a copyright Linter on the fbcode/fbpmp/ directory
https://www.internalfb.com/intern/wiki/Linting/License_Lint/#enabling-the-linter

Differential Revision: D30235738

