### PR TITLE
Add GCS FileType

### DIFF
--- a/fbpcf/io/FileManagerUtil.cpp
+++ b/fbpcf/io/FileManagerUtil.cpp
@@ -29,7 +29,13 @@ void write(const std::string& fileName, const std::string& data) {
 
 FileType getFileType(const std::string& fileName) {
   // S3 file format: https://bucket-name.s3.Region.amazonaws.com/key-name
-  return fileName.find("https://", 0) == 0 ? FileType::S3 : FileType::Local;
+  // GCS file format: https://storage.cloud.google.com/bucket-name/key-name
+  if (fileName.find("https://", 0) != 0) {
+    return FileType::Local;
+  }
+  bool isGCSPath =
+      fileName.find("storage.cloud.google.com") != std::string::npos;
+  return isGCSPath ? FileType::GCS : FileType::S3;
 }
 
 std::unique_ptr<fbpcf::IFileManager> getFileManager(

--- a/fbpcf/io/FileManagerUtil.h
+++ b/fbpcf/io/FileManagerUtil.h
@@ -14,7 +14,7 @@
 #include "IInputStream.h"
 
 namespace fbpcf::io {
-enum class FileType { Local, S3 };
+enum class FileType { Local, S3, GCS };
 
 std::unique_ptr<IInputStream> getInputStream(const std::string& fileName);
 

--- a/fbpcf/io/test/FileManagerUtilTest.cpp
+++ b/fbpcf/io/test/FileManagerUtilTest.cpp
@@ -16,6 +16,12 @@ TEST(FileManagerUtilTest, TestGetS3FileType) {
   EXPECT_EQ(FileType::S3, type);
 }
 
+TEST(FileManagerUtilTest, TestGetGCSFileType) {
+  auto type =
+      getFileType("https://storage.cloud.google.com/bucket-name/key-name");
+  EXPECT_EQ(FileType::GCS, type);
+}
+
 TEST(FileManagerUtilTest, TestGetLocalFileType) {
   auto type = getFileType("/root/local");
   EXPECT_EQ(FileType::Local, type);


### PR DESCRIPTION
Summary:
The diff are copied from D32471543 and contains the interface changes that do not rely on gcp-cpp import.

The purpose of this diff is to unblock GCP work in FBPCS.

Differential Revision: D33156054

