### PR TITLE
Move input since currently we're making a giant copy of input data

### DIFF
--- a/fbpcf/mpc/EmpTestUtil.h
+++ b/fbpcf/mpc/EmpTestUtil.h
@@ -44,8 +44,8 @@ std::pair<OutputDataType, OutputDataType> test(
     }
   };
 
-  auto futureAlice = std::async(lambda, Party::Alice, aliceInput);
-  auto futureBob = std::async(lambda, Party::Bob, bobInput);
+  auto futureAlice = std::async(lambda, Party::Alice, std::move(aliceInput));
+  auto futureBob = std::async(lambda, Party::Bob, std::move(bobInput));
 
   auto resAlice = futureAlice.get();
   auto resBob = futureBob.get();


### PR DESCRIPTION
Summary:
# What
* `std::move` on inputData for each party
# Why
* We're copying giant structures of input data. In the best case, it's wasted memory. In the worst case (like what I experienced elsewhere), we'll call a `delete`d copy constructor and the code fails to compile.

Differential Revision: D32129208

