### PR TITLE
Expose CLI arguments in decoupled version of attribution/aggregtion games

### DIFF
--- a/fbpcf/io/api/CloudFileReader.cpp
+++ b/fbpcf/io/api/CloudFileReader.cpp
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "fbpcf/io/api/CloudFileReader.h"
+
+namespace fbpcf::io {} // namespace fbpcf::io

--- a/fbpcf/io/api/CloudFileReader.h
+++ b/fbpcf/io/api/CloudFileReader.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+#include "fbpcf/io/api/ICloser.h"
+#include "fbpcf/io/api/IReader.h"
+
+namespace fbpcf::io {
+
+/*
+This class is the API for reading a file from cloud
+storage. It can be in any supported cloud provider, but
+cannot be a local file.
+*/
+class CloudFileReader : public IReader, public ICloser {
+ public:
+  int close() override;
+  int read(char buf[]) override;
+  ~CloudFileReader() override;
+};
+
+} // namespace fbpcf::io

--- a/fbpcf/io/api/CloudFileWriter.cpp
+++ b/fbpcf/io/api/CloudFileWriter.cpp
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "fbpcf/io/api/CloudFileWriter.h"
+
+namespace fbpcf::io {} // namespace fbpcf::io

--- a/fbpcf/io/api/CloudFileWriter.h
+++ b/fbpcf/io/api/CloudFileWriter.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+#include "fbpcf/io/api/ICloser.h"
+#include "fbpcf/io/api/IWriter.h"
+
+namespace fbpcf::io {
+
+/*
+This class is the API for writing a file to cloud
+storage. It can be in any supported cloud provider, but
+cannot be a local file.
+*/
+class CloudFileWriter : public IWriter, public ICloser {
+ public:
+  int close() override;
+  int write(char buf[]) override;
+  ~CloudFileWriter() override;
+};
+
+} // namespace fbpcf::io

--- a/fbpcf/io/api/FileReader.cpp
+++ b/fbpcf/io/api/FileReader.cpp
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "fbpcf/io/api/FileReader.h"
+
+namespace fbpcf::io {} // namespace fbpcf::io

--- a/fbpcf/io/api/FileReader.h
+++ b/fbpcf/io/api/FileReader.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+#include "fbpcf/io/api/ICloser.h"
+#include "fbpcf/io/api/IReader.h"
+
+namespace fbpcf::io {
+
+/*
+This class is the API for reading a file from any
+storage, local or cloud. It can be in any supported
+cloud provider or a file on disk. Internally, this
+class will create a LocalFileReader or CloudFileReader
+depending on what file path is provided.
+*/
+class FileReader : public IReader, public ICloser {
+ public:
+  int close() override;
+  int read(char buf[]) override;
+  ~FileReader() override;
+};
+
+} // namespace fbpcf::io

--- a/fbpcf/io/api/FileWriter.cpp
+++ b/fbpcf/io/api/FileWriter.cpp
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "fbpcf/io/api/FileWriter.h"
+
+namespace fbpcf::io {} // namespace fbpcf::io

--- a/fbpcf/io/api/FileWriter.h
+++ b/fbpcf/io/api/FileWriter.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+#include "fbpcf/io/api/ICloser.h"
+#include "fbpcf/io/api/IWriter.h"
+
+namespace fbpcf::io {
+
+/*
+This class is the API for writing a file to any
+storage, local or cloud. It can be in any supported
+cloud provider or a file on disk. Internally, this
+class will create a LocalFileWriter or CloudFileWriter
+depending on what file path is provided.
+*/
+class FileWriter : public IWriter, public ICloser {
+ public:
+  int close() override;
+  int write(char buf[]) override;
+  ~FileWriter() override;
+};
+
+} // namespace fbpcf::io

--- a/fbpcf/io/api/ICloser.h
+++ b/fbpcf/io/api/ICloser.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace fbpcf::io {
+
+/*
+ * Defines a class that uses an underlying
+ * medium and must close it to free up the allocated
+ * resources.
+ */
+class ICloser {
+ public:
+  /*
+   * close() returns 0 if it succeeds, and -1
+   * in the case of an error.
+   */
+  virtual int close();
+  virtual ~ICloser();
+};
+
+} // namespace fbpcf::io

