### PR TITLE
Add support for Google Cloud Storage

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -9,6 +9,7 @@ set -e
 UBUNTU_RELEASE="20.04"
 EMP_RELEASE="0.1"
 AWS_RELEASE="1.8.177"
+GCP_RELEASE="1.32.1"
 FMT_RELEASE="7.1.3"
 FOLLY_RELEASE="2021.06.28.00"
 GITHUB_PACKAGES="ghcr.io/facebookresearch"
@@ -80,6 +81,10 @@ AWS_IMAGE="fbpcf/${IMAGE_PREFIX}-aws-s3-core:${AWS_RELEASE}"
 build_dep_image "${AWS_IMAGE}" "aws-s3-core" "--build-arg os_release=${OS_RELEASE} --build-arg aws_release=${AWS_RELEASE}"
 AWS_IMAGE="${RETURN}"
 
+GCP_IMAGE="fbpcf/${IMAGE_PREFIX}-google-cloud-cpp:${GCP_RELEASE}"
+build_dep_image "${GCP_IMAGE}" "google-cloud-cpp" "--build-arg os_release=${OS_RELEASE} --build-arg gcp_cpp_release=v${GCP_RELEASE}"
+GCP_IMAGE="${RETURN}"
+
 FOLLY_IMAGE="fbpcf/${IMAGE_PREFIX}-folly:${FOLLY_RELEASE}"
 build_dep_image "${FOLLY_IMAGE}" "folly" "--build-arg os_release=${OS_RELEASE} --build-arg folly_release=${FOLLY_RELEASE} --build-arg fmt_release=${FMT_RELEASE}"
 FOLLY_IMAGE="${RETURN}"
@@ -90,5 +95,6 @@ docker build \
   --build-arg emp_image="${EMP_IMAGE}" \
   --build-arg aws_image="${AWS_IMAGE}" \
   --build-arg folly_image="${FOLLY_IMAGE}" \
+  --build-arg gcp_image="${GCP_IMAGE}" \
   --compress \
   -t "fbpcf/${IMAGE_PREFIX}:${TAG}" -f "docker/Dockerfile${DOCKER_EXTENSION}" .

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -5,12 +5,14 @@
 
 ARG os_release="latest"
 ARG emp_image="fbpcf/ubuntu-emp:0.1"
-ARG aws_image="fbpcf/ubuntu-aws:1.8.177"
+ARG aws_image="fbpcf/ubuntu-aws-s3-core:1.8.177"
 ARG folly_image="fbpcf/ubuntu-folly:2021.03.29.00"
+ARG gcp_image="fbpcf/ubuntu-gcp-cloud-cpp:1.32.1"
 
 FROM ${emp_image} as emp
 FROM ${aws_image} as aws
 FROM ${folly_image} as folly
+FROM ${gcp_image} as gcp
 
 FROM ubuntu:${os_release} as dev
 
@@ -19,8 +21,10 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get -y update && apt-get install -y --no-install-recommends \
     build-essential \
     ca-certificates \
+    ccache \
     cmake \
     git \
+    libc-ares-dev \
     libboost-dev \
     libboost-context-dev \
     libboost-filesystem-dev \
@@ -43,6 +47,7 @@ WORKDIR /root/build/fbpcf
 COPY --from=emp /usr/local/. /usr/local/.
 COPY --from=aws /usr/local/. /usr/local/.
 COPY --from=folly /usr/local/. /usr/local/.
+COPY --from=gcp /usr/local/. /usr/local/.
 
 # fbpcf build and install
 COPY docker/CMakeLists.txt .

--- a/docker/cmake/fbpcf.cmake
+++ b/docker/cmake/fbpcf.cmake
@@ -30,6 +30,8 @@ endif()
 
 find_package(AWSSDK REQUIRED COMPONENTS s3)
 
+find_package(google_cloud_cpp_storage REQUIRED)
+
 find_library(re2 libre2.so)
 
 # since emp-tool is compiled with cc++11 and our games needs c++17 overwrite the

