### PR TITLE
Add number of bytes as argument to read and write APIs

### DIFF
--- a/fbpcf/io/api/CloudFileReader.cpp
+++ b/fbpcf/io/api/CloudFileReader.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "fbpcf/io/api/CloudFileReader.h"
+#include <cstddef>
 #include <string>
 
 namespace fbpcf::io {
@@ -15,7 +16,7 @@ CloudFileReader::CloudFileReader(std::string /* filePath */) {}
 int CloudFileReader::close() {
   return 0;
 }
-int CloudFileReader::read(char buf[]) {
+int CloudFileReader::read(char buf[], size_t nBytes) {
   return 0;
 }
 

--- a/fbpcf/io/api/CloudFileReader.h
+++ b/fbpcf/io/api/CloudFileReader.h
@@ -6,6 +6,7 @@
  */
 
 #pragma once
+#include <cstddef>
 #include <string>
 #include "fbpcf/io/api/IReaderCloser.h"
 
@@ -21,7 +22,7 @@ class CloudFileReader : public IReaderCloser {
   explicit CloudFileReader(std::string filePath);
 
   int close() override;
-  int read(char buf[]) override;
+  int read(char buf[], size_t nBytes) override;
   ~CloudFileReader() override;
 };
 

--- a/fbpcf/io/api/CloudFileReader.h
+++ b/fbpcf/io/api/CloudFileReader.h
@@ -6,6 +6,7 @@
  */
 
 #pragma once
+#include <string>
 #include "fbpcf/io/api/IReaderCloser.h"
 
 namespace fbpcf::io {
@@ -17,6 +18,8 @@ cannot be a local file.
 */
 class CloudFileReader : public IReaderCloser {
  public:
+  explicit CloudFileReader(std::string filePath);
+
   int close() override;
   int read(char buf[]) override;
   ~CloudFileReader() override;

--- a/fbpcf/io/api/CloudFileReader.h
+++ b/fbpcf/io/api/CloudFileReader.h
@@ -6,8 +6,7 @@
  */
 
 #pragma once
-#include "fbpcf/io/api/ICloser.h"
-#include "fbpcf/io/api/IReader.h"
+#include "fbpcf/io/api/IReaderCloser.h"
 
 namespace fbpcf::io {
 
@@ -16,7 +15,7 @@ This class is the API for reading a file from cloud
 storage. It can be in any supported cloud provider, but
 cannot be a local file.
 */
-class CloudFileReader : public IReader, public ICloser {
+class CloudFileReader : public IReaderCloser {
  public:
   int close() override;
   int read(char buf[]) override;

--- a/fbpcf/io/api/CloudFileWriter.cpp
+++ b/fbpcf/io/api/CloudFileWriter.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "fbpcf/io/api/CloudFileWriter.h"
+#include <cstddef>
 #include <string>
 
 namespace fbpcf::io {
@@ -15,7 +16,7 @@ CloudFileWriter::CloudFileWriter(std::string /* filePath */) {}
 int CloudFileWriter::close() {
   return 0;
 }
-int CloudFileWriter::write(char buf[]) {
+int CloudFileWriter::write(char buf[], size_t nBytes) {
   return 0;
 }
 

--- a/fbpcf/io/api/CloudFileWriter.cpp
+++ b/fbpcf/io/api/CloudFileWriter.cpp
@@ -6,5 +6,20 @@
  */
 
 #include "fbpcf/io/api/CloudFileWriter.h"
+#include <string>
 
-namespace fbpcf::io {} // namespace fbpcf::io
+namespace fbpcf::io {
+
+CloudFileWriter::CloudFileWriter(std::string /* filePath */) {}
+
+int CloudFileWriter::close() {
+  return 0;
+}
+int CloudFileWriter::write(char buf[]) {
+  return 0;
+}
+
+CloudFileWriter::~CloudFileWriter() {
+  close();
+}
+} // namespace fbpcf::io

--- a/fbpcf/io/api/CloudFileWriter.h
+++ b/fbpcf/io/api/CloudFileWriter.h
@@ -6,6 +6,7 @@
  */
 
 #pragma once
+#include <string>
 #include "fbpcf/io/api/IWriterCloser.h"
 
 namespace fbpcf::io {
@@ -17,6 +18,8 @@ cannot be a local file.
 */
 class CloudFileWriter : public IWriterCloser {
  public:
+  explicit CloudFileWriter(std::string filePath);
+
   int close() override;
   int write(char buf[]) override;
   ~CloudFileWriter() override;

--- a/fbpcf/io/api/CloudFileWriter.h
+++ b/fbpcf/io/api/CloudFileWriter.h
@@ -6,8 +6,7 @@
  */
 
 #pragma once
-#include "fbpcf/io/api/ICloser.h"
-#include "fbpcf/io/api/IWriter.h"
+#include "fbpcf/io/api/IWriterCloser.h"
 
 namespace fbpcf::io {
 
@@ -16,7 +15,7 @@ This class is the API for writing a file to cloud
 storage. It can be in any supported cloud provider, but
 cannot be a local file.
 */
-class CloudFileWriter : public IWriter, public ICloser {
+class CloudFileWriter : public IWriterCloser {
  public:
   int close() override;
   int write(char buf[]) override;

--- a/fbpcf/io/api/CloudFileWriter.h
+++ b/fbpcf/io/api/CloudFileWriter.h
@@ -6,6 +6,7 @@
  */
 
 #pragma once
+#include <cstddef>
 #include <string>
 #include "fbpcf/io/api/IWriterCloser.h"
 
@@ -21,7 +22,7 @@ class CloudFileWriter : public IWriterCloser {
   explicit CloudFileWriter(std::string filePath);
 
   int close() override;
-  int write(char buf[]) override;
+  int write(char buf[], size_t nBytes) override;
   ~CloudFileWriter() override;
 };
 

--- a/fbpcf/io/api/FileReader.cpp
+++ b/fbpcf/io/api/FileReader.cpp
@@ -6,5 +6,31 @@
  */
 
 #include "fbpcf/io/api/FileReader.h"
+#include <memory>
+#include <string>
+#include "fbpcf/io/api/CloudFileReader.h"
+#include "fbpcf/io/api/LocalFileReader.h"
 
-namespace fbpcf::io {} // namespace fbpcf::io
+#include "IOUtils.h"
+
+namespace fbpcf::io {
+FileReader::FileReader(std::string filePath) {
+  if (IOUtils::isCloudFile(filePath)) {
+    childReader_ = std::make_unique<CloudFileReader>(filePath);
+  } else {
+    childReader_ = std::make_unique<LocalFileReader>(filePath);
+  }
+}
+
+FileReader::~FileReader() {
+  close();
+}
+
+int FileReader::read(char buf[]) {
+  return childReader_->read(buf);
+}
+
+int FileReader::close() {
+  return childReader_->close();
+}
+} // namespace fbpcf::io

--- a/fbpcf/io/api/FileReader.cpp
+++ b/fbpcf/io/api/FileReader.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "fbpcf/io/api/FileReader.h"
+#include <cstddef>
 #include <memory>
 #include <string>
 #include "fbpcf/io/api/CloudFileReader.h"
@@ -26,8 +27,8 @@ FileReader::~FileReader() {
   close();
 }
 
-int FileReader::read(char buf[]) {
-  return childReader_->read(buf);
+int FileReader::read(char buf[], size_t nBytes) {
+  return childReader_->read(buf, nBytes);
 }
 
 int FileReader::close() {

--- a/fbpcf/io/api/FileReader.h
+++ b/fbpcf/io/api/FileReader.h
@@ -6,6 +6,8 @@
  */
 
 #pragma once
+#include <memory>
+#include <string>
 #include "fbpcf/io/api/IReaderCloser.h"
 
 namespace fbpcf::io {
@@ -19,9 +21,14 @@ depending on what file path is provided.
 */
 class FileReader : public IReaderCloser {
  public:
+  explicit FileReader(std::string filePath);
+
   int close() override;
   int read(char buf[]) override;
   ~FileReader() override;
+
+ private:
+  std::unique_ptr<IReaderCloser> childReader_;
 };
 
 } // namespace fbpcf::io

--- a/fbpcf/io/api/FileReader.h
+++ b/fbpcf/io/api/FileReader.h
@@ -6,6 +6,7 @@
  */
 
 #pragma once
+#include <cstddef>
 #include <memory>
 #include <string>
 #include "fbpcf/io/api/IReaderCloser.h"
@@ -24,7 +25,7 @@ class FileReader : public IReaderCloser {
   explicit FileReader(std::string filePath);
 
   int close() override;
-  int read(char buf[]) override;
+  int read(char buf[], size_t nBytes) override;
   ~FileReader() override;
 
  private:

--- a/fbpcf/io/api/FileReader.h
+++ b/fbpcf/io/api/FileReader.h
@@ -6,8 +6,7 @@
  */
 
 #pragma once
-#include "fbpcf/io/api/ICloser.h"
-#include "fbpcf/io/api/IReader.h"
+#include "fbpcf/io/api/IReaderCloser.h"
 
 namespace fbpcf::io {
 
@@ -18,7 +17,7 @@ cloud provider or a file on disk. Internally, this
 class will create a LocalFileReader or CloudFileReader
 depending on what file path is provided.
 */
-class FileReader : public IReader, public ICloser {
+class FileReader : public IReaderCloser {
  public:
   int close() override;
   int read(char buf[]) override;

--- a/fbpcf/io/api/FileWriter.cpp
+++ b/fbpcf/io/api/FileWriter.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "fbpcf/io/api/FileWriter.h"
+#include <cstddef>
 #include <memory>
 #include <string>
 #include "fbpcf/io/api/CloudFileWriter.h"
@@ -25,8 +26,8 @@ FileWriter::~FileWriter() {
   close();
 }
 
-int FileWriter::write(char buf[]) {
-  return childWriter_->write(buf);
+int FileWriter::write(char buf[], size_t nBytes) {
+  return childWriter_->write(buf, nBytes);
 }
 
 int FileWriter::close() {

--- a/fbpcf/io/api/FileWriter.cpp
+++ b/fbpcf/io/api/FileWriter.cpp
@@ -6,5 +6,30 @@
  */
 
 #include "fbpcf/io/api/FileWriter.h"
+#include <memory>
+#include <string>
+#include "fbpcf/io/api/CloudFileWriter.h"
+#include "fbpcf/io/api/IOUtils.h"
+#include "fbpcf/io/api/LocalFileWriter.h"
 
-namespace fbpcf::io {} // namespace fbpcf::io
+namespace fbpcf::io {
+FileWriter::FileWriter(std::string filePath) {
+  if (IOUtils::isCloudFile(filePath)) {
+    childWriter_ = std::make_unique<CloudFileWriter>(filePath);
+  } else {
+    childWriter_ = std::make_unique<LocalFileWriter>(filePath);
+  }
+}
+
+FileWriter::~FileWriter() {
+  close();
+}
+
+int FileWriter::write(char buf[]) {
+  return childWriter_->write(buf);
+}
+
+int FileWriter::close() {
+  return childWriter_->close();
+}
+} // namespace fbpcf::io

--- a/fbpcf/io/api/FileWriter.h
+++ b/fbpcf/io/api/FileWriter.h
@@ -6,8 +6,7 @@
  */
 
 #pragma once
-#include "fbpcf/io/api/ICloser.h"
-#include "fbpcf/io/api/IWriter.h"
+#include "fbpcf/io/api/IWriterCloser.h"
 
 namespace fbpcf::io {
 
@@ -18,7 +17,7 @@ cloud provider or a file on disk. Internally, this
 class will create a LocalFileWriter or CloudFileWriter
 depending on what file path is provided.
 */
-class FileWriter : public IWriter, public ICloser {
+class FileWriter : public IWriterCloser {
  public:
   int close() override;
   int write(char buf[]) override;

--- a/fbpcf/io/api/FileWriter.h
+++ b/fbpcf/io/api/FileWriter.h
@@ -6,6 +6,8 @@
  */
 
 #pragma once
+#include <memory>
+#include <string>
 #include "fbpcf/io/api/IWriterCloser.h"
 
 namespace fbpcf::io {
@@ -19,9 +21,14 @@ depending on what file path is provided.
 */
 class FileWriter : public IWriterCloser {
  public:
+  explicit FileWriter(std::string filePath);
+
   int close() override;
   int write(char buf[]) override;
   ~FileWriter() override;
+
+ private:
+  std::unique_ptr<IWriterCloser> childWriter_;
 };
 
 } // namespace fbpcf::io

--- a/fbpcf/io/api/FileWriter.h
+++ b/fbpcf/io/api/FileWriter.h
@@ -6,6 +6,7 @@
  */
 
 #pragma once
+#include <cstddef>
 #include <memory>
 #include <string>
 #include "fbpcf/io/api/IWriterCloser.h"
@@ -24,7 +25,7 @@ class FileWriter : public IWriterCloser {
   explicit FileWriter(std::string filePath);
 
   int close() override;
-  int write(char buf[]) override;
+  int write(char buf[], size_t nBytes) override;
   ~FileWriter() override;
 
  private:

--- a/fbpcf/io/api/IOUtils.h
+++ b/fbpcf/io/api/IOUtils.h
@@ -5,22 +5,17 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "fbpcf/io/api/CloudFileReader.h"
+#pragma once
+
 #include <string>
 
 namespace fbpcf::io {
 
-CloudFileReader::CloudFileReader(std::string /* filePath */) {}
-
-int CloudFileReader::close() {
-  return 0;
-}
-int CloudFileReader::read(char buf[]) {
-  return 0;
-}
-
-CloudFileReader::~CloudFileReader() {
-  close();
-}
+class IOUtils {
+ public:
+  static bool isCloudFile(std::string filePath) {
+    return filePath.find("https://", 0) == 0;
+  }
+};
 
 } // namespace fbpcf::io

--- a/fbpcf/io/api/IReader.h
+++ b/fbpcf/io/api/IReader.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <cstddef>
+
 namespace fbpcf::io {
 
 /*
@@ -21,7 +23,7 @@ class IReader {
    * the provided buffer with the data that was
    * read
    */
-  virtual int read(char buf[]) = 0;
+  virtual int read(char buf[], size_t nBytes) = 0;
   virtual ~IReader() = default;
 };
 

--- a/fbpcf/io/api/IReader.h
+++ b/fbpcf/io/api/IReader.h
@@ -21,8 +21,8 @@ class IReader {
    * the provided buffer with the data that was
    * read
    */
-  virtual int read(char buf[]);
-  virtual ~IReader();
+  virtual int read(char buf[]) = 0;
+  virtual ~IReader() = default;
 };
 
 } // namespace fbpcf::io

--- a/fbpcf/io/api/IReaderCloser.h
+++ b/fbpcf/io/api/IReaderCloser.h
@@ -7,21 +7,18 @@
 
 #pragma once
 
+#include "fbpcf/io/api/ICloser.h"
+#include "fbpcf/io/api/IReader.h"
+
 namespace fbpcf::io {
 
 /*
- * Defines a class that uses an underlying
- * medium and must close it to free up the allocated
- * resources.
+ * Defines a class that reads data from an
+ * underlying medium and closes it.
  */
-class ICloser {
+class IReaderCloser : public IReader, public ICloser {
  public:
-  /*
-   * close() returns 0 if it succeeds, and -1
-   * in the case of an error.
-   */
-  virtual int close() = 0;
-  virtual ~ICloser() = default;
+  virtual ~IReaderCloser() = default;
 };
 
 } // namespace fbpcf::io

--- a/fbpcf/io/api/IWriter.h
+++ b/fbpcf/io/api/IWriter.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <cstddef>
+
 namespace fbpcf::io {
 
 /*
@@ -18,10 +20,10 @@ class IWriter {
   /*
    * write() returns the number of bytes it
    * was able to write, or -1 if there was
-   * an error. It attempts to write the
-   * entire provided buffer.
+   * an error. It attempts to write the first
+   * n bytes of the entire provided buffer.
    */
-  virtual int write(char buf[]) = 0;
+  virtual int write(char buf[], size_t nBytes) = 0;
   virtual ~IWriter() = default;
 };
 

--- a/fbpcf/io/api/IWriter.h
+++ b/fbpcf/io/api/IWriter.h
@@ -21,8 +21,8 @@ class IWriter {
    * an error. It attempts to write the
    * entire provided buffer.
    */
-  virtual int write(char buf[]);
-  virtual ~IWriter();
+  virtual int write(char buf[]) = 0;
+  virtual ~IWriter() = default;
 };
 
 } // namespace fbpcf::io

--- a/fbpcf/io/api/IWriterCloser.h
+++ b/fbpcf/io/api/IWriterCloser.h
@@ -7,21 +7,18 @@
 
 #pragma once
 
+#include "fbpcf/io/api/ICloser.h"
+#include "fbpcf/io/api/IWriter.h"
+
 namespace fbpcf::io {
 
 /*
- * Defines a class that uses an underlying
- * medium and must close it to free up the allocated
- * resources.
+ * Defines a class that writes data to an
+ * underlying medium and closes it.
  */
-class ICloser {
+class IWriterCloser : public IWriter, public ICloser {
  public:
-  /*
-   * close() returns 0 if it succeeds, and -1
-   * in the case of an error.
-   */
-  virtual int close() = 0;
-  virtual ~ICloser() = default;
+  virtual ~IWriterCloser() = default;
 };
 
 } // namespace fbpcf::io

--- a/fbpcf/io/api/LocalFileReader.cpp
+++ b/fbpcf/io/api/LocalFileReader.cpp
@@ -7,4 +7,18 @@
 
 #include "fbpcf/io/api/LocalFileReader.h"
 
-namespace fbpcf::io {} // namespace fbpcf::io
+namespace fbpcf::io {
+
+LocalFileReader::LocalFileReader(std::string /* filePath */) {}
+
+int LocalFileReader::close() {
+  return 0;
+}
+int LocalFileReader::read(char buf[]) {
+  return 0;
+}
+
+LocalFileReader::~LocalFileReader() {
+  close();
+}
+} // namespace fbpcf::io

--- a/fbpcf/io/api/LocalFileReader.cpp
+++ b/fbpcf/io/api/LocalFileReader.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "fbpcf/io/api/LocalFileReader.h"
+#include <cstddef>
 
 namespace fbpcf::io {
 
@@ -14,7 +15,7 @@ LocalFileReader::LocalFileReader(std::string /* filePath */) {}
 int LocalFileReader::close() {
   return 0;
 }
-int LocalFileReader::read(char buf[]) {
+int LocalFileReader::read(char buf[], size_t nBytes) {
   return 0;
 }
 

--- a/fbpcf/io/api/LocalFileReader.h
+++ b/fbpcf/io/api/LocalFileReader.h
@@ -6,9 +6,7 @@
  */
 
 #pragma once
-#include <vector>
-#include "fbpcf/io/api/ICloser.h"
-#include "fbpcf/io/api/IReader.h"
+#include "fbpcf/io/api/IReaderCloser.h"
 
 namespace fbpcf::io {
 
@@ -17,7 +15,7 @@ This class is the API for reading a file from local
 storage. It must be on disk and cannot be a file in
 cloud storage.
 */
-class LocalFileReader : public IReader, public ICloser {
+class LocalFileReader : public IReaderCloser {
  public:
   int close() override;
   int read(char buf[]) override;

--- a/fbpcf/io/api/LocalFileReader.h
+++ b/fbpcf/io/api/LocalFileReader.h
@@ -6,6 +6,7 @@
  */
 
 #pragma once
+#include <cstddef>
 #include <string>
 #include "fbpcf/io/api/IReaderCloser.h"
 
@@ -21,7 +22,7 @@ class LocalFileReader : public IReaderCloser {
   explicit LocalFileReader(std::string filePath);
 
   int close() override;
-  int read(char buf[]) override;
+  int read(char buf[], size_t nBytes) override;
   ~LocalFileReader() override;
 };
 

--- a/fbpcf/io/api/LocalFileReader.h
+++ b/fbpcf/io/api/LocalFileReader.h
@@ -6,6 +6,7 @@
  */
 
 #pragma once
+#include <string>
 #include "fbpcf/io/api/IReaderCloser.h"
 
 namespace fbpcf::io {
@@ -17,6 +18,8 @@ cloud storage.
 */
 class LocalFileReader : public IReaderCloser {
  public:
+  explicit LocalFileReader(std::string filePath);
+
   int close() override;
   int read(char buf[]) override;
   ~LocalFileReader() override;

--- a/fbpcf/io/api/LocalFileWriter.cpp
+++ b/fbpcf/io/api/LocalFileWriter.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "fbpcf/io/api/LocalFileWriter.h"
+#include <cstddef>
 #include <string>
 
 namespace fbpcf::io {
@@ -14,7 +15,7 @@ LocalFileWriter::LocalFileWriter(std::string /* filePath */) {}
 int LocalFileWriter::close() {
   return 0;
 }
-int LocalFileWriter::write(char buf[]) {
+int LocalFileWriter::write(char buf[], size_t nBytes) {
   return 0;
 }
 

--- a/fbpcf/io/api/LocalFileWriter.cpp
+++ b/fbpcf/io/api/LocalFileWriter.cpp
@@ -6,5 +6,19 @@
  */
 
 #include "fbpcf/io/api/LocalFileWriter.h"
+#include <string>
 
-namespace fbpcf::io {} // namespace fbpcf::io
+namespace fbpcf::io {
+LocalFileWriter::LocalFileWriter(std::string /* filePath */) {}
+
+int LocalFileWriter::close() {
+  return 0;
+}
+int LocalFileWriter::write(char buf[]) {
+  return 0;
+}
+
+LocalFileWriter::~LocalFileWriter() {
+  close();
+}
+} // namespace fbpcf::io

--- a/fbpcf/io/api/LocalFileWriter.h
+++ b/fbpcf/io/api/LocalFileWriter.h
@@ -6,6 +6,7 @@
  */
 
 #pragma once
+#include <cstddef>
 #include <string>
 #include "fbpcf/io/api/IWriterCloser.h"
 
@@ -21,7 +22,7 @@ class LocalFileWriter : public IWriterCloser {
   explicit LocalFileWriter(std::string filePath);
 
   int close() override;
-  int write(char buf[]) override;
+  int write(char buf[], size_t nBytes) override;
   ~LocalFileWriter() override;
 };
 

--- a/fbpcf/io/api/LocalFileWriter.h
+++ b/fbpcf/io/api/LocalFileWriter.h
@@ -6,8 +6,7 @@
  */
 
 #pragma once
-#include "fbpcf/io/api/ICloser.h"
-#include "fbpcf/io/api/IWriter.h"
+#include "fbpcf/io/api/IWriterCloser.h"
 
 namespace fbpcf::io {
 
@@ -16,7 +15,7 @@ This class is the API for writing a file to local
 storage. It must be on disk and cannot be a file in
 cloud storage.
 */
-class LocalFileWriter : public IWriter, public ICloser {
+class LocalFileWriter : public IWriterCloser {
  public:
   int close() override;
   int write(char buf[]) override;

--- a/fbpcf/io/api/LocalFileWriter.h
+++ b/fbpcf/io/api/LocalFileWriter.h
@@ -6,6 +6,7 @@
  */
 
 #pragma once
+#include <string>
 #include "fbpcf/io/api/IWriterCloser.h"
 
 namespace fbpcf::io {
@@ -17,6 +18,8 @@ cloud storage.
 */
 class LocalFileWriter : public IWriterCloser {
  public:
+  explicit LocalFileWriter(std::string filePath);
+
   int close() override;
   int write(char buf[]) override;
   ~LocalFileWriter() override;

--- a/fbpcf/io/api/SocketReader.h
+++ b/fbpcf/io/api/SocketReader.h
@@ -7,6 +7,7 @@
 
 #pragma once
 #include <openssl/ssl.h>
+#include <cstddef>
 
 #include "fbpcf/io/api/IReaderCloser.h"
 
@@ -31,7 +32,7 @@ class SocketReader : public IReaderCloser {
   SocketReader(SSL* ssl);
 
   int close() override;
-  int read(char buf[]) override;
+  int read(char buf[], size_t nBytes) override;
   ~SocketReader() override;
 };
 

--- a/fbpcf/io/api/SocketReader.h
+++ b/fbpcf/io/api/SocketReader.h
@@ -8,8 +8,7 @@
 #pragma once
 #include <openssl/ssl.h>
 
-#include "fbpcf/io/api/ICloser.h"
-#include "fbpcf/io/api/IReader.h"
+#include "fbpcf/io/api/IReaderCloser.h"
 
 namespace fbpcf::io {
 
@@ -17,7 +16,7 @@ namespace fbpcf::io {
 This class is the API for reading data from network
 socket. It is constructed with a socket file descriptor.
 */
-class SocketReader : public IReader, public ICloser {
+class SocketReader : public IReaderCloser {
  public:
   /*
    * Creates a SocketReader to read from the given

--- a/fbpcf/io/api/SocketWriter.h
+++ b/fbpcf/io/api/SocketWriter.h
@@ -9,8 +9,7 @@
 
 #include <openssl/ssl.h>
 
-#include "fbpcf/io/api/ICloser.h"
-#include "fbpcf/io/api/IWriter.h"
+#include "fbpcf/io/api/IWriterCloser.h"
 
 namespace fbpcf::io {
 
@@ -18,7 +17,7 @@ namespace fbpcf::io {
 This class is the API for writing data to a network
 socket. It is constructed with a socket file descriptor.
 */
-class SocketWriter : public IWriter, public ICloser {
+class SocketWriter : public IWriterCloser {
  public:
   /*
    * Creates a SocketWriter to write to the given

--- a/fbpcf/io/api/SocketWriter.h
+++ b/fbpcf/io/api/SocketWriter.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <openssl/ssl.h>
+#include <cstddef>
 
 #include "fbpcf/io/api/IWriterCloser.h"
 
@@ -32,7 +33,7 @@ class SocketWriter : public IWriterCloser {
   SocketWriter(SSL* ssl);
 
   int close() override;
-  int write(char buf[]) override;
+  int write(char buf[], size_t nBytes) override;
   ~SocketWriter() override;
 };
 

--- a/fbpcf/io/api/test/IOUtilsTest.cpp
+++ b/fbpcf/io/api/test/IOUtilsTest.cpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "fbpcf/io/api/IOUtils.h"
+#include <gtest/gtest.h>
+#include <string>
+
+namespace fbpcf::io {
+
+TEST(IOUtilsTest, testIsCloudFile) {
+  bool ans =
+      IOUtils::isCloudFile("https://random_bucket.us-west-2.amazonaws.com");
+  EXPECT_EQ(ans, true);
+
+  ans = IOUtils::isCloudFile("/random/local/file");
+  EXPECT_EQ(ans, false);
+}
+
+} // namespace fbpcf::io


### PR DESCRIPTION
Summary: We cannot simply pass a `buf[]` to the `read` and `write` APIs, because you cannot retrieve the size of the provided buffer in C++. The C++ standard library needs to be told the number of bytes

Differential Revision: D34539989

