### PR TITLE
Add GCS client support in FileManagerUtil

### DIFF
--- a/fbpcf/gcp/GCSUtil.cpp
+++ b/fbpcf/gcp/GCSUtil.cpp
@@ -54,4 +54,9 @@ GCSObjectReference uriToObjectReference(std::string url) {
   return GCSObjectReference{bucket, path.substr(pos + 1)};
 }
 
+std::unique_ptr<google::cloud::storage::Client> createGCSClient() {
+  // TODO set options based on env variables
+  return std::make_unique<google::cloud::storage::Client>();
+}
+
 } // namespace fbpcf::gcp

--- a/fbpcf/gcp/GCSUtil.h
+++ b/fbpcf/gcp/GCSUtil.h
@@ -22,6 +22,5 @@ struct GCSObjectReference {
 };
 
 GCSObjectReference uriToObjectReference(std::string url);
-std::unique_ptr<google::cloud::storage::Client> createGCSClient(
-    const GCSClientOption& option);
+std::unique_ptr<google::cloud::storage::Client> createGCSClient();
 } // namespace fbpcf::gcp

--- a/fbpcf/io/FileManagerUtil.cpp
+++ b/fbpcf/io/FileManagerUtil.cpp
@@ -7,9 +7,11 @@
 
 #include "FileManagerUtil.h"
 
+#include <fbpcf/gcp/GCSUtil.h>
 #include "LocalFileManager.h"
 #include "S3FileManager.h"
 #include "fbpcf/aws/S3Util.h"
+#include "fbpcf/io/GCSFileManager.h"
 
 namespace fbpcf::io {
 std::unique_ptr<IInputStream> getInputStream(const std::string& fileName) {
@@ -29,7 +31,13 @@ void write(const std::string& fileName, const std::string& data) {
 
 FileType getFileType(const std::string& fileName) {
   // S3 file format: https://bucket-name.s3.Region.amazonaws.com/key-name
-  return fileName.find("https://", 0) == 0 ? FileType::S3 : FileType::Local;
+  if (fileName.find("https://", 0) != 0) {
+    return FileType::Local;
+  } else if (fileName.find("https://storage.cloud.google.com") == 0) {
+    return FileType::GCS;
+  } else {
+    return FileType::S3;
+  }
 }
 
 std::unique_ptr<fbpcf::IFileManager> getFileManager(
@@ -40,6 +48,9 @@ std::unique_ptr<fbpcf::IFileManager> getFileManager(
     // Other options have to be set via environment variables
     return std::make_unique<S3FileManager>(fbpcf::aws::createS3Client(
         fbpcf::aws::S3ClientOption{.region = ref.region}));
+  } else if (type == FileType ::GCS) {
+    return std::make_unique<GCSFileManager<google::cloud::storage::Client>>(
+        fbpcf::gcp::createGCSClient());
   } else {
     return std::make_unique<LocalFileManager>();
   }

--- a/fbpcf/io/FileManagerUtil.h
+++ b/fbpcf/io/FileManagerUtil.h
@@ -14,7 +14,7 @@
 #include "IInputStream.h"
 
 namespace fbpcf::io {
-enum class FileType { Local, S3 };
+enum class FileType { Local, GCS, S3 };
 
 std::unique_ptr<IInputStream> getInputStream(const std::string& fileName);
 

--- a/fbpcf/io/test/FileManagerUtilTest.cpp
+++ b/fbpcf/io/test/FileManagerUtilTest.cpp
@@ -5,9 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <type_traits>
+#include <utility>
+
 #include <gtest/gtest.h>
 
 #include "fbpcf/io/FileManagerUtil.h"
+#include "fbpcf/io/GCSFileManager.h"
 
 namespace fbpcf::io {
 TEST(FileManagerUtilTest, TestGetS3FileType) {
@@ -19,5 +23,20 @@ TEST(FileManagerUtilTest, TestGetS3FileType) {
 TEST(FileManagerUtilTest, TestGetLocalFileType) {
   auto type = getFileType("/root/local");
   EXPECT_EQ(FileType::Local, type);
+}
+
+TEST(FileManagerUtilTest, TestGetGCSFileType) {
+  auto type =
+      getFileType("https://storage.cloud.google.com/bucket-name/key-name");
+  EXPECT_EQ(FileType::GCS, type);
+}
+
+TEST(FileManagerUtilTest, TestGetGCSFileManager) {
+  auto fileManager =
+      getFileManager("https://storage.cloud.google.com/bucket-name/key-name");
+  auto& fileManagerRef = *fileManager;
+  EXPECT_EQ(
+      typeid(fileManagerRef),
+      typeid(fbpcf::GCSFileManager<google::cloud::storage::Client>));
 }
 } // namespace fbpcf::io


### PR DESCRIPTION
Summary:
To enable IO on GCS, we need to add GCS client/fileManager support in FileManagerUtil.

## Details
1. Create a default GCS client if the file path is a gcs one.
2. A default GCS client is an empty one according to [google api doc](https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/storage/quickstart/README.md).
2. Added unit tests for GCS client creation

Differential Revision: D33357687