--- a/docker/google-cloud-cpp/Dockerfile.ubuntu
+++ b/docker/google-cloud-cpp/Dockerfile.ubuntu
@@ -1,0 +1,137 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+ARG os_release="latest"
+FROM ubuntu:${os_release} AS builder
+ARG gcp_cpp_release="1.8.177"
+# Required Packages for google-cloud-cpp 
+# Instructions modified from https://github.com/googleapis/google-cloud-cpp/blob/main/doc/packaging.md
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get -y update && apt-get install --no-install-recommends -y \
+    apt-transport-https \
+    apt-utils \
+    automake \
+    build-essential \
+    ccache \
+    cmake \
+    ca-certificates \
+    curl \
+    git \
+    gcc \
+    g++ \
+    libc-ares-dev \
+    libc-ares2 \
+    libcurl4-openssl-dev \
+    libre2-dev \
+    libssl-dev \
+    m4 \
+    make \
+    pkg-config \
+    tar \
+    wget \
+    zlib1g-dev
+
+ARG HOME="/root"
+# Download google-cloud-cpp
+RUN mkdir -p ${HOME}/google-cloud-cpp
+RUN wget -q https://github.com/googleapis/google-cloud-cpp/archive/${gcp_cpp_release}.tar.gz && \
+    tar -xf ${gcp_cpp_release}.tar.gz -C ${HOME}/google-cloud-cpp --strip=1
+
+# Install Abseil
+RUN mkdir -p ${HOME}/Downloads/abseil-cpp 
+WORKDIR ${HOME}/Downloads/abseil-cpp
+RUN curl -sSL https://github.com/abseil/abseil-cpp/archive/20210324.2.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
+    cmake \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_TESTING=OFF \
+      -DBUILD_SHARED_LIBS=yes \
+      -DCMAKE_CXX_STANDARD=11 \
+      -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j "$(nproc)" && \
+    cmake --build cmake-out --target install -- -j "$(nproc)" && \
+    ldconfig
+
+# Install Protobuf
+RUN mkdir -p ${HOME}/Downloads/protobuf 
+WORKDIR ${HOME}/Downloads/protobuf
+RUN curl -sSL https://github.com/protocolbuffers/protobuf/archive/v3.19.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=yes \
+        -Dprotobuf_BUILD_TESTS=OFF \
+        -Hcmake -Bcmake-out && \
+    cmake --build cmake-out -- -j "$(nproc)" && \
+    cmake --build cmake-out --target install -- -j "$(nproc)" && \
+    ldconfig
+
+# Install gRPC
+RUN mkdir -p ${HOME}/Downloads/grpc 
+WORKDIR ${HOME}/Downloads/grpc
+RUN curl -sSL https://github.com/grpc/grpc/archive/v1.41.1.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DgRPC_INSTALL=ON \
+        -DgRPC_BUILD_TESTS=OFF \
+        -DgRPC_ABSL_PROVIDER=package \
+        -DgRPC_CARES_PROVIDER=package \
+        -DgRPC_PROTOBUF_PROVIDER=package \
+        -DgRPC_RE2_PROVIDER=package \
+        -DgRPC_SSL_PROVIDER=package \
+        -DgRPC_ZLIB_PROVIDER=package \
+        -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j "$(nproc)" && \
+    cmake --build cmake-out --target install -- -j "$(nproc)" && \
+    ldconfig
+
+# Install crc32c
+RUN mkdir -p ${HOME}/Downloads/crc32c 
+WORKDIR ${HOME}/Downloads/crc32c
+RUN curl -sSL https://github.com/google/crc32c/archive/1.1.2.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=yes \
+        -DCRC32C_BUILD_TESTS=OFF \
+        -DCRC32C_BUILD_BENCHMARKS=OFF \
+        -DCRC32C_USE_GLOG=OFF \
+        -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j "$(nproc)" && \
+    cmake --build cmake-out --target install -- -j "$(nproc)" && \
+    ldconfig
+
+# Install nlohmann_json
+RUN mkdir -p ${HOME}/Downloads/json 
+WORKDIR ${HOME}/Downloads/json
+RUN curl -sSL https://github.com/nlohmann/json/archive/v3.10.4.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_SHARED_LIBS=yes \
+      -DBUILD_TESTING=OFF \
+      -H. -Bcmake-out/nlohmann/json && \
+    cmake --build cmake-out/nlohmann/json --target install -- -j "$(nproc)" && \
+    ldconfig
+
+# Build google-cloud-cpp
+WORKDIR ${HOME}/google-cloud-cpp
+RUN cmake \ 
+        -DBUILD_TESTING=OFF \
+        -DGOOGLE_CLOUD_CPP_ENABLE_BIGTABLE=OFF \
+        -DGOOGLE_CLOUD_CPP_ENABLE_BIGQUERY=OFF \
+        -DGOOGLE_CLOUD_CPP_ENABLE_SPANNER=OFF \
+        -DGOOGLE_CLOUD_CPP_ENABLE_PUBSUB=OFF \
+        -DGOOGLE_CLOUD_CPP_ENABLE_IAM=OFF \
+        -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
+        -H. -Bcmake-out && \
+cmake --build cmake-out -- -j "$(nproc)" && \
+cmake --build cmake-out --target install
+
+FROM ubuntu:${os_release}
+COPY --from=builder /usr/local/include/. /usr/local/include/.
+COPY --from=builder /usr/local/lib/. /usr/local/lib/.
+ENTRYPOINT [ "/bin/bash" ]