--- a/fbpcf/io/api/IReader.h
+++ b/fbpcf/io/api/IReader.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace fbpcf::io {
+
+/*
+ * Defines a class that reads data from an
+ * underlying medium.
+ */
+class IReader {
+ public:
+  /*
+   * read() returns the number of bytes it was
+   * able to read, or -1 if error. It fills
+   * the provided buffer with the data that was
+   * read
+   */
+  virtual int read(char buf[]);
+  virtual ~IReader();
+};
+
+} // namespace fbpcf::io

--- a/fbpcf/io/api/IWriter.h
+++ b/fbpcf/io/api/IWriter.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace fbpcf::io {
+
+/*
+ * Defines a class that writes data to
+ * an underlying medium.
+ */
+class IWriter {
+ public:
+  /*
+   * write() returns the number of bytes it
+   * was able to write, or -1 if there was
+   * an error. It attempts to write the
+   * entire provided buffer.
+   */
+  virtual int write(char buf[]);
+  virtual ~IWriter();
+};
+
+} // namespace fbpcf::io

--- a/fbpcf/io/api/LocalFileReader.cpp
+++ b/fbpcf/io/api/LocalFileReader.cpp
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "fbpcf/io/api/LocalFileReader.h"
+
+namespace fbpcf::io {} // namespace fbpcf::io

--- a/fbpcf/io/api/LocalFileReader.h
+++ b/fbpcf/io/api/LocalFileReader.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+#include <vector>
+#include "fbpcf/io/api/ICloser.h"
+#include "fbpcf/io/api/IReader.h"
+
+namespace fbpcf::io {
+
+/*
+This class is the API for reading a file from local
+storage. It must be on disk and cannot be a file in
+cloud storage.
+*/
+class LocalFileReader : public IReader, public ICloser {
+ public:
+  int close() override;
+  int read(char buf[]) override;
+  ~LocalFileReader() override;
+};
+
+} // namespace fbpcf::io

--- a/fbpcf/io/api/LocalFileWriter.cpp
+++ b/fbpcf/io/api/LocalFileWriter.cpp
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "fbpcf/io/api/LocalFileWriter.h"
+
+namespace fbpcf::io {} // namespace fbpcf::io

--- a/fbpcf/io/api/LocalFileWriter.h
+++ b/fbpcf/io/api/LocalFileWriter.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+#include "fbpcf/io/api/ICloser.h"
+#include "fbpcf/io/api/IWriter.h"
+
+namespace fbpcf::io {
+
+/*
+This class is the API for writing a file to local
+storage. It must be on disk and cannot be a file in
+cloud storage.
+*/
+class LocalFileWriter : public IWriter, public ICloser {
+ public:
+  int close() override;
+  int write(char buf[]) override;
+  ~LocalFileWriter() override;
+};
+
+} // namespace fbpcf::io

--- a/fbpcf/io/api/SocketReader.cpp
+++ b/fbpcf/io/api/SocketReader.cpp
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "fbpcf/io/api/SocketReader.h"
+
+namespace fbpcf::io {} // namespace fbpcf::io

--- a/fbpcf/io/api/SocketReader.h
+++ b/fbpcf/io/api/SocketReader.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+#include "fbpcf/io/api/ICloser.h"
+#include "fbpcf/io/api/IReader.h"
+
+namespace fbpcf::io {
+
+/*
+This class is the API for reading data from network
+socket. It is constructed with a socket file descriptor.
+*/
+class SocketReader : public IReader, public ICloser {
+ public:
+  int close() override;
+  int read(char buf[]) override;
+  ~SocketReader() override;
+};
+
+} // namespace fbpcf::io

--- a/fbpcf/io/api/SocketReader.h
+++ b/fbpcf/io/api/SocketReader.h
@@ -6,6 +6,8 @@
  */
 
 #pragma once
+#include <openssl/ssl.h>
+
 #include "fbpcf/io/api/ICloser.h"
 #include "fbpcf/io/api/IReader.h"
 
