### PR TITLE
Back out "Add GCS client support in FileManagerUtil"

### DIFF
--- a/fbpcf/gcp/GCSUtil.cpp
+++ b/fbpcf/gcp/GCSUtil.cpp
@@ -54,9 +54,4 @@ GCSObjectReference uriToObjectReference(std::string url) {
   return GCSObjectReference{bucket, path.substr(pos + 1)};
 }
 
-std::unique_ptr<google::cloud::storage::Client> createGCSClient() {
-  // TODO set options based on env variables
-  return std::make_unique<google::cloud::storage::Client>();
-}
-
 } // namespace fbpcf::gcp

--- a/fbpcf/gcp/GCSUtil.h
+++ b/fbpcf/gcp/GCSUtil.h
@@ -22,5 +22,6 @@ struct GCSObjectReference {
 };
 
 GCSObjectReference uriToObjectReference(std::string url);
-std::unique_ptr<google::cloud::storage::Client> createGCSClient();
+std::unique_ptr<google::cloud::storage::Client> createGCSClient(
+    const GCSClientOption& option);
 } // namespace fbpcf::gcp

--- a/fbpcf/io/FileManagerUtil.h
+++ b/fbpcf/io/FileManagerUtil.h
@@ -14,7 +14,7 @@
 #include "IInputStream.h"
 
 namespace fbpcf::io {
-enum class FileType { Local, GCS, S3 };
+enum class FileType { Local, S3 };
 
 std::unique_ptr<IInputStream> getInputStream(const std::string& fileName);
 

--- a/fbpcf/io/test/FileManagerUtilTest.cpp
+++ b/fbpcf/io/test/FileManagerUtilTest.cpp
@@ -5,13 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <type_traits>
-#include <utility>
-
 #include <gtest/gtest.h>
 
 #include "fbpcf/io/FileManagerUtil.h"
-#include "fbpcf/io/GCSFileManager.h"
 
 namespace fbpcf::io {
 TEST(FileManagerUtilTest, TestGetS3FileType) {
@@ -23,20 +19,5 @@ TEST(FileManagerUtilTest, TestGetS3FileType) {
 TEST(FileManagerUtilTest, TestGetLocalFileType) {
   auto type = getFileType("/root/local");
   EXPECT_EQ(FileType::Local, type);
-}
-
-TEST(FileManagerUtilTest, TestGetGCSFileType) {
-  auto type =
-      getFileType("https://storage.cloud.google.com/bucket-name/key-name");
-  EXPECT_EQ(FileType::GCS, type);
-}
-
-TEST(FileManagerUtilTest, TestGetGCSFileManager) {
-  auto fileManager =
-      getFileManager("https://storage.cloud.google.com/bucket-name/key-name");
-  auto& fileManagerRef = *fileManager;
-  EXPECT_EQ(
-      typeid(fileManagerRef),
-      typeid(fbpcf::GCSFileManager<google::cloud::storage::Client>));
 }
 } // namespace fbpcf::io


### PR DESCRIPTION
Summary:
Original commit changeset: 23bfa8854cd1

Original Phabricator Diff: D33357687 (https://github.com/facebookresearch/fbpcf/commit/0293215f02403c102dd2a6e90a4fe1f9bd0f4883)

The diff is generated by ```hg backout D33357687 (https://github.com/facebookresearch/fbpcf/commit/0293215f02403c102dd2a6e90a4fe1f9bd0f4883) && jf s``` using the Unland button in the original diff.

Differential Revision: D33897046

