### PR TITLE
Create workflow for building and testing at diff time

### DIFF
--- a/.github/workflows/continuous-tests-nonblocking.yml
+++ b/.github/workflows/continuous-tests-nonblocking.yml
@@ -1,0 +1,317 @@
+name: E2E Test
+
+on:
+  push:
+    branches: [ main ]
+
+env:
+  DISTRO: ubuntu
+  REGISTRY: ghcr.io
+  FBPCF_LOCAL_IMAGE_NAME: ${{ github.event.repository.name }}/ubuntu
+  REGISTRY_IMAGE_NAME: ghcr.io/${{ github.repository }}/ubuntu
+  COORDINATOR_IMAGE: ghcr.io/facebookresearch/fbpcs/coordinator
+  LOCAL_IMAGE_NAME: fbpcs/onedocker
+  TEST_REGISTRY_IMAGE_NAME: ghcr.io/${{ github.repository }}/test/ubuntu
+  PL_CONTAINER_NAME: e2e_pl_container
+  PA_CONTAINER_NAME: e2e_pa_container
+  VERSION_TAG: latest-build
+
+jobs:
+  build_docker_fbpcf:
+    runs-on: [self-hosted, e2e_test_runner]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Remove unused images
+      run: |
+        docker image prune -af
+
+    - name: Build fbpcf docker image
+      run: |
+        ./build-docker.sh -u
+
+  sanity_check_pcf_v1:
+    runs-on: [self-hosted, e2e_test_runner]
+    needs: build_docker_fbpcf
+    steps:
+    - uses: actions/checkout@v2
+    - name: Sanity check fbpcf library
+      timeout-minutes: 3
+      run: |
+        ./run-millionaire-sample.sh -u
+
+  build_docker_fbpcs:
+    runs-on: [self-hosted, e2e_test_runner]
+    needs: build_docker_fbpcf
+    steps:
+    - uses: actions/checkout@v2
+    - name: Log into registry ${{ env.REGISTRY }}
+      uses: docker/login-action@v1
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Clone latest stable fbpcs
+      run: |
+        git clone https://github.com/facebookresearch/fbpcs
+        cd fbpcs
+        git reset --hard $(curl \
+        --header 'content-type: application/json' \
+        "https://api.github.com/repos/facebookresearch/fbpcs/actions/workflows/12965519/runs?per_page=1&status=success" | jq \
+        ".workflow_runs[0] .head_sha" | tr -d '"')
+
+    - name: Build fbpcs image (this uses the locally built fbpcf image as a dependency)
+      run: |
+        cd fbpcs
+        ./build-docker.sh onedocker -t ${{ env.VERSION_TAG }}
+
+    - name: Tag docker image
+      run: |
+        docker tag ${{ env.LOCAL_IMAGE_NAME }}:${{ env.VERSION_TAG }} ${{ env.TEST_REGISTRY_IMAGE_NAME }}:${{ github.sha }}
+        docker tag ${{ env.LOCAL_IMAGE_NAME }}:${{ env.VERSION_TAG }} ${{ env.TEST_REGISTRY_IMAGE_NAME }}:${{ env.VERSION_TAG }}
+        docker tag ${{ env.LOCAL_IMAGE_NAME }}:${{ env.VERSION_TAG }} ${{ env.TEST_REGISTRY_IMAGE_NAME }}:test_image
+
+    - name: Push image to test registry
+      run: |
+        docker push --all-tags ${{ env.TEST_REGISTRY_IMAGE_NAME }}
+
+  private_attribution_e2e_test:
+    runs-on: [self-hosted, e2e_test_runner]
+    needs: build_docker_fbpcs
+    steps:
+    - uses: actions/checkout@v2
+    - name: Log into registry ${{ env.REGISTRY }}
+      uses: docker/login-action@v1
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Pull coordinator image
+      run: |
+        docker pull ${{ env.COORDINATOR_IMAGE }}:${{ env.VERSION_TAG }}
+
+    - name: Start container
+      run: |
+        ./start_container.sh ${{ env.PA_CONTAINER_NAME }} ${{ env.COORDINATOR_IMAGE }}:${{ env.VERSION_TAG }}
+      working-directory: fbpcf/tests/github/
+
+    - name: Attribution - Create Instance
+      run: |
+        ./attribution_run_stages.sh ${{ env.PA_CONTAINER_NAME }} create_instance
+      working-directory: fbpcf/tests/github/
+
+    - name: Attribution - Data validation
+      run: |
+        ./attribution_run_stages.sh ${{ env.PA_CONTAINER_NAME }} data_validation
+      working-directory: fbpcf/tests/github/
+
+    - name: Check Status
+      timeout-minutes: 5
+      run: |
+        ./check_status.sh ${{ env.PA_CONTAINER_NAME }} attribution
+      working-directory: fbpcf/tests/github/
+
+    - name: Attribution - Id Match
+      run: |
+        ./attribution_run_stages.sh ${{ env.PA_CONTAINER_NAME }} run_next
+      working-directory: fbpcf/tests/github/
+
+    - name: Check status
+      timeout-minutes: 5
+      run: |
+        ./check_status.sh ${{ env.PA_CONTAINER_NAME }} attribution
+      working-directory: fbpcf/tests/github/
+
+    - name: Attribution - PID export metrics
+      run: |
+        ./attribution_run_stages.sh ${{ env.PA_CONTAINER_NAME }} pid_metric_export
+      working-directory: fbpcf/tests/github/
+
+    - name: Check Status
+      timeout-minutes: 5
+      run: |
+        ./check_status.sh ${{ env.PA_CONTAINER_NAME }} attribution
+      working-directory: fbpcf/tests/github/
+
+    - name: Attribution - Prepare Compute Input
+      run: |
+        ./attribution_run_stages.sh ${{ env.PA_CONTAINER_NAME }} prepare_compute_input
+      working-directory: fbpcf/tests/github/
+
+    - name: Check Status
+      timeout-minutes: 5
+      run: |
+        ./check_status.sh ${{ env.PA_CONTAINER_NAME }} attribution
+      working-directory: fbpcf/tests/github/
+
+    - name: Attribution - Decoupled Attribution
+      run: |
+        ./attribution_run_stages.sh ${{ env.PA_CONTAINER_NAME }} run_next
+      working-directory: fbpcf/tests/github/
+
+    - name: Check Status
+      timeout-minutes: 5
+      run: |
+        ./check_status.sh ${{ env.PA_CONTAINER_NAME }} attribution
+      working-directory: fbpcf/tests/github/
+
+    - name: Attribution - Decoupled Aggregation
+      run: |
+        ./attribution_run_stages.sh ${{ env.PA_CONTAINER_NAME }} run_next
+      working-directory: fbpcf/tests/github/
+
+    - name: Check Status
+      timeout-minutes: 5
+      run: |
+        ./check_status.sh ${{ env.PA_CONTAINER_NAME }} attribution
+      working-directory: fbpcf/tests/github/
+
+    - name: Attribution - Aggregate Shards
+      run: |
+        ./attribution_run_stages.sh ${{ env.PA_CONTAINER_NAME }} run_next
+      working-directory: fbpcf/tests/github/
+
+    - name: Check Status
+      timeout-minutes: 5
+      run: |
+        ./check_status.sh ${{ env.PA_CONTAINER_NAME }} attribution
+      working-directory: fbpcf/tests/github/
+
+    - name: Attribution - Validate Result
+      run: |
+        ./validate_result.sh attribution
+      working-directory: fbpcf/tests/github/
+
+    - name: Cleanup
+      run: |
+        docker stop ${{ env.PA_CONTAINER_NAME }}
+        docker rm ${{ env.PA_CONTAINER_NAME }}
+
+
+  private_lift_e2e_test:
+    runs-on: [self-hosted, e2e_test_runner]
+    needs: build_docker_fbpcs
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Log into registry ${{ env.REGISTRY }}
+      uses: docker/login-action@v1
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Pull coordinator image
+      run: |
+        docker pull ${{ env.COORDINATOR_IMAGE }}:${{ env.VERSION_TAG }}
+
+    - name: Start container
+      run: |
+        ./start_container.sh ${{ env.PA_CONTAINER_NAME }} ${{ env.COORDINATOR_IMAGE }}:${{ env.VERSION_TAG }}
+      working-directory: fbpcf/tests/github/
+
+    - name: Lift - Create Instance
+      run: |
+        ./lift_run_stages.sh ${{ env.PL_CONTAINER_NAME }} create_instance
+      working-directory: fbpcf/tests/github/
+
+    - name: Lift - Data validation
+      run: |
+        ./lift_run_stages.sh ${{ env.PL_CONTAINER_NAME }} data_validation
+      working-directory: fbpcf/tests/github/
+
+    - name: Check Status
+      timeout-minutes: 5
+      run: |
+        ./check_status.sh ${{ env.PL_CONTAINER_NAME }} lift
+      working-directory: fbpcf/tests/github/
+
+    - name: Lift - Pid shard
+      run: |
+        ./lift_run_stages.sh ${{ env.PL_CONTAINER_NAME }} pid_shard
+      working-directory: fbpcf/tests/github/
+
+    - name: Check Status
+      timeout-minutes: 5
+      run: |
+        ./check_status.sh ${{ env.PL_CONTAINER_NAME }} lift
+      working-directory: fbpcf/tests/github/
+
+    - name: Lift - Pid prepare
+      run: |
+        ./lift_run_stages.sh ${{ env.PL_CONTAINER_NAME }} pid_prepare
+      working-directory: fbpcf/tests/github/
+
+    - name: Check Status
+      timeout-minutes: 5
+      run: |
+        ./check_status.sh ${{ env.PL_CONTAINER_NAME }} lift
+      working-directory: fbpcf/tests/github/
+
+    - name: Lift - Id Match
+      run: |
+        ./lift_run_stages.sh ${{ env.PL_CONTAINER_NAME }} run_next
+      working-directory: fbpcf/tests/github/
+
+    - name: Check Status
+      timeout-minutes: 5
+      run: |
+        ./check_status.sh ${{ env.PL_CONTAINER_NAME }} lift
+      working-directory: fbpcf/tests/github/
+
+    - name: Lift - PID export metrics
+      run: |
+        ./lift_run_stages.sh ${{ env.PL_CONTAINER_NAME }} pid_metric_export
+      working-directory: fbpcf/tests/github/
+
+    - name: Check Status
+      timeout-minutes: 5
+      run: |
+        ./check_status.sh ${{ env.PL_CONTAINER_NAME }} lift
+      working-directory: fbpcf/tests/github/
+
+    - name: Lift - Prepare Compute Input
+      run: |
+        ./lift_run_stages.sh ${{ env.PL_CONTAINER_NAME }} prepare_compute_input
+      working-directory: fbpcf/tests/github/
+
+    - name: Check Status
+      timeout-minutes: 5
+      run: |
+        ./check_status.sh ${{ env.PL_CONTAINER_NAME }} lift
+      working-directory: fbpcf/tests/github/
+
+    - name: Lift - Compute Metrics
+      run: |
+        ./lift_run_stages.sh ${{ env.PL_CONTAINER_NAME }} run_next
+      working-directory: fbpcf/tests/github/
+
+    - name: Check Status
+      timeout-minutes: 5
+      run: |
+        ./check_status.sh ${{ env.PL_CONTAINER_NAME }} lift
+      working-directory: fbpcf/tests/github/
+
+    - name: Lift - Aggregate Shards
+      run: |
+        ./lift_run_stages.sh ${{ env.PL_CONTAINER_NAME }} run_next
+      working-directory: fbpcf/tests/github/
+
+    - name: Check Status
+      timeout-minutes: 5
+      run: |
+        ./check_status.sh ${{ env.PL_CONTAINER_NAME }} lift
+      working-directory: fbpcf/tests/github/
+
+    - name: Lift - Validate Results
+      run: |
+        ./validate_result.sh lift
+      working-directory: fbpcf/tests/github/
+
+    - name: Cleanup
+      run: |
+        docker stop ${{ env.PL_CONTAINER_NAME }}
+        docker rm ${{ env.PL_CONTAINER_NAME }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,8 +3,6 @@ name: Publish Docker image
 on:
   push:
     branches: [ main ]
-  release:
-    types: [ published ]
 
 env:
   DISTRO: ubuntu
@@ -27,10 +25,19 @@ jobs:
         run: |
           ./build-docker.sh -u
 
-      - name: Sanity check fbpcf library
+      - name: Sanity check fbpcf library (only tests v1 functionality)
         timeout-minutes: 3
         run: |
           ./run-millionaire-sample.sh -u
+
+      - name: Create version string
+        id: create_version
+        uses: paulhatch/semantic-version@v4.0.2
+        with:
+          tag_prefix: "v"
+          major_pattern: "((MAJOR))"
+          minor_pattern: "((MINOR))"
+          format: "${major}.${minor}.${patch}-pre${increment}"
 
       - name: Log into registry ${{ env.REGISTRY }}
         uses: docker/login-action@v1
@@ -47,16 +54,20 @@ jobs:
         run: |
           docker tag ${{ env.LOCAL_IMAGE_NAME }} ${{ env.REGISTRY_IMAGE_NAME }}:${{ github.sha }}
           docker tag ${{ env.LOCAL_IMAGE_NAME }} ${{ env.REGISTRY_IMAGE_NAME }}:${{ steps.vars.outputs.ref }}
-
-      - name: Tag as latest
-        # Tag as latest only for main branch
-        if: github.event_name == 'push'
-        run: |
+          docker tag ${{ env.LOCAL_IMAGE_NAME }} ${{ env.REGISTRY_IMAGE_NAME }}:${{ steps.create_version.outputs.version_tag }}
           docker tag ${{ env.LOCAL_IMAGE_NAME }} ${{ env.REGISTRY_IMAGE_NAME }}:latest
 
       - name: Push Docker image
         run: |
           docker push --all-tags ${{ env.REGISTRY_IMAGE_NAME }}
+
+      - name: Create release
+        uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          prerelease: false
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "latest"
+          title: ${{ steps.create_version.outputs.version_tag }}
 
       - name: Cleanup
         run: |

--- a/fbpcf/tests/github/attribution_run_stages.sh
+++ b/fbpcf/tests/github/attribution_run_stages.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Usage:Run attribution different stages: create_instance, id_match, prepare_compute_input, compute_attribution, aggregate_shards
+
+set -e
+
+container_name=$1
+stage=$2
+
+# shellcheck disable=SC1091,SC1090
+source "$(dirname "${BASH_SOURCE[0]}")/config.sh" || exit 1
+
+docker_command="docker exec $container_name $COORDINATOR"
+
+case "$stage" in
+    create_instance )
+        echo "Create Attribution Publisher instance"
+        $docker_command create_instance "$ATTRIBUTION_PUBLISHER_NAME" \
+            --config="$DOCKER_CLOUD_CONFIG_FILE" \
+            --input_path="$ATTRIBUTION_PUBLISHER_INPUT_FILE" \
+            --output_dir="$ATTRIBUTION_OUTPUT_DIR" \
+            --role=publisher \
+            --game_type=attribution \
+            --num_pid_containers="$ATTRIBUTION_NUM_PID_CONTAINERS" \
+            --num_mpc_containers="$ATTRIBUTION_NUM_MPC_CONTAINERS" \
+            --num_files_per_mpc_container="$ATTRIBUTION_NUM_FILES_PER_MPC_CONTAINER" \
+            --concurrency="$ATTRIBUTION_CONCURRENCY" \
+            --attribution_rule="$ATTRIBUTION_RULE" \
+            --aggregation_type="$ATTRIBUTION_TYPE"
+        echo "Create Attribution Partner instance"
+        $docker_command create_instance "$ATTRIBUTION_PARTNER_NAME" \
+            --config="$DOCKER_CLOUD_CONFIG_FILE" \
+            --input_path="$ATTRIBUTION_PARTNER_INPUT_FILE" \
+            --output_dir="$ATTRIBUTION_OUTPUT_DIR" \
+            --role=partner \
+            --game_type=attribution \
+            --num_pid_containers="$ATTRIBUTION_NUM_PID_CONTAINERS" \
+            --num_mpc_containers="$ATTRIBUTION_NUM_MPC_CONTAINERS" \
+            --num_files_per_mpc_container="$ATTRIBUTION_NUM_FILES_PER_MPC_CONTAINER" \
+            --concurrency="$ATTRIBUTION_CONCURRENCY" \
+            --attribution_rule="$ATTRIBUTION_RULE" \
+            --aggregation_type="$ATTRIBUTION_TYPE"
+            ;;
+    # Stages without passing IP addresses
+    prepare_compute_input | pid_metric_export | data_validation )
+        echo "Attribution Publisher $stage starts"
+        $docker_command run_next "$ATTRIBUTION_PUBLISHER_NAME" \
+            --config="$DOCKER_CLOUD_CONFIG_FILE"
+        echo "Attribution Partner $stage starts"
+        $docker_command run_next "$ATTRIBUTION_PARTNER_NAME" \
+            --config="$DOCKER_CLOUD_CONFIG_FILE"
+        ;;
+     # Stages need to pass IP address
+    run_next )
+        echo "Attribution Publisher $stage starts"
+        $docker_command run_next "$ATTRIBUTION_PUBLISHER_NAME" \
+            --config="$DOCKER_CLOUD_CONFIG_FILE"
+        echo "Get Publisher Ips"
+        publisher_server_ips=$($docker_command get_server_ips "$ATTRIBUTION_PUBLISHER_NAME" \
+            --config="$DOCKER_CLOUD_CONFIG_FILE" | sed 's/\r//g')
+        echo "Server IPs are ${publisher_server_ips}"
+        echo "Attribution Partner $stage starts"
+        $docker_command run_next "$ATTRIBUTION_PARTNER_NAME" \
+            --config="$DOCKER_CLOUD_CONFIG_FILE" \
+            --server_ips="${publisher_server_ips}"
+        ;;
+
+    * )
+        echo "Not a valid Attribution stage"
+esac

