### PR TITLE
Add tests for SecretSharing

### DIFF
--- a/fbpcf/mpc/EmpTestUtil.h
+++ b/fbpcf/mpc/EmpTestUtil.h
@@ -54,7 +54,7 @@ std::pair<OutputDataType, OutputDataType> test(
 }
 
 template <class TestCase>
-void wrapTest(TestCase testCase) {
+void wrapTestWithParty(TestCase testCase) {
   auto queueA = std::make_shared<folly::Synchronized<std::queue<char>>>();
   auto queueB = std::make_shared<folly::Synchronized<std::queue<char>>>();
 
@@ -65,7 +65,7 @@ void wrapTest(TestCase testCase) {
     emp::setup_semi_honest(io.get(), static_cast<int>(party));
 
     try {
-      testCase();
+      testCase(party);
     } catch (const std::exception& e) {
       std::cout << "Exception occured. " << e.what() << endl;
       exit(EXIT_FAILURE);
@@ -77,6 +77,12 @@ void wrapTest(TestCase testCase) {
 
   futureAlice.wait();
   futureBob.wait();
+}
+
+template <class TestCase>
+void wrapTest(TestCase testCase) {
+  return wrapTestWithParty<std::function<void(Party party)>>(
+      [&testCase](Party party) { return testCase(); });
 }
 
 bool isTestable();


### PR DESCRIPTION
Summary:
SecretSharing.h has some pretty core functions for sharing data between Alice and Bob, and the way they work was not entirely obvious to me at first.

This diff adds unit tests for the three main types of functions in that file:
- Share an array
- Share an array of arrays (with padding)
- Share an array of arrays (no padding)

Differential Revision: D30466031

