### PR TITLE
Add a "copy" API to IFileManager for movement of local files

### DIFF
--- a/fbpcf/gcp/MockGCSClient.h
+++ b/fbpcf/gcp/MockGCSClient.h
@@ -27,5 +27,10 @@ class MockGCSClient : public gcs::Client {
       gcs::ObjectWriteStream,
       WriteObject,
       (const std::string, const std::string));
+
+  MOCK_METHOD(
+      google::cloud::StatusOr<gcs::ObjectMetadata>,
+      UploadFile,
+      (const std::string, const std::string, const std::string));
 };
 } // namespace fbpcf

--- a/fbpcf/io/IFileManager.h
+++ b/fbpcf/io/IFileManager.h
@@ -25,6 +25,10 @@ class IFileManager {
 
   virtual void write(const std::string& fileName, const std::string& data) = 0;
 
+  virtual void copy(
+      const std::string& sourceFile,
+      const std::string& destination) = 0;
+
   virtual std::string readBytes(
       const std::string& fileName,
       std::size_t start,

--- a/fbpcf/io/LocalFileManager.cpp
+++ b/fbpcf/io/LocalFileManager.cpp
@@ -51,6 +51,13 @@ void LocalFileManager::write(
   os << data;
 }
 
+void LocalFileManager::copy(
+    const std::string& sourceFile,
+    const std::string& destination) {
+  auto fileData = read(sourceFile);
+  write(destination, fileData);
+}
+
 std::string LocalFileManager::readBytes(
     const std::string& fileName,
     std::size_t start,

--- a/fbpcf/io/LocalFileManager.h
+++ b/fbpcf/io/LocalFileManager.h
@@ -21,6 +21,9 @@ class LocalFileManager : public IFileManager {
 
   void write(const std::string& fileName, const std::string& data) override;
 
+  void copy(const std::string& sourceFile, const std::string& destination)
+      override;
+
   std::string
   readBytes(const std::string& fileName, std::size_t start, std::size_t end);
 };

--- a/fbpcf/io/S3FileManager.h
+++ b/fbpcf/io/S3FileManager.h
@@ -10,8 +10,10 @@
 #include <memory>
 
 #include <aws/s3/S3Client.h>
+#include <sstream>
 
 #include "IFileManager.h"
+#include "IInputStream.h"
 
 namespace fbpcf {
 class S3FileManager : public IFileManager {
@@ -27,6 +29,14 @@ class S3FileManager : public IFileManager {
   std::string read(const std::string& fileName) override;
 
   void write(const std::string& fileName, const std::string& data) override;
+
+  void copy(const std::string& sourceFile, const std::string& destination)
+      override;
+
+  void writeDataStream(
+      const std::string& fileName,
+      std::shared_ptr<std::basic_iostream<char, std::char_traits<char>>>
+          dataStream);
 
  private:
   std::unique_ptr<Aws::S3::S3Client> s3Client_;

--- a/fbpcf/io/test/LocalFileManagerTest.cpp
+++ b/fbpcf/io/test/LocalFileManagerTest.cpp
@@ -22,12 +22,15 @@ class LocalFileManagerTest : public ::testing::Test {
  protected:
   void TearDown() override {
     std::remove(filePath_.c_str());
+    std::remove(copiedFilePath_.c_str());
     std::remove(nonExistentFolderPath_.c_str());
   }
 
   const std::string testData_ = "this is test data";
   const std::string filePath_ =
       folly::sformat("./testfile_{}", folly::Random::rand32());
+  const std::string copiedFilePath_ =
+      folly::sformat("./copy_testfile_{}", folly::Random::rand32());
   const std::string nonExistentFolderPath_ =
       folly::sformat("fakedfolder/testfile_{}", folly::Random::rand32());
 };
@@ -72,5 +75,13 @@ TEST_F(LocalFileManagerTest, testByteReadException) {
   fileManager.write(filePath_, testData_);
   EXPECT_THROW(fileManager.readBytes(filePath_, 100, 101), PcfException);
   EXPECT_THROW(fileManager.readBytes(filePath_, 5, 1), PcfException);
+}
+
+TEST_F(LocalFileManagerTest, testCopy) {
+  LocalFileManager fileManager;
+  fileManager.write(filePath_, testData_);
+  fileManager.copy(filePath_, copiedFilePath_);
+  auto copiedData = fileManager.read(copiedFilePath_);
+  EXPECT_EQ(testData_, copiedData);
 }
 } // namespace fbpcf

--- a/fbpcf/io/test/S3FileManagerTest.cpp
+++ b/fbpcf/io/test/S3FileManagerTest.cpp
@@ -5,11 +5,17 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <cstdio>
 #include <memory>
+#include <sstream>
 #include <string>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+
+#include "fbpcf/io/LocalFileManager.h"
+#include "folly/Format.h"
+#include "folly/Random.h"
 
 #include "fbpcf/aws/AwsSdk.h"
 #include "fbpcf/aws/MockS3Client.h"
@@ -18,24 +24,47 @@
 
 using ::testing::_;
 
-const std::string kS3URL = "https://bucket.s3.region.amazonaws.com/key";
-
 namespace fbpcf {
-TEST(S3FileManager, testReadWithException) {
-  AwsSdk::aquire();
-  auto s3Client = std::make_unique<MockS3Client>();
+class S3FileManagerTest : public ::testing::Test {
+ protected:
+  void TearDown() override {
+    std::remove(filePath_.c_str());
+    s3Client = nullptr;
+  }
+
+  void SetUp() override {
+    AwsSdk::aquire();
+    s3Client = std::make_unique<MockS3Client>();
+  }
+
+  std::unique_ptr<MockS3Client> s3Client;
+
+  const std::string testData_ = "this is test data";
+  const std::string filePath_ =
+      folly::sformat("./testfile_{}", folly::Random::rand32());
+  const std::string kS3URL = "https://bucket.s3.region.amazonaws.com/key";
+};
+
+TEST_F(S3FileManagerTest, testReadWithException) {
   EXPECT_CALL(*s3Client, GetObject(_)).Times(1);
   S3FileManager fileManager{std::move(s3Client)};
   // by default, the call will fail, because the response indicates failure
   EXPECT_THROW(fileManager.read(kS3URL), AwsException);
 }
 
-TEST(S3FileManager, testWriteWithException) {
-  AwsSdk::aquire();
-  auto s3Client = std::make_unique<MockS3Client>();
+TEST_F(S3FileManagerTest, testWriteWithException) {
   EXPECT_CALL(*s3Client, PutObject(_)).Times(1);
   S3FileManager fileManager{std::move(s3Client)};
   // by default, the call will fail, because the response indicates failure
-  EXPECT_THROW(fileManager.write(kS3URL, "abc"), AwsException);
+  EXPECT_THROW(fileManager.write(kS3URL, testData_), AwsException);
+}
+
+TEST_F(S3FileManagerTest, testCopyWritesToS3) {
+  EXPECT_CALL(*s3Client, PutObject(_)).Times(1);
+  S3FileManager fileManager{std::move(s3Client)};
+  auto localFileManager = LocalFileManager{};
+  localFileManager.write(filePath_, testData_);
+  // by default, the call will fail, because the response indicates failure
+  EXPECT_THROW(fileManager.copy(filePath_, kS3URL), AwsException);
 }
 } // namespace fbpcf


### PR DESCRIPTION
Summary: This commit adds a new API to copy a file from one location to another. Each implementation of the IFileManager uses it's write function to put the file in the appropriate location on the service/local machine.

Differential Revision: D34584787