--- a/fbpcf/tests/github/check_status.sh
+++ b/fbpcf/tests/github/check_status.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Usage: Check if all status are COMPLETED for differennt stages(except create_instance stage)
+set -e
+
+container_name=$1
+game=$2
+
+if [ "$game" == 'lift' ]||[ "$game" == 'attribution' ]
+then
+    upper_game=${game^^}
+    publisher_name=${upper_game}_PUBLISHER_NAME
+    partner_name=${upper_game}_PARTNER_NAME
+else
+    echo "Invalid Game"
+    exit 1
+fi
+
+
+# shellcheck disable=SC1091,SC1090
+source "$(dirname "${BASH_SOURCE[0]}")/config.sh" || exit 1
+
+docker_command="docker exec $container_name $COORDINATOR"
+
+# check if all the status are COMPLETED, if yes, return true
+function check_status_complete() {
+    echo "Get status for $1 ..."
+    $docker_command get_instance "$1" --config="$DOCKER_CLOUD_CONFIG_FILE" || exit 1
+    #filter out "status": "COMPLETED" or  "status": "COMPLETED": "XX_COMPLETED"
+    non_complete_status=$($docker_command get_instance "$1" \
+        --config="$DOCKER_CLOUD_CONFIG_FILE" 2>&1 \
+        | grep -Eo '\{.{1,}\}' \
+        | jq ''.'status' \
+        | grep -v "\"\S*COMPLETED\"" )
+
+    if [ -z "$non_complete_status" ]
+    then
+        echo "$1 status is complete"
+        return 0
+    else
+        echo "$1 has noncomplete status: $non_complete_status"
+        return 1
+    fi
+}
+# timeout is added in github workflows
+until check_status_complete "${!publisher_name}" && check_status_complete "${!partner_name}"
+    do echo "Waiting status to complete ..."
+    sleep 60
+done
+
+echo "Stage completes successfully!"