### PR DESCRIPTION
- Add basic support for Google Cloud Storage
- Similar to AWS-S3, google-cloud-cpp has to be built from source and has quite a few sets of external (built from source) dependencies

Test Plan:
```
./build-docker.sh
Building fbpcf/ubuntu-google-cloud-cpp:1.32.1 docker image...
[+] Building 441.4s (28/28) FINISHED
 => [internal] load build definition from Dockerfile.ubuntu                                                                            0.0s
 => => transferring dockerfile: 4.67kB                                                                                                 0.0s
 => [internal] load .dockerignore                                                                                                      0.0s
 => => transferring context: 2B                                                                                                        0.0s
 => [internal] load metadata for docker.io/library/ubuntu:20.04                                                                        1.1s
 => [auth] library/ubuntu:pull token for registry-1.docker.io                                                                          0.0s
 => [stage-1 1/3] FROM docker.io/library/ubuntu:20.04@sha256:626ffe58f6e7566e00254b638eb7e0f3b11d4da9675088f4781a50ae288f3322          0.0s
 => CACHED [builder  2/21] RUN apt-get -y update && apt-get install --no-install-recommends -y     apt-transport-https     apt-utils   0.0s
 => CACHED [builder  3/21] RUN mkdir -p /root/google-cloud-cpp                                                                         0.0s
 => CACHED [builder  4/21] RUN wget -q https://github.com/googleapis/google-cloud-cpp/archive/v1.32.1.tar.gz &&     tar -xf v1.32.1.t  0.0s
 => CACHED [builder  5/21] RUN mkdir -p /root/Downloads/abseil-cpp                                                                     0.0s
 => CACHED [builder  6/21] WORKDIR /root/Downloads/abseil-cpp                                                                          0.0s
 => [builder  7/21] RUN curl -sSL https://github.com/abseil/abseil-cpp/archive/20210324.2.tar.gz |     tar -xzf - --strip-components  19.8s
 => [builder  8/21] RUN mkdir -p /root/Downloads/protobuf                                                                              0.2s
 => [builder  9/21] WORKDIR /root/Downloads/protobuf                                                                                   0.0s
 => [builder 10/21] RUN curl -sSL https://github.com/protocolbuffers/protobuf/archive/v3.19.0.tar.gz |     tar -xzf - --strip-compon  60.0s
 => [builder 11/21] RUN mkdir -p /root/Downloads/grpc                                                                                  0.2s
 => [builder 12/21] WORKDIR /root/Downloads/grpc                                                                                       0.0s
 => [builder 13/21] RUN curl -sSL https://github.com/grpc/grpc/archive/v1.41.1.tar.gz |     tar -xzf - --strip-components=1 &&       139.4s
 => [builder 14/21] RUN mkdir -p /root/Downloads/crc32c                                                                                0.2s
 => [builder 15/21] WORKDIR /root/Downloads/crc32c                                                                                     0.0s
 => [builder 16/21] RUN curl -sSL https://github.com/google/crc32c/archive/1.1.2.tar.gz |     tar -xzf - --strip-components=1 &&       3.2s
 => [builder 17/21] RUN mkdir -p /root/Downloads/json                                                                                  0.2s
 => [builder 18/21] WORKDIR /root/Downloads/json                                                                                       0.0s
 => [builder 19/21] RUN curl -sSL https://github.com/nlohmann/json/archive/v3.10.4.tar.gz |     tar -xzf - --strip-components=1 &&    80.2s
 => [builder 20/21] WORKDIR /root/google-cloud-cpp                                                                                     0.0s
 => [builder 21/21] RUN cmake         -DBUILD_TESTING=OFF         -DGOOGLE_CLOUD_CPP_ENABLE_BIGTABLE=OFF         -DGOOGLE_CLOUD_CPP  135.6s
 => CACHED [stage-1 2/3] COPY --from=builder /usr/local/include/. /usr/local/include/.                                                 0.0s
 => CACHED [stage-1 3/3] COPY --from=builder /usr/local/lib/. /usr/local/lib/.                                                         0.0s
 => exporting to image                                                                                                                 0.0s
 => => exporting layers                                                                                                                0.0s
 => => writing image sha256:a920946a739795eaddb61062a345c6218bc22b6b68f0ea42e2ddb41f267fa56f                                           0.0s
 => => naming to docker.io/fbpcf/ubuntu-google-cloud-cpp:1.32.1
 ```