### PR TITLE
Improve/fix interfaces for all IO

### DIFF
--- a/fbpcf/io/api/CloudFileReader.h
+++ b/fbpcf/io/api/CloudFileReader.h
@@ -6,8 +6,7 @@
  */
 
 #pragma once
-#include "fbpcf/io/api/ICloser.h"
-#include "fbpcf/io/api/IReader.h"
+#include "fbpcf/io/api/IReaderCloser.h"
 
 namespace fbpcf::io {
 
@@ -16,7 +15,7 @@ This class is the API for reading a file from cloud
 storage. It can be in any supported cloud provider, but
 cannot be a local file.
 */
-class CloudFileReader : public IReader, public ICloser {
+class CloudFileReader : public IReaderCloser {
  public:
   int close() override;
   int read(char buf[]) override;

--- a/fbpcf/io/api/CloudFileWriter.h
+++ b/fbpcf/io/api/CloudFileWriter.h
@@ -6,8 +6,7 @@
  */
 
 #pragma once
-#include "fbpcf/io/api/ICloser.h"
-#include "fbpcf/io/api/IWriter.h"
+#include "fbpcf/io/api/IWriterCloser.h"
 
 namespace fbpcf::io {
 
@@ -16,7 +15,7 @@ This class is the API for writing a file to cloud
 storage. It can be in any supported cloud provider, but
 cannot be a local file.
 */
-class CloudFileWriter : public IWriter, public ICloser {
+class CloudFileWriter : public IWriterCloser {
  public:
   int close() override;
   int write(char buf[]) override;

--- a/fbpcf/io/api/FileReader.h
+++ b/fbpcf/io/api/FileReader.h
@@ -6,8 +6,7 @@
  */
 
 #pragma once
-#include "fbpcf/io/api/ICloser.h"
-#include "fbpcf/io/api/IReader.h"
+#include "fbpcf/io/api/IReaderCloser.h"
 
 namespace fbpcf::io {
 
@@ -18,7 +17,7 @@ cloud provider or a file on disk. Internally, this
 class will create a LocalFileReader or CloudFileReader
 depending on what file path is provided.
 */
-class FileReader : public IReader, public ICloser {
+class FileReader : public IReaderCloser {
  public:
   int close() override;
   int read(char buf[]) override;

--- a/fbpcf/io/api/FileWriter.h
+++ b/fbpcf/io/api/FileWriter.h
@@ -6,8 +6,7 @@
  */
 
 #pragma once
-#include "fbpcf/io/api/ICloser.h"
-#include "fbpcf/io/api/IWriter.h"
+#include "fbpcf/io/api/IWriterCloser.h"
 
 namespace fbpcf::io {
 
@@ -18,7 +17,7 @@ cloud provider or a file on disk. Internally, this
 class will create a LocalFileWriter or CloudFileWriter
 depending on what file path is provided.
 */
-class FileWriter : public IWriter, public ICloser {
+class FileWriter : public IWriterCloser {
  public:
   int close() override;
   int write(char buf[]) override;

--- a/fbpcf/io/api/IReader.h
+++ b/fbpcf/io/api/IReader.h
@@ -21,8 +21,8 @@ class IReader {
    * the provided buffer with the data that was
    * read
    */
-  virtual int read(char buf[]);
-  virtual ~IReader();
+  virtual int read(char buf[]) = 0;
+  virtual ~IReader() = default;
 };
 
 } // namespace fbpcf::io

--- a/fbpcf/io/api/IReaderCloser.h
+++ b/fbpcf/io/api/IReaderCloser.h
@@ -7,21 +7,18 @@
 
 #pragma once
 
+#include "fbpcf/io/api/ICloser.h"
+#include "fbpcf/io/api/IReader.h"
+
 namespace fbpcf::io {
 
 /*
- * Defines a class that uses an underlying
- * medium and must close it to free up the allocated
- * resources.
+ * Defines a class that reads data from an
+ * underlying medium and closes it.
  */
-class ICloser {
+class IReaderCloser : public IReader, public ICloser {
  public:
-  /*
-   * close() returns 0 if it succeeds, and -1
-   * in the case of an error.
-   */
-  virtual int close() = 0;
-  virtual ~ICloser() = default;
+  virtual ~IReaderCloser() = default;
 };
 
 } // namespace fbpcf::io

--- a/fbpcf/io/api/IWriter.h
+++ b/fbpcf/io/api/IWriter.h
@@ -21,8 +21,8 @@ class IWriter {
    * an error. It attempts to write the
    * entire provided buffer.
    */
-  virtual int write(char buf[]);
-  virtual ~IWriter();
+  virtual int write(char buf[]) = 0;
+  virtual ~IWriter() = default;
 };
 
 } // namespace fbpcf::io

--- a/fbpcf/io/api/IWriterCloser.h
+++ b/fbpcf/io/api/IWriterCloser.h
@@ -7,21 +7,18 @@
 
 #pragma once
 
+#include "fbpcf/io/api/ICloser.h"
+#include "fbpcf/io/api/IWriter.h"
+
 namespace fbpcf::io {
 
 /*
- * Defines a class that uses an underlying
- * medium and must close it to free up the allocated
- * resources.
+ * Defines a class that writes data to an
+ * underlying medium and closes it.
  */
-class ICloser {
+class IWriterCloser : public IWriter, public ICloser {
  public:
-  /*
-   * close() returns 0 if it succeeds, and -1
-   * in the case of an error.
-   */
-  virtual int close() = 0;
-  virtual ~ICloser() = default;
+  virtual ~IWriterCloser() = default;
 };
 
 } // namespace fbpcf::io

--- a/fbpcf/io/api/LocalFileReader.h
+++ b/fbpcf/io/api/LocalFileReader.h
@@ -6,9 +6,7 @@
  */
 
 #pragma once
-#include <vector>
-#include "fbpcf/io/api/ICloser.h"
-#include "fbpcf/io/api/IReader.h"
+#include "fbpcf/io/api/IReaderCloser.h"
 
 namespace fbpcf::io {
 
@@ -17,7 +15,7 @@ This class is the API for reading a file from local
 storage. It must be on disk and cannot be a file in
 cloud storage.
 */
-class LocalFileReader : public IReader, public ICloser {
+class LocalFileReader : public IReaderCloser {
  public:
   int close() override;
   int read(char buf[]) override;

--- a/fbpcf/io/api/LocalFileWriter.h
+++ b/fbpcf/io/api/LocalFileWriter.h
@@ -6,8 +6,7 @@
  */
 
 #pragma once
-#include "fbpcf/io/api/ICloser.h"
-#include "fbpcf/io/api/IWriter.h"
+#include "fbpcf/io/api/IWriterCloser.h"
 
 namespace fbpcf::io {
 
@@ -16,7 +15,7 @@ This class is the API for writing a file to local
 storage. It must be on disk and cannot be a file in
 cloud storage.
 */
-class LocalFileWriter : public IWriter, public ICloser {
+class LocalFileWriter : public IWriterCloser {
  public:
   int close() override;
   int write(char buf[]) override;

--- a/fbpcf/io/api/SocketReader.h
+++ b/fbpcf/io/api/SocketReader.h
@@ -8,8 +8,7 @@
 #pragma once
 #include <openssl/ssl.h>
 
-#include "fbpcf/io/api/ICloser.h"
-#include "fbpcf/io/api/IReader.h"
+#include "fbpcf/io/api/IReaderCloser.h"
 
 namespace fbpcf::io {
 
@@ -17,7 +16,7 @@ namespace fbpcf::io {
 This class is the API for reading data from network
 socket. It is constructed with a socket file descriptor.
 */
-class SocketReader : public IReader, public ICloser {
+class SocketReader : public IReaderCloser {
  public:
   /*
    * Creates a SocketReader to read from the given

--- a/fbpcf/io/api/SocketWriter.h
+++ b/fbpcf/io/api/SocketWriter.h
@@ -9,8 +9,7 @@
 
 #include <openssl/ssl.h>
 
-#include "fbpcf/io/api/ICloser.h"
-#include "fbpcf/io/api/IWriter.h"
+#include "fbpcf/io/api/IWriterCloser.h"
 
 namespace fbpcf::io {
 
@@ -18,7 +17,7 @@ namespace fbpcf::io {
 This class is the API for writing data to a network
 socket. It is constructed with a socket file descriptor.
 */
-class SocketWriter : public IWriter, public ICloser {
+class SocketWriter : public IWriterCloser {
  public:
   /*
    * Creates a SocketWriter to write to the given


### PR DESCRIPTION
Summary:
There were two issues with PCF IO APIs
- We want to consolidate IReader and ICloser (and also for IWriter/ICloser) into a single interface for composed use. This is so that the FileReader can create something like `std::unique_ptr<IReaderCloser> childReader_` which will either be `LocalFileReader` or `CloudFileReader`.
- We need to make virtual methods pure virtual (see this: https://fburl.com/sxuecig3). This wasn't being done and was causing errors "undefined symbol: vtable for IReader"

This diff fixes both of these issues

Differential Revision: D34531885