--- a/fbpcf/tests/github/cleanup.sh
+++ b/fbpcf/tests/github/cleanup.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Usage:Remove ECS tasks and aggregation outputs in S3 bucket
+set -e
+
+# shellcheck disable=SC1091,SC1090
+source "$(dirname "${BASH_SOURCE[0]}")/config.sh" || exit 1
+
+# Remove ECS tasks
+RUNNING_TASKS=$(aws ecs list-tasks --cluster "$E2E_CLUSTER_NAME" --desired-status RUNNING --region us-west-2 | grep -E "task/" | sed -E "s/.*task\/(.*)\"/\1/" | sed -z 's/\n/ /g')
+IFS=', ' read -r -a array <<< "$RUNNING_TASKS"
+for task in "${array[@]}"
+do
+    aws ecs stop-task --cluster "${E2E_CLUSTER_NAME}" --task "${task}" --region us-west-2 > /dev/null
+    echo "Task:${task} is stopped"
+done
+
+# Remove all the outputs from previous run
+aws s3 rm --recursive "$LIFT_OUTPUT_PATH"
+aws s3 rm --recursive "$ATTRIBUTION_OUTPUT_PATH"

--- a/fbpcf/tests/github/config.sh
+++ b/fbpcf/tests/github/config.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Usage: Github e2e configs
+
+## Shared
+export E2E_CLUSTER_NAME="onedocker-cluster-fbpcf-e2e-workflow"
+export E2E_S3_BUCKET="fbpcf-e2e-github-workflow"
+export E2E_GITHUB_S3_URL="https://$E2E_S3_BUCKET.s3.us-west-2.amazonaws.com"
+export COORDINATOR="python3.8 -m fbpcs.private_computation_cli.private_computation_cli"
+
+# Matched with yaml file
+export CLOUD_CONFIG_FILE="fbpcf_e2e_aws.yml"
+export DOCKER_CLOUD_CONFIG_FILE="/$CLOUD_CONFIG_FILE"
+export DOCKER_INSTANCE_REPO="/instances"
+
+## Lift
+# Lift study configs
+export LIFT_PUBLISHER_NAME="pl_publisher_github"
+export LIFT_PARTNER_NAME="pl_partner_github"
+export LIFT_NUM_MPC_CONTAIENRS=2
+export LIFT_NUM_PID_CONTAINERS=2
+export LIFT_CONCURRENCY=4
+export LIFT_PUBLISHER_INPUT_FILE=$E2E_GITHUB_S3_URL/lift/inputs/publisher_e2e_input.csv
+export LIFT_PARTNER_INPUT_FILE=$E2E_GITHUB_S3_URL/lift/inputs/partner_e2e_input.csv
+export LIFT_OUTPUT_DIR=$E2E_GITHUB_S3_URL/lift/outputs
+
+# Lift result comparison
+export LIFT_OUTPUT_PATH=s3://$E2E_S3_BUCKET/lift/outputs
+export LIFT_PUBLISHER_AGGREGATION_OUTPUT=$LIFT_OUTPUT_PATH/"$LIFT_PUBLISHER_NAME"_out_dir/shard_aggregation_stage/out.json
+export LIFT_PARTNER_AGGREGATION_OUTPUT=$LIFT_OUTPUT_PATH/"$LIFT_PARTNER_NAME"_out_dir/shard_aggregation_stage/out.json
+
+export LIFT_RESULT_PATH=s3://$E2E_S3_BUCKET/lift/results
+export LIFT_PUBLISHER_EXPECTED_RESULT=$LIFT_RESULT_PATH/publisher_expected_result.json
+export LIFT_PARTNER_EXPECTED_RESULT=$LIFT_RESULT_PATH/partner_expected_result.json
+
+## Attribution
+# Attribution study configs
+export ATTRIBUTION_PUBLISHER_NAME="pa_publisher_github"
+export ATTRIBUTION_PARTNER_NAME="pa_partner_github"
+
+export ATTRIBUTION_NUM_FILES_PER_MPC_CONTAINER=1
+export ATTRIBUTION_CONCURRENCY=1
+export ATTRIBUTION_NUM_PID_CONTAINERS=1
+export ATTRIBUTION_NUM_MPC_CONTAINERS=1
+export ATTRIBUTION_RULE="last_touch_1d"
+export ATTRIBUTION_TYPE="measurement"
+
+export ATTRIBUTION_PUBLISHER_INPUT_FILE=$E2E_GITHUB_S3_URL/attribution/inputs/publisher_e2e_input.csv
+export ATTRIBUTION_PARTNER_INPUT_FILE=$E2E_GITHUB_S3_URL/attribution/inputs/partner_e2e_input.csv
+
+export ATTRIBUTION_OUTPUT_DIR=$E2E_GITHUB_S3_URL/attribution/outputs
+
+# Attribution result comparison
+export ATTRIBUTION_OUTPUT_PATH=s3://$E2E_S3_BUCKET/attribution/outputs
+export ATTRIBUTION_PUBLISHER_AGGREGATION_OUTPUT=$ATTRIBUTION_OUTPUT_PATH/"$ATTRIBUTION_PUBLISHER_NAME"_out_dir/shard_aggregation_stage/out.json
+export ATTRIBUTION_PARTNER_AGGREGATION_OUTPUT=$ATTRIBUTION_OUTPUT_PATH/"$ATTRIBUTION_PARTNER_NAME"_out_dir/shard_aggregation_stage/out.json
+
+export ATTRIBUTION_RESULT_PATH=s3://$E2E_S3_BUCKET/attribution/results
+export ATTRIBUTION_PUBLISHER_EXPECTED_RESULT=$ATTRIBUTION_RESULT_PATH/publisher_expected_result.json
+export ATTRIBUTION_PARTNER_EXPECTED_RESULT=$ATTRIBUTION_RESULT_PATH/partner_expected_result.json

