### PR TITLE
Move unified data processing components to a new place

### DIFF
--- a/fbpcf/unified_data_process/adapter/Adapter.h
+++ b/fbpcf/unified_data_process/adapter/Adapter.h
@@ -9,9 +9,9 @@
 
 #include "fbpcf/mpc_framework/frontend/BitString.h"
 #include "fbpcf/mpc_framework/mpc_std_lib/shuffler/IShuffler.h"
-#include "fbpcf/mpc_games/unified_data_process/adapter/IAdapter.h"
+#include "fbpcf/unified_data_process/adapter/IAdapter.h"
 
-namespace fbpcf::mpc_games::udp::adapter {
+namespace fbpcf::udp::adapter {
 
 template <int schedulerId>
 class Adapter final : public IAdapter {
@@ -42,6 +42,6 @@ class Adapter final : public IAdapter {
       shuffler_;
 };
 
-} // namespace fbpcf::mpc_games::udp::adapter
+} // namespace fbpcf::udp::adapter
 
-#include "fbpcf/mpc_games/unified_data_process/adapter/Adapter_impl.h"
+#include "fbpcf/unified_data_process/adapter/Adapter_impl.h"

--- a/fbpcf/unified_data_process/adapter/AdapterFactory.h
+++ b/fbpcf/unified_data_process/adapter/AdapterFactory.h
@@ -7,10 +7,10 @@
 
 #pragma once
 
-#include "fbpcf/mpc_games/unified_data_process/adapter/Adapter.h"
-#include "fbpcf/mpc_games/unified_data_process/adapter/IAdapterFactory.h"
+#include "fbpcf/unified_data_process/adapter/Adapter.h"
+#include "fbpcf/unified_data_process/adapter/IAdapterFactory.h"
 
-namespace fbpcf::mpc_games::udp::adapter {
+namespace fbpcf::udp::adapter {
 
 template <int schedulerId>
 class AdapterFactory final : public IAdapterFactory {
@@ -42,4 +42,4 @@ class AdapterFactory final : public IAdapterFactory {
       shufflerFactory_;
 };
 
-} // namespace fbpcf::mpc_games::udp::adapter
+} // namespace fbpcf::udp::adapter

--- a/fbpcf/unified_data_process/adapter/Adapter_impl.h
+++ b/fbpcf/unified_data_process/adapter/Adapter_impl.h
@@ -8,9 +8,9 @@
 #pragma once
 
 #include <cmath>
-#include "fbpcf/mpc_games/unified_data_process/adapter/Adapter.h"
+#include "fbpcf/unified_data_process/adapter/Adapter.h"
 
-namespace fbpcf::mpc_games::udp::adapter {
+namespace fbpcf::udp::adapter {
 
 template <int schedulerId>
 std::vector<int64_t> Adapter<schedulerId>::adapt(
@@ -88,4 +88,4 @@ std::vector<int64_t> Adapter<schedulerId>::adapt(
   return rst;
 }
 
-} // namespace fbpcf::mpc_games::udp::adapter
+} // namespace fbpcf::udp::adapter

--- a/fbpcf/unified_data_process/adapter/IAdapter.h
+++ b/fbpcf/unified_data_process/adapter/IAdapter.h
@@ -10,7 +10,7 @@
 #include <stdint.h>
 #include <vector>
 
-namespace fbpcf::mpc_games::udp::adapter {
+namespace fbpcf::udp::adapter {
 
 /*
  * An adapter converts a union-like mapping result into an intersection-like
@@ -34,4 +34,4 @@ class IAdapter {
       const std::vector<int64_t>& unionMap) const = 0;
 };
 
-} // namespace fbpcf::mpc_games::udp::adapter
+} // namespace fbpcf::udp::adapter

--- a/fbpcf/unified_data_process/adapter/IAdapterFactory.h
+++ b/fbpcf/unified_data_process/adapter/IAdapterFactory.h
@@ -7,9 +7,9 @@
 
 #pragma once
 
-#include "fbpcf/mpc_games/unified_data_process/adapter/IAdapter.h"
+#include "fbpcf/unified_data_process/adapter/IAdapter.h"
 
-namespace fbpcf::mpc_games::udp::adapter {
+namespace fbpcf::udp::adapter {
 
 class IAdapterFactory {
  public:
@@ -17,4 +17,4 @@ class IAdapterFactory {
   virtual std::unique_ptr<IAdapter> create() = 0;
 };
 
-} // namespace fbpcf::mpc_games::udp::adapter
+} // namespace fbpcf::udp::adapter

--- a/fbpcf/unified_data_process/adapter/test/AdapterTest.cpp
+++ b/fbpcf/unified_data_process/adapter/test/AdapterTest.cpp
@@ -17,9 +17,9 @@
 #include "fbpcf/mpc_framework/mpc_std_lib/shuffler/NonShufflerFactory.h"
 #include "fbpcf/mpc_framework/scheduler/SchedulerHelper.h"
 #include "fbpcf/mpc_framework/test/TestHelper.h"
-#include "fbpcf/mpc_games/unified_data_process/adapter/AdapterFactory.h"
+#include "fbpcf/unified_data_process/adapter/AdapterFactory.h"
 
-namespace fbpcf::mpc_games::udp::adapter {
+namespace fbpcf::udp::adapter {
 
 std::vector<int64_t> generateShuffledIndex(size_t size) {
   std::vector<int64_t> rst(size);
@@ -132,4 +132,4 @@ TEST(AdapterTest, testAdapterWithNonShuffler) {
   adapterTest(factory0.create(), factory1.create());
 }
 
-} // namespace fbpcf::mpc_games::udp::adapter
+} // namespace fbpcf::udp::adapter

--- a/fbpcf/unified_data_process/data_processor/DummyDataProcessor.h
+++ b/fbpcf/unified_data_process/data_processor/DummyDataProcessor.h
@@ -8,9 +8,9 @@
 #pragma once
 
 #include "fbpcf/mpc_framework/engine/communication/IPartyCommunicationAgent.h"
-#include "fbpcf/mpc_games/unified_data_process/data_processor/IDataProcessor.h"
+#include "fbpcf/unified_data_process/data_processor/IDataProcessor.h"
 
-namespace fbpcf::mpc_games::udp::data_processor::insecure {
+namespace fbpcf::udp::data_processor::insecure {
 
 /**
  * This is an insecure implementation. This object is only meant to be used as a
@@ -50,6 +50,6 @@ class DummyDataProcessor final : public IDataProcessor<schedulerId> {
       agent_;
 };
 
-} // namespace fbpcf::mpc_games::udp::data_processor::insecure
+} // namespace fbpcf::udp::data_processor::insecure
 
-#include "fbpcf/mpc_games/unified_data_process/data_processor/DummyDataProcessor_impl.h"
+#include "fbpcf/unified_data_process/data_processor/DummyDataProcessor_impl.h"

--- a/fbpcf/unified_data_process/data_processor/DummyDataProcessorFactory.h
+++ b/fbpcf/unified_data_process/data_processor/DummyDataProcessorFactory.h
@@ -9,10 +9,10 @@
 
 #include <memory>
 #include "fbpcf/mpc_framework/engine/communication/IPartyCommunicationAgentFactory.h"
-#include "fbpcf/mpc_games/unified_data_process/data_processor/DummyDataProcessor.h"
-#include "fbpcf/mpc_games/unified_data_process/data_processor/IDataProcessorFactory.h"
+#include "fbpcf/unified_data_process/data_processor/DummyDataProcessor.h"
+#include "fbpcf/unified_data_process/data_processor/IDataProcessorFactory.h"
 
-namespace fbpcf::mpc_games::udp::data_processor::insecure {
+namespace fbpcf::udp::data_processor::insecure {
 
 template <int schedulerId>
 class DummyDataProcessorFactory final
@@ -37,4 +37,4 @@ class DummyDataProcessorFactory final
       agentFactory_;
 };
 
-} // namespace fbpcf::mpc_games::udp::data_processor::insecure
+} // namespace fbpcf::udp::data_processor::insecure

--- a/fbpcf/unified_data_process/data_processor/DummyDataProcessor_impl.h
+++ b/fbpcf/unified_data_process/data_processor/DummyDataProcessor_impl.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-namespace fbpcf::mpc_games::udp::data_processor::insecure {
+namespace fbpcf::udp::data_processor::insecure {
 
 template <int schedulerId>
 typename IDataProcessor<schedulerId>::SecString
@@ -51,4 +51,4 @@ DummyDataProcessor<schedulerId>::processPeersData(
   return typename IDataProcessor<schedulerId>::SecString(myShare, myId_);
 }
 
-} // namespace fbpcf::mpc_games::udp::data_processor::insecure
+} // namespace fbpcf::udp::data_processor::insecure

--- a/fbpcf/unified_data_process/data_processor/IDataProcessor.h
+++ b/fbpcf/unified_data_process/data_processor/IDataProcessor.h
@@ -11,7 +11,7 @@
 #include <vector>
 #include "fbpcf/mpc_framework/frontend/BitString.h"
 
-namespace fbpcf::mpc_games::udp::data_processor {
+namespace fbpcf::udp::data_processor {
 
 /**
  * A data processor can generate the secret shares of the data of the matched
@@ -53,4 +53,4 @@ class IDataProcessor {
       size_t dataWidth) = 0;
 };
 
-} // namespace fbpcf::mpc_games::udp::data_processor
+} // namespace fbpcf::udp::data_processor

--- a/fbpcf/unified_data_process/data_processor/IDataProcessorFactory.h
+++ b/fbpcf/unified_data_process/data_processor/IDataProcessorFactory.h
@@ -8,9 +8,9 @@
 #pragma once
 
 #include <memory>
-#include "fbpcf/mpc_games/unified_data_process/data_processor/IDataProcessor.h"
+#include "fbpcf/unified_data_process/data_processor/IDataProcessor.h"
 
-namespace fbpcf::mpc_games::udp::data_processor {
+namespace fbpcf::udp::data_processor {
 
 template <int schedulerId>
 class IDataProcessorFactory {
@@ -19,4 +19,4 @@ class IDataProcessorFactory {
   virtual std::unique_ptr<IDataProcessor<schedulerId>> create() = 0;
 };
 
-} // namespace fbpcf::mpc_games::udp::data_processor
+} // namespace fbpcf::udp::data_processor

--- a/fbpcf/unified_data_process/data_processor/test/DataProcessorTest.cpp
+++ b/fbpcf/unified_data_process/data_processor/test/DataProcessorTest.cpp
@@ -16,9 +16,9 @@
 #include "fbpcf/mpc_framework/engine/communication/test/AgentFactoryCreationHelper.h"
 #include "fbpcf/mpc_framework/scheduler/SchedulerHelper.h"
 #include "fbpcf/mpc_framework/test/TestHelper.h"
-#include "fbpcf/mpc_games/unified_data_process/data_processor/DummyDataProcessorFactory.h"
+#include "fbpcf/unified_data_process/data_processor/DummyDataProcessorFactory.h"
 
-namespace fbpcf::mpc_games::udp::data_processor {
+namespace fbpcf::udp::data_processor {
 
 std::tuple<
     std::vector<std::vector<uint8_t>>,
@@ -111,4 +111,4 @@ TEST(DummyDataProcessor, testDummyDataProcessor) {
   testDataProcessor(factory0.create(), factory1.create());
 }
 
-} // namespace fbpcf::mpc_games::udp::data_processor
+} // namespace fbpcf::udp::data_processor


### PR DESCRIPTION
Summary:
As title.
This diff is created via the following steps:
1. manualy move the folder.
2. run `grep -rl "mpc_games/unified“ . | xargs sed -i 's+mpc_games/unified+unified+g'` under `fbpcf/`
3. run `grep -rl "mpc_games::udp” . | xargs sed -i 's/mpc_games::udp/udp/g’` under `fbpcf/`

Differential Revision: D34705159

