### PR TITLE
automatically create directories that don't exist on writes for private computation stages

### DIFF
--- a/fbpcf/io/LocalFileManager.cpp
+++ b/fbpcf/io/LocalFileManager.cpp
@@ -7,6 +7,7 @@
 
 #include "LocalFileManager.h"
 
+#include <filesystem>
 #include <fstream>
 #include <memory>
 #include <sstream>
@@ -40,6 +41,8 @@ std::string LocalFileManager::read(const std::string& fileName) {
 void LocalFileManager::write(
     const std::string& fileName,
     const std::string& data) {
+  std::filesystem::path filePath{fileName};
+  std::filesystem::create_directories(filePath.parent_path());
   std::ofstream os{fileName};
   if (!os.is_open()) {
     throw PcfException{folly::sformat("Failed to open file {}", fileName)};

--- a/fbpcf/io/test/LocalFileManagerTest.cpp
+++ b/fbpcf/io/test/LocalFileManagerTest.cpp
@@ -22,11 +22,13 @@ class LocalFileManagerTest : public ::testing::Test {
  protected:
   void TearDown() override {
     std::remove(filePath_.c_str());
+    std::remove(nonExistentFolderPath_.c_str());
   }
 
   const std::string testData_ = "this is test data";
   const std::string filePath_ =
       folly::sformat("./testfile_{}", folly::Random::rand32());
+  const std::string nonExistentFolderPath_ = "./fakedfolder/fakedfile";
 };
 
 TEST_F(LocalFileManagerTest, testReadWrite) {
@@ -41,10 +43,11 @@ TEST_F(LocalFileManagerTest, testReadException) {
   EXPECT_THROW(fileManager.read("./fakedfile"), PcfException);
 }
 
-TEST_F(LocalFileManagerTest, testWriteException) {
+TEST_F(LocalFileManagerTest, testWriteNonExistentFolder) {
   LocalFileManager fileManager;
-  EXPECT_THROW(
-      fileManager.write("./fakedfolder/fakedfile", testData_), PcfException);
+  fileManager.write(nonExistentFolderPath_, testData_);
+  auto resp = fileManager.read(nonExistentFolderPath_);
+  EXPECT_EQ(testData_, resp);
 }
 
 TEST_F(LocalFileManagerTest, testWriteReadBytes) {


### PR DESCRIPTION
Summary: the aws write file code automatically creates directories when they don't exist. However, our local filesystem code wasn't doing that. We should have equal behavior when we use the local vs the aws file system.

Reviewed By: gorel

Differential Revision: D32223838