--- a/fbpcf/tests/github/fbpcf_e2e_aws.yml
+++ b/fbpcf/tests/github/fbpcf_e2e_aws.yml
@@ -1,0 +1,52 @@
+private_computation:
+  dependency:
+    PrivateComputationInstanceRepository:
+      class: fbpcs.private_computation.repository.private_computation_instance_local.LocalPrivateComputationInstanceRepository
+      constructor:
+        base_dir: /instances
+    ContainerService:
+      class: fbpcp.service.container_aws.AWSContainerService
+      constructor:
+        region: us-west-2
+        cluster: onedocker-cluster-fbpcf-e2e-workflow
+        subnets: [subnet-063921a0b73eb5593]
+        access_key_id:
+        access_key_data:
+    StorageService:
+      class: fbpcp.service.storage_s3.S3StorageService
+      constructor:
+        region: us-west-2
+        access_key_id:
+        access_key_data:
+    ValidationConfig:
+      is_validating: false
+      synthetic_shard_path:
+    OneDockerBinaryConfig:
+      default:
+        constructor:
+          tmp_directory: /tmp
+          binary_version: latest
+    OneDockerServiceConfig:
+      constructor:
+        task_definition: onedocker-task-fbpcf-e2e-workflow:6#onedocker-container-fbpcf-e2e-workflow
+pid:
+  dependency:
+    PIDInstanceRepository:
+      class: fbpcs.pid.repository.pid_instance_local.LocalPIDInstanceRepository
+      constructor:
+        base_dir: /instances
+  skip_aggregation_step: true
+  task_definition:
+mpc:
+  dependency:
+    MPCGameService:
+      class: fbpcp.service.mpc_game.MPCGameService
+      dependency:
+        PrivateComputationGameRepository:
+          class: fbpcs.private_computation.repository.private_computation_game.PrivateComputationGameRepository
+    MPCInstanceRepository:
+      class: fbpcs.common.repository.mpc_instance_local.LocalMPCInstanceRepository
+      constructor:
+        base_dir: /instances
+graphapi:
+  access_token: TODO

