### PR TITLE
Refactor secret share engine class

### DIFF
--- a/fbpcf/engine/ISecretShareEngine.h
+++ b/fbpcf/engine/ISecretShareEngine.h
@@ -130,6 +130,8 @@ class ISecretShareEngine {
   virtual std::vector<bool> computeBatchAsymmetricNOT(
       const std::vector<bool>& input) const = 0;
 
+  //======== Below are free AND computation API's: ========
+
   /**
    * Compute a free AND gate: at least one of the input is a public value, thus
    * the parties only need to multiply the secret share and the public value
@@ -163,11 +165,39 @@ class ISecretShareEngine {
    */
   virtual uint32_t scheduleAND(bool left, bool right) = 0;
 
+  /** Schedule a batch AND gates for computation. Since computing AND gates
+   * incurs 2 roundtrips, we want to batch them together to reduce the total
+   * number of roundtrips.
+   * @param left the value on left input wire
+   * @param right the value on right input wire. Must be same length as left
+   * @return the index of the scheduled gate, i.e. how many gates has already
+   * been scheduled.
+   */
+  virtual uint32_t scheduleBatchAND(
+      const std::vector<bool>& left,
+      const std::vector<bool>& right) = 0;
+
+  //======== Below are API's to execute non free AND's: ========
+
   /**
-   * Execute all the scheduled AND/batch AND computation within TWO roundtrips,
-   * no matter how many AND gates are scheduled.
+   * Get the execution result of the executed AND gate
+   * @param index the index of the AND gate in the schedule
+   * @return the result value
    */
   virtual void executeScheduledAND() = 0;
+
+  /**
+   * Compute a batch of AND gate: all inputs are private values. This batch of
+   * gates will be immediately executed, incuring a roundtrip.
+   * @param left the values on left input wires
+   * @param right the values on right input wires
+   * @return the values of the results
+   */
+  virtual std::vector<bool> computeBatchANDImmediately(
+      const std::vector<bool>& left,
+      const std::vector<bool>& right) = 0;
+
+  //======== Below are API's to retrieve non-free AND results: ========
 
   /**
    * Get the execution result of the executed AND gate
@@ -175,18 +205,6 @@ class ISecretShareEngine {
    * @return the result value
    */
   virtual bool getANDExecutionResult(uint32_t index) const = 0;
-
-  /** Schedule a batch AND gates for computation. Since computing AND gates
-   * incurs 2 roundtrips, we want to batch them together to reduce the total
-   * number of roundtrips.
-   * @param left the value on left input wire
-   * @param right the value on right input wire
-   * @return the index of the scheduled gate, i.e. how many gates has already
-   * been scheduled.
-   */
-  virtual uint32_t scheduleBatchAND(
-      const std::vector<bool>& left,
-      const std::vector<bool>& right) = 0;
 
   /**
    * Get the execution result of the executed AND gate
@@ -197,20 +215,10 @@ class ISecretShareEngine {
       uint32_t index) const = 0;
 
   /**
-   * Compute a batch of AND gate: all inputs are private values. This batch of
-   * gates will be immediately executed, incuring a roundtrip.
-   * @param left the values on left input wires
-   * @param right the values on right input wires
-   * @return the values of the results
-   */
-  virtual std::vector<bool> computeBatchAND(
-      const std::vector<bool>& left,
-      const std::vector<bool>& right) = 0;
-
-  /**
    * reveal a vector of shared secret to a designated party
    * @param Id the identity of the plaintext receiver
-   * @param output the plaintext output, false if this party is not the receiver
+   * @param output the plaintext output, false if this party is not the
+   * receiver
    */
   virtual std::vector<bool> revealToParty(
       int id,

--- a/fbpcf/engine/test/SecretShareEngineTest.cpp
+++ b/fbpcf/engine/test/SecretShareEngineTest.cpp
@@ -220,7 +220,7 @@ std::vector<bool> asymmetricXORTestBody(
   return rst;
 }
 
-TEST(SecretShareEngineTest, TestXORtWithDummyComponents) {
+TEST(SecretShareEngineTest, TestXORtWitDummyComponents) {
   int numberOfParty = 4;
   int size = 16384;
   auto inputs1 = generateRandomInputs(numberOfParty, size, size);
@@ -270,7 +270,7 @@ std::vector<bool> batchAsymmetricXORTestBody(
   return engine.computeBatchAsymmetricXOR(firstHalfInput, secondHalfInput);
 }
 
-TEST(SecretShareEngineTest, TestBatchXORtWithDummyComponents) {
+TEST(SecretShareEngineTest, TestBatchXORWithDummyComponents) {
   int numberOfParty = 4;
   int size = 16384;
   auto inputs1 = generateRandomInputs(numberOfParty, size, size);
@@ -310,7 +310,7 @@ std::vector<bool> ANDTestBody(
 
   auto secondHalfInput =
       std::vector<bool>(inputs.begin() + size / 2, inputs.end());
-  engine.computeBatchAND(firstHalfInput, secondHalfInput);
+  engine.computeBatchANDImmediately(firstHalfInput, secondHalfInput);
 
   auto batchIndex0 = engine.scheduleBatchAND(firstHalfInput, secondHalfInput);
   auto batchIndex1 = engine.scheduleBatchAND(firstHalfInput, secondHalfInput);
@@ -327,12 +327,12 @@ std::vector<bool> ANDTestBody(
   tmp = engine.getBatchANDExecutionResult(batchIndex1);
   rst.insert(rst.end(), tmp.begin(), tmp.end());
 
-  tmp = engine.computeBatchAND(firstHalfInput, secondHalfInput);
+  tmp = engine.computeBatchANDImmediately(firstHalfInput, secondHalfInput);
   rst.insert(rst.end(), tmp.begin(), tmp.end());
   return rst;
 }
 
-TEST(SecretShareEngineTest, TestANDtWithDummyComponents) {
+TEST(SecretShareEngineTest, TestANDWithDummyComponents) {
   int numberOfParty = 4;
   int size = 16384;
   auto inputs = generateRandomInputs(numberOfParty, size, size);
@@ -361,7 +361,7 @@ std::vector<bool> FreeANDTestBody(
   return rst;
 }
 
-TEST(SecretShareEngineTest, TestFreeANDtWithDummyComponents) {
+TEST(SecretShareEngineTest, TestFreeANDWithDummyComponents) {
   int numberOfParty = 4;
   int size = 16384;
   auto inputs1 = generateRandomInputs(numberOfParty, size, size / 2);
@@ -392,7 +392,7 @@ std::vector<bool> BatchFreeANDTestBody(
   return engine.computeBatchFreeAND(firstHalfInput, secondHalfInput);
 }
 
-TEST(SecretShareEngineTest, TestBatchFreeANDtWithDummyComponents) {
+TEST(SecretShareEngineTest, TestBatchFreeANDWithDummyComponents) {
   int numberOfParty = 4;
   int size = 16384;
   auto inputs1 = generateRandomInputs(numberOfParty, size, size / 2);

--- a/fbpcf/scheduler/EagerScheduler.cpp
+++ b/fbpcf/scheduler/EagerScheduler.cpp
@@ -123,7 +123,7 @@ IScheduler::WireId<IScheduler::Boolean> EagerScheduler::privateAndPrivateBatch(
   auto rightValue = wireKeeper_->getBatchBooleanValue(right);
   nonFreeGates_ += leftValue.size();
   return wireKeeper_->allocateBatchBooleanValue(
-      engine_->computeBatchAND(leftValue, rightValue));
+      engine_->computeBatchANDImmediately(leftValue, rightValue));
 }
 
 IScheduler::WireId<IScheduler::Boolean> EagerScheduler::privateAndPublic(


### PR DESCRIPTION
Summary:
Refactored the MPC SecretEngine interface in a couple of ways

1. Re-organized non-free AND related methods to be in order of the action they perform (scheduling, execution, retrieval). This will make it more clear in the next diff since we are adding two more scheduling and two more retrieval methods.
2. Removed the nested return structure of the execution loop [[andResults], [batch] ... [batch]] is now a struct. This also removed the need to copy all of the scheduled data into a new format before processing the data.
3. Removed copy constructors from ScheduledAND objects. Switched internal vectors to hold unique pointers.
4. Moved the validation checks for batch sizes from execution time to scheduling time. This should make debugging easier (and also logic is a little simpler in next diff)

Differential Revision: D34308024