@@ -17,6 +19,18 @@ socket. It is constructed with a socket file descriptor.
 */
 class SocketReader : public IReader, public ICloser {
  public:
+  /*
+   * Creates a SocketReader to read from the given
+   * file descriptor.
+   */
+  SocketReader(FILE* socket);
+
+  /*
+   * Creates a SocketReader to read from
+   * the provided SSL/TLS connection object.
+   */
+  SocketReader(SSL* ssl);
+
   int close() override;
   int read(char buf[]) override;
   ~SocketReader() override;

--- a/fbpcf/io/api/SocketWriter.cpp
+++ b/fbpcf/io/api/SocketWriter.cpp
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "fbpcf/io/api/SocketWriter.h"
+
+namespace fbpcf::io {} // namespace fbpcf::io

--- a/fbpcf/io/api/SocketWriter.h
+++ b/fbpcf/io/api/SocketWriter.h
@@ -6,6 +6,9 @@
  */
 
 #pragma once
+
+#include <openssl/ssl.h>
+
 #include "fbpcf/io/api/ICloser.h"
 #include "fbpcf/io/api/IWriter.h"
 
@@ -17,6 +20,18 @@ socket. It is constructed with a socket file descriptor.
 */
 class SocketWriter : public IWriter, public ICloser {
  public:
+  /*
+   * Creates a SocketWriter to write to the given
+   * file descriptor.
+   */
+  SocketWriter(FILE* socket);
+
+  /*
+   * Creates a SocketReader to write to
+   * the provided SSL/TLS connection object.
+   */
+  SocketWriter(SSL* ssl);
+
   int close() override;
   int write(char buf[]) override;
   ~SocketWriter() override;

--- a/fbpcf/io/api/SocketWriter.h
+++ b/fbpcf/io/api/SocketWriter.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+#include "fbpcf/io/api/ICloser.h"
+#include "fbpcf/io/api/IWriter.h"
+
+namespace fbpcf::io {
+
+/*
+This class is the API for writing data to a network
+socket. It is constructed with a socket file descriptor.
+*/
+class SocketWriter : public IWriter, public ICloser {
+ public:
+  int close() override;
+  int write(char buf[]) override;
+  ~SocketWriter() override;
+};
+
+} // namespace fbpcf::io

--- a/fbpcf/mpc/EmpApp.h
+++ b/fbpcf/mpc/EmpApp.h
@@ -20,8 +20,17 @@ namespace fbpcf {
 template <class GameType, class InputDataType, class OutputDataType>
 class EmpApp {
  public:
-  EmpApp(Party party, const std::string& serverIp, uint16_t port)
-      : party_{party}, serverIp_{serverIp}, port_{port} {}
+  EmpApp(
+      Party party,
+      const std::string& serverIp,
+      uint16_t port,
+      bool useTls = false,
+      const std::string& tlsDir = "")
+      : party_{party},
+        serverIp_{serverIp},
+        port_{port},
+        useTls_{useTls},
+        tlsDir_{tlsDir} {}
 
   virtual ~EmpApp(){};
 
@@ -42,8 +51,11 @@ class EmpApp {
   virtual void putOutputData(const OutputDataType& output) = 0;
 
  protected:
-  Party party_;
-  std::string serverIp_;
-  uint16_t port_;
+  Party party_; // Alice or Bob (Publisher or Partner)
+  std::string serverIp_; // Ip address of the publisher
+  uint16_t port_; // Port to bind to, or port to connect to (for publisher or
+                  // partner respectively)
+  bool useTls_; // whether to use TLS for communication
+  const std::string& tlsDir_; // directory that holds the TLS certificates/keys
 };
 } // namespace fbpcf


### PR DESCRIPTION
Summary:
The goal of this series of diffs is to set up the API for configuring TLS for inter party communication. This involves a few steps
1) Add openssl as a dependency
2) Add the SSL as an argument to the SocketReader and SocketWriter so that it can either send data unencrypted or encrypted
3) Add a tls_dir parameter to the AgentFactory and the Agent, and store it in a private field
4) propagate the tls_dir from the factory to construct the appropriate agent
5) expose CLI arguments for tls

**In this diff, we do step 5 for the decoupled version of the games**

Differential Revision: D34048421