--- a/fbpcf/tests/github/lift_run_stages.sh
+++ b/fbpcf/tests/github/lift_run_stages.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Usage: Run Lift different stages: create_instance, id_match, prepare_compute_input, compute_metrics, aggregate_shards
+
+set -e
+
+container_name=$1
+stage=$2
+
+# shellcheck disable=SC1091,SC1090
+source "$(dirname "${BASH_SOURCE[0]}")/config.sh" || exit 1
+
+docker_command="docker exec $container_name $COORDINATOR"
+
+case "$stage" in
+    create_instance )
+        echo "Create Lift Publisher instance"
+        $docker_command create_instance "$LIFT_PUBLISHER_NAME" \
+            --config="$DOCKER_CLOUD_CONFIG_FILE" \
+            --role=publisher \
+            --game_type=lift \
+            --input_path="$LIFT_PUBLISHER_INPUT_FILE" \
+            --output_dir="$LIFT_OUTPUT_DIR" \
+            --num_pid_containers="$LIFT_NUM_PID_CONTAINERS" \
+            --num_mpc_containers="$LIFT_NUM_MPC_CONTAIENRS" \
+            --concurrency="$LIFT_CONCURRENCY"
+        echo "Create Lift Partner instance"
+        $docker_command create_instance "$LIFT_PARTNER_NAME" \
+            --config="$DOCKER_CLOUD_CONFIG_FILE" \
+            --role=partner \
+            --game_type=lift \
+            --input_path="$LIFT_PARTNER_INPUT_FILE" \
+            --output_dir="$LIFT_OUTPUT_DIR" \
+            --num_pid_containers="$LIFT_NUM_PID_CONTAINERS" \
+            --num_mpc_containers="$LIFT_NUM_MPC_CONTAIENRS" \
+            --concurrency="$LIFT_CONCURRENCY"
+            ;;
+    # stages donot need IP exchange
+    prepare_compute_input | pid_shard | pid_prepare | pid_metric_export | data_validation )
+        echo "Lift Publisher $stage starts"
+        $docker_command run_next "$LIFT_PUBLISHER_NAME" \
+            --config="$DOCKER_CLOUD_CONFIG_FILE"
+        echo "Lift Partner $stage starts"
+        $docker_command run_next "$LIFT_PARTNER_NAME" \
+            --config="$DOCKER_CLOUD_CONFIG_FILE"
+        ;;
+    # stages require IP exchange
+    run_next )
+        echo "Lift Publisher $stage starts"
+        $docker_command run_next "$LIFT_PUBLISHER_NAME" \
+            --config="$DOCKER_CLOUD_CONFIG_FILE"
+        echo "Get Publisher Ips"
+        # get_server_ips returns an extra carriage return character
+        publisher_server_ips=$($docker_command get_server_ips "$LIFT_PUBLISHER_NAME" \
+            --config="$DOCKER_CLOUD_CONFIG_FILE" | sed 's/\r//g')
+        echo "Server IPs are ${publisher_server_ips}"
+        echo "Lift Partner $stage starts"
+        $docker_command run_next "$LIFT_PARTNER_NAME" \
+            --config="$DOCKER_CLOUD_CONFIG_FILE" \
+            --server_ips="${publisher_server_ips}"
+        ;;
+    * )
+        echo "Not a valid Lift stage"
+esac

