### PR TITLE
Use linear ORAM for aggregation

### DIFF
--- a/fbpcf/mpc_framework/mpc_std_lib/oram/WriteOnlyOramFactory.h
+++ b/fbpcf/mpc_framework/mpc_std_lib/oram/WriteOnlyOramFactory.h
@@ -9,9 +9,12 @@
 
 #include <memory>
 #include "fbpcf/mpc_framework/engine/communication/IPartyCommunicationAgentFactory.h"
+#include "fbpcf/mpc_framework/mpc_std_lib/oram/DifferenceCalculatorFactory.h"
 #include "fbpcf/mpc_framework/mpc_std_lib/oram/IDifferenceCalculatorFactory.h"
 #include "fbpcf/mpc_framework/mpc_std_lib/oram/ISinglePointArrayGeneratorFactory.h"
 #include "fbpcf/mpc_framework/mpc_std_lib/oram/IWriteOnlyOramFactory.h"
+#include "fbpcf/mpc_framework/mpc_std_lib/oram/ObliviousDeltaCalculatorFactory.h"
+#include "fbpcf/mpc_framework/mpc_std_lib/oram/SinglePointArrayGeneratorFactory.h"
 #include "fbpcf/mpc_framework/mpc_std_lib/oram/WriteOnlyOram.h"
 
 namespace fbpcf::mpc_framework::mpc_std_lib::oram {
@@ -71,5 +74,24 @@ class WriteOnlyOramFactory final : public IWriteOnlyOramFactory<T> {
   const double intercept2 = 0.1;
   const double slope = -0.757;
 };
+
+template <typename T, int indicatorSumWidth, int schedulerId>
+std::unique_ptr<IWriteOnlyOramFactory<T>> getSecureWriteOnlyOramFactory(
+    bool amIParty0,
+    int32_t party0Id,
+    int32_t party1Id,
+    engine::communication::IPartyCommunicationAgentFactory& factory) {
+  return std::make_unique<WriteOnlyOramFactory<T>>(
+      amIParty0 ? IWriteOnlyOram<T>::Role::Alice : IWriteOnlyOram<T>::Role::Bob,
+      amIParty0 ? party1Id : party0Id,
+      factory,
+      std::make_unique<SinglePointArrayGeneratorFactory>(
+          amIParty0,
+          std::make_unique<ObliviousDeltaCalculatorFactory<schedulerId>>(
+              amIParty0, party0Id, party1Id)),
+      std::make_unique<
+          DifferenceCalculatorFactory<T, indicatorSumWidth, schedulerId>>(
+          amIParty0, party0Id, party1Id));
+}
 
 } // namespace fbpcf::mpc_framework::mpc_std_lib::oram


### PR DESCRIPTION
Summary: This diff automatically decides which ORAM implementation to use based on Ad ids.

Differential Revision: D34591843