--- a/fbpcf/tests/github/start_container.sh
+++ b/fbpcf/tests/github/start_container.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Usage: Start container and setup directory and files
+set -e
+
+container_name=$1
+image=$2
+
+# shellcheck disable=SC1091,SC1090
+source "$(dirname "${BASH_SOURCE[0]}")/config.sh" || exit 1
+
+if [ "$(docker ps -q -f name="$container_name")" ]; then
+        # cleanup
+        echo "Stop and remove old container"
+        docker stop "$container_name"
+        docker rm  "$container_name"
+fi
+# run container
+echo "Run container $container_name"
+docker run -td --name "$container_name" "$image"
+
+# setup
+echo "Create base directory for study"
+docker exec "$container_name" mkdir "$DOCKER_INSTANCE_REPO" || exit 1
+
+echo "Copy study yaml file to container"
+docker cp "$CLOUD_CONFIG_FILE" "$container_name":"$DOCKER_CLOUD_CONFIG_FILE" || exit 1

--- a/fbpcf/tests/github/validate_result.sh
+++ b/fbpcf/tests/github/validate_result.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Usage: ./validate_result.sh lift|attribution, to validate aggregation output is matching with expected results
+
+set -e
+game=$1
+
+# shellcheck disable=SC1091,SC1090
+source "$(dirname "${BASH_SOURCE[0]}")/config.sh" || exit 1
+
+TMP_DIR="/tmp"
+PUBLISHER_EXPECTED_RESULT=$TMP_DIR/publisher_expected_result.json
+PARTNER_EXPECTED_RESULT=$TMP_DIR/partner_expected_result.json
+PUBLISHER_AGGREGATION_OUTPUT=$TMP_DIR/publisher_output.json
+PARTNER_AGGREGATION_OUTPUT=$TMP_DIR/partner_output.json
+
+echo "Remove publisher and partner files"
+rm -f $TMP_DIR/publisher* $TMP_DIR/partner*
+
+if [ "$game" == 'lift' ]
+then
+    aws s3 cp "$LIFT_PUBLISHER_AGGREGATION_OUTPUT" $PUBLISHER_AGGREGATION_OUTPUT
+    aws s3 cp "$LIFT_PARTNER_AGGREGATION_OUTPUT" $PARTNER_AGGREGATION_OUTPUT
+    aws s3 cp "$LIFT_PUBLISHER_EXPECTED_RESULT" $PUBLISHER_EXPECTED_RESULT
+    aws s3 cp "$LIFT_PARTNER_EXPECTED_RESULT" $PARTNER_EXPECTED_RESULT
+    echo "Lift files are copied to $TMP_DIR"
+
+elif [ "$game" == "attribution" ]
+then
+    aws s3 cp "$ATTRIBUTION_PUBLISHER_AGGREGATION_OUTPUT" "$PUBLISHER_AGGREGATION_OUTPUT"
+    aws s3 cp "$ATTRIBUTION_PARTNER_AGGREGATION_OUTPUT" "$PARTNER_AGGREGATION_OUTPUT"
+    aws s3 cp "$ATTRIBUTION_PUBLISHER_EXPECTED_RESULT" "$PUBLISHER_EXPECTED_RESULT"
+    aws s3 cp "$ATTRIBUTION_PARTNER_EXPECTED_RESULT" "$PARTNER_EXPECTED_RESULT"
+    echo "Attribution files are copied to $TMP_DIR"
+
+else
+    echo "Invalid game: $game"
+fi
+# check if there is difference
+function check_results_match() {
+    diff <(jq -S . "$1") <(jq -S . "$2") || exit 1
+    diff_output=$(diff <(jq -S . "$1") <(jq -S . "$2"))
+    if [ -z "$diff_output" ];
+    then
+        echo "$1 and $2 results are the same"
+        return 0
+    else
+        echo "$1 and $2 results are different"
+        return 1
+    fi
+}
+
+if check_results_match $PUBLISHER_AGGREGATION_OUTPUT $PUBLISHER_EXPECTED_RESULT \
+&& check_results_match $PARTNER_AGGREGATION_OUTPUT $PARTNER_EXPECTED_RESULT
+then
+    echo "$game e2e tests succeed"
+else
+    echo "$game e2e tests failed, results donot not match"
+    exit 1
+fi


### PR DESCRIPTION
Summary:
This workflow does 3 things
- runs a docker build with the new changes
- runs a sanity check, the run-millionaire-sample.sh script
- runs a full set of PA e2e tests, copied from https://github.com/facebookresearch/fbpcs/blob/main/.github/workflows/docker-publish.yml#L232

Some considerations:
- There is already a `tests.yml` workflow that does the first two. I chose to create a duplicate workflow for a couple of reasons. Firstly, I did not want to break the current production workflowwith any new changes. Secondly, this allows me to do a bit of refactoring and test it in a safe way. Once this succeeds, I will delete that workflow.
- There is a lot of copied code, and I am looking into a way to reuse workflows. This is something supported by Github https://docs.github.com/en/actions/using-workflows/reusing-workflows). I will iterate on this.

Differential Revision: D34456173

