### PR TITLE
Get rid of `mpc_framework` namespace

### DIFF
--- a/fbpcf/mpc_framework/engine/ISecretShareEngine.h
+++ b/fbpcf/mpc_framework/engine/ISecretShareEngine.h
@@ -10,7 +10,7 @@
 #include <optional>
 #include <vector>
 
-namespace fbpcf::mpc_framework::engine {
+namespace fbpcf::engine {
 
 /**
  The MPC engine API
@@ -223,4 +223,4 @@ class ISecretShareEngine {
   virtual std::pair<uint64_t, uint64_t> getTrafficStatistics() const = 0;
 };
 
-} // namespace fbpcf::mpc_framework::engine
+} // namespace fbpcf::engine

--- a/fbpcf/mpc_framework/engine/ISecretShareEngineFactory.h
+++ b/fbpcf/mpc_framework/engine/ISecretShareEngineFactory.h
@@ -13,7 +13,7 @@
 
 #include "fbpcf/mpc_framework/engine/ISecretShareEngine.h"
 
-namespace fbpcf::mpc_framework::engine {
+namespace fbpcf::engine {
 
 /**
  * This factory creates secret share MPC engine
@@ -25,4 +25,4 @@ class ISecretShareEngineFactory {
   virtual std::unique_ptr<ISecretShareEngine> create() = 0;
 };
 
-} // namespace fbpcf::mpc_framework::engine
+} // namespace fbpcf::engine

--- a/fbpcf/mpc_framework/engine/SecretShareEngine.cpp
+++ b/fbpcf/mpc_framework/engine/SecretShareEngine.cpp
@@ -12,7 +12,7 @@
 #include "fbpcf/mpc_framework/engine/SecretShareEngine.h"
 #include "fbpcf/mpc_framework/engine/util/util.h"
 
-namespace fbpcf::mpc_framework::engine {
+namespace fbpcf::engine {
 SecretShareEngine::SecretShareEngine(
     std::unique_ptr<tuple_generator::ITupleGenerator> tupleGenerator,
     std::unique_ptr<communication::ISecretShareEngineCommunicationAgent>
@@ -308,4 +308,4 @@ std::vector<bool> SecretShareEngine::revealToParty(
   return communicationAgent_->openSecretsToParty(id, output);
 }
 
-} // namespace fbpcf::mpc_framework::engine
+} // namespace fbpcf::engine

--- a/fbpcf/mpc_framework/engine/SecretShareEngine.h
+++ b/fbpcf/mpc_framework/engine/SecretShareEngine.h
@@ -15,7 +15,7 @@
 #include "fbpcf/mpc_framework/engine/tuple_generator/ITupleGenerator.h"
 #include "fbpcf/mpc_framework/engine/util/IPrgFactory.h"
 
-namespace fbpcf::mpc_framework::engine {
+namespace fbpcf::engine {
 
 class SecretShareEngine final : public ISecretShareEngine {
  public:
@@ -218,4 +218,4 @@ class SecretShareEngine final : public ISecretShareEngine {
   std::vector<ScheduledBatchAND> scheduledBatchANDGates_;
 };
 
-} // namespace fbpcf::mpc_framework::engine
+} // namespace fbpcf::engine

--- a/fbpcf/mpc_framework/engine/SecretShareEngineFactory.h
+++ b/fbpcf/mpc_framework/engine/SecretShareEngineFactory.h
@@ -26,7 +26,7 @@
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/RcotHelper.h"
 #include "fbpcf/mpc_framework/engine/util/AesPrgFactory.h"
 
-namespace fbpcf::mpc_framework::engine {
+namespace fbpcf::engine {
 
 /**
  * This factory creates a secure secret share MPC engine, provided underlying
@@ -195,4 +195,4 @@ getInsecureEngineFactoryWithDummyTupleGenerator(
           tuple_generator::insecure::DummyTupleGeneratorFactory>());
 }
 
-} // namespace fbpcf::mpc_framework::engine
+} // namespace fbpcf::engine

--- a/fbpcf/mpc_framework/engine/communication/AgentMapHelper.h
+++ b/fbpcf/mpc_framework/engine/communication/AgentMapHelper.h
@@ -13,7 +13,7 @@
 #include "fbpcf/mpc_framework/engine/communication/IPartyCommunicationAgent.h"
 #include "fbpcf/mpc_framework/engine/communication/IPartyCommunicationAgentFactory.h"
 
-namespace fbpcf::mpc_framework::engine::communication {
+namespace fbpcf::engine::communication {
 
 /**
  * Create an agent map for party with 'myId' with entries for all the other
@@ -33,4 +33,4 @@ inline std::map<int, std::unique_ptr<IPartyCommunicationAgent>> getAgentMap(
   return agentMap;
 }
 
-} // namespace fbpcf::mpc_framework::engine::communication
+} // namespace fbpcf::engine::communication

--- a/fbpcf/mpc_framework/engine/communication/IPartyCommunicationAgent.h
+++ b/fbpcf/mpc_framework/engine/communication/IPartyCommunicationAgent.h
@@ -15,7 +15,7 @@
 #error "Machine must be little endian"
 #endif
 
-namespace fbpcf::mpc_framework::engine::communication {
+namespace fbpcf::engine::communication {
 
 /**
  * This is the network API between two parties.
@@ -158,4 +158,4 @@ inline std::vector<bool> IPartyCommunicationAgent::receiveT(int size) {
   return receiveBool(size);
 }
 
-} // namespace fbpcf::mpc_framework::engine::communication
+} // namespace fbpcf::engine::communication

--- a/fbpcf/mpc_framework/engine/communication/IPartyCommunicationAgentFactory.h
+++ b/fbpcf/mpc_framework/engine/communication/IPartyCommunicationAgentFactory.h
@@ -10,7 +10,7 @@
 
 #include "fbpcf/mpc_framework/engine/communication/IPartyCommunicationAgent.h"
 
-namespace fbpcf::mpc_framework::engine::communication {
+namespace fbpcf::engine::communication {
 
 /**
  * An communication factory API
@@ -25,4 +25,4 @@ class IPartyCommunicationAgentFactory {
   virtual std::unique_ptr<IPartyCommunicationAgent> create(int id) = 0;
 };
 
-} // namespace fbpcf::mpc_framework::engine::communication
+} // namespace fbpcf::engine::communication

--- a/fbpcf/mpc_framework/engine/communication/ISecretShareEngineCommunicationAgent.h
+++ b/fbpcf/mpc_framework/engine/communication/ISecretShareEngineCommunicationAgent.h
@@ -10,7 +10,7 @@
 #include <map>
 #include <vector>
 
-namespace fbpcf::mpc_framework::engine::communication {
+namespace fbpcf::engine::communication {
 
 /**
  * This class abstract all the communication patterns in a secret-share-based
@@ -57,4 +57,4 @@ class ISecretShareEngineCommunicationAgent {
   virtual std::pair<uint64_t, uint64_t> getTrafficStatistics() const = 0;
 };
 
-} // namespace fbpcf::mpc_framework::engine::communication
+} // namespace fbpcf::engine::communication

--- a/fbpcf/mpc_framework/engine/communication/InMemoryPartyCommunicationAgentFactory.h
+++ b/fbpcf/mpc_framework/engine/communication/InMemoryPartyCommunicationAgentFactory.h
@@ -17,7 +17,7 @@
 #include "fbpcf/mpc_framework/engine/communication/IPartyCommunicationAgentFactory.h"
 #include "fbpcf/mpc_framework/engine/communication/InMemoryPartyCommunicationAgentHost.h"
 
-namespace fbpcf::mpc_framework::engine::communication {
+namespace fbpcf::engine::communication {
 
 /**
  * An communication factory API
@@ -73,4 +73,4 @@ class InMemoryPartyCommunicationAgentFactory final
   std::map<int, int> createdAgentCount_;
 };
 
-} // namespace fbpcf::mpc_framework::engine::communication
+} // namespace fbpcf::engine::communication

--- a/fbpcf/mpc_framework/engine/communication/InMemoryPartyCommunicationAgentHost.cpp
+++ b/fbpcf/mpc_framework/engine/communication/InMemoryPartyCommunicationAgentHost.cpp
@@ -7,7 +7,7 @@
 
 #include "fbpcf/mpc_framework/engine/communication/InMemoryPartyCommunicationAgentHost.h"
 
-namespace fbpcf::mpc_framework::engine::communication {
+namespace fbpcf::engine::communication {
 
 void InMemoryPartyCommunicationAgent::send(
     const std::vector<unsigned char>& data) {
@@ -70,4 +70,4 @@ std::vector<unsigned char> InMemoryPartyCommunicationAgentHost::receive(
   return result;
 }
 
-} // namespace fbpcf::mpc_framework::engine::communication
+} // namespace fbpcf::engine::communication

--- a/fbpcf/mpc_framework/engine/communication/InMemoryPartyCommunicationAgentHost.h
+++ b/fbpcf/mpc_framework/engine/communication/InMemoryPartyCommunicationAgentHost.h
@@ -14,7 +14,7 @@
 
 #include "fbpcf/mpc_framework/engine/communication/IPartyCommunicationAgent.h"
 
-namespace fbpcf::mpc_framework::engine::communication {
+namespace fbpcf::engine::communication {
 
 class InMemoryPartyCommunicationAgentHost;
 
@@ -93,4 +93,4 @@ class InMemoryPartyCommunicationAgentHost {
   friend class InMemoryPartyCommunicationAgent;
 };
 
-} // namespace fbpcf::mpc_framework::engine::communication
+} // namespace fbpcf::engine::communication

--- a/fbpcf/mpc_framework/engine/communication/SecretShareEngineCommunicationAgent.cpp
+++ b/fbpcf/mpc_framework/engine/communication/SecretShareEngineCommunicationAgent.cpp
@@ -12,7 +12,7 @@
 
 #include "fbpcf/mpc_framework/engine/communication/SecretShareEngineCommunicationAgent.h"
 
-namespace fbpcf::mpc_framework::engine::communication {
+namespace fbpcf::engine::communication {
 std::map<int, __m128i> SecretShareEngineCommunicationAgent::exchangeKeys(
     const std::map<int, __m128i>& keys) {
   std::map<int, __m128i> rst;
@@ -74,4 +74,4 @@ SecretShareEngineCommunicationAgent::getTrafficStatistics() const {
   return {sent, received};
 }
 
-} // namespace fbpcf::mpc_framework::engine::communication
+} // namespace fbpcf::engine::communication

--- a/fbpcf/mpc_framework/engine/communication/SecretShareEngineCommunicationAgent.h
+++ b/fbpcf/mpc_framework/engine/communication/SecretShareEngineCommunicationAgent.h
@@ -13,7 +13,7 @@
 #include "fbpcf/mpc_framework/engine/communication/IPartyCommunicationAgent.h"
 #include "fbpcf/mpc_framework/engine/communication/ISecretShareEngineCommunicationAgent.h"
 
-namespace fbpcf::mpc_framework::engine::communication {
+namespace fbpcf::engine::communication {
 
 /**
  * This object will operate with an underlying commnuication agent
@@ -55,4 +55,4 @@ class SecretShareEngineCommunicationAgent final
   std::map<int, std::unique_ptr<IPartyCommunicationAgent>> agentMap_;
 };
 
-} // namespace fbpcf::mpc_framework::engine::communication
+} // namespace fbpcf::engine::communication

--- a/fbpcf/mpc_framework/engine/communication/SocketPartyCommunicationAgent.cpp
+++ b/fbpcf/mpc_framework/engine/communication/SocketPartyCommunicationAgent.cpp
@@ -19,7 +19,7 @@
 
 #include "folly/logging/xlog.h"
 
-namespace fbpcf::mpc_framework::engine::communication {
+namespace fbpcf::engine::communication {
 
 SocketPartyCommunicationAgent::SocketPartyCommunicationAgent(
     int portNo,
@@ -177,4 +177,4 @@ int SocketPartyCommunicationAgent::receiveFromClient(int portNo) {
   return acceptedConnection;
 }
 
-} // namespace fbpcf::mpc_framework::engine::communication
+} // namespace fbpcf::engine::communication

--- a/fbpcf/mpc_framework/engine/communication/SocketPartyCommunicationAgent.h
+++ b/fbpcf/mpc_framework/engine/communication/SocketPartyCommunicationAgent.h
@@ -11,7 +11,7 @@
 
 #include "fbpcf/mpc_framework/engine/communication/IPartyCommunicationAgent.h"
 
-namespace fbpcf::mpc_framework::engine::communication {
+namespace fbpcf::engine::communication {
 
 /**
  * This object connect two parties on different machines via socket. This object
@@ -72,4 +72,4 @@ class SocketPartyCommunicationAgent final : public IPartyCommunicationAgent {
   uint64_t receivedData_;
 };
 
-} // namespace fbpcf::mpc_framework::engine::communication
+} // namespace fbpcf::engine::communication

--- a/fbpcf/mpc_framework/engine/communication/SocketPartyCommunicationAgentFactory.h
+++ b/fbpcf/mpc_framework/engine/communication/SocketPartyCommunicationAgentFactory.h
@@ -11,7 +11,7 @@
 #include "fbpcf/mpc_framework/engine/communication/IPartyCommunicationAgentFactory.h"
 #include "fbpcf/mpc_framework/engine/communication/SocketPartyCommunicationAgent.h"
 
-namespace fbpcf::mpc_framework::engine::communication {
+namespace fbpcf::engine::communication {
 
 /**
  * An communication factory API
@@ -82,4 +82,4 @@ class SocketPartyCommunicationAgentFactory final
   std::string tlsDir_;
 };
 
-} // namespace fbpcf::mpc_framework::engine::communication
+} // namespace fbpcf::engine::communication

--- a/fbpcf/mpc_framework/engine/communication/test/AgentFactoryCreationHelper.h
+++ b/fbpcf/mpc_framework/engine/communication/test/AgentFactoryCreationHelper.h
@@ -10,7 +10,7 @@
 #include <memory>
 #include "fbpcf/mpc_framework/engine/communication/InMemoryPartyCommunicationAgentFactory.h"
 
-namespace fbpcf::mpc_framework::engine::communication {
+namespace fbpcf::engine::communication {
 
 inline std::vector<std::unique_ptr<IPartyCommunicationAgentFactory>>
 getInMemoryAgentFactory(int numberOfParty) {
@@ -36,4 +36,4 @@ getInMemoryAgentFactory(int numberOfParty) {
   return rst;
 }
 
-} // namespace fbpcf::mpc_framework::engine::communication
+} // namespace fbpcf::engine::communication

--- a/fbpcf/mpc_framework/engine/communication/test/PartyCommunicationAgentTest.cpp
+++ b/fbpcf/mpc_framework/engine/communication/test/PartyCommunicationAgentTest.cpp
@@ -19,7 +19,7 @@
 #include "fbpcf/mpc_framework/engine/communication/SocketPartyCommunicationAgentFactory.h"
 #include "fbpcf/mpc_framework/engine/communication/test/AgentFactoryCreationHelper.h"
 
-namespace fbpcf::mpc_framework::engine::communication {
+namespace fbpcf::engine::communication {
 
 void sendAndReceive(std::unique_ptr<IPartyCommunicationAgent> agent, int size) {
   int repeat = 10;
@@ -85,4 +85,4 @@ TEST(SocketPartyCommunicationAgentTest, testSendAndReceive) {
   thread0.join();
 }
 
-} // namespace fbpcf::mpc_framework::engine::communication
+} // namespace fbpcf::engine::communication

--- a/fbpcf/mpc_framework/engine/communication/test/SecretShareEngineCommunicationAgentTest.cpp
+++ b/fbpcf/mpc_framework/engine/communication/test/SecretShareEngineCommunicationAgentTest.cpp
@@ -16,7 +16,7 @@
 #include "fbpcf/mpc_framework/engine/communication/InMemoryPartyCommunicationAgentHost.h"
 #include "fbpcf/mpc_framework/engine/communication/test/SecretShareEngineCommunicationAgentTestHelper.h"
 
-namespace fbpcf::mpc_framework::engine::communication {
+namespace fbpcf::engine::communication {
 
 void exchangeKeyTest(
     std::unique_ptr<SecretShareEngineCommunicationAgent> agent,
@@ -160,4 +160,4 @@ TEST(secretShareEngineCommunicationAgentTest, testOpenToParty) {
   }
 }
 
-} // namespace fbpcf::mpc_framework::engine::communication
+} // namespace fbpcf::engine::communication

--- a/fbpcf/mpc_framework/engine/communication/test/SecretShareEngineCommunicationAgentTestHelper.h
+++ b/fbpcf/mpc_framework/engine/communication/test/SecretShareEngineCommunicationAgentTestHelper.h
@@ -13,7 +13,7 @@
 #include "fbpcf/mpc_framework/engine/communication/SecretShareEngineCommunicationAgent.h"
 #include "fbpcf/mpc_framework/engine/communication/test/AgentFactoryCreationHelper.h"
 
-namespace fbpcf::mpc_framework::engine::communication {
+namespace fbpcf::engine::communication {
 
 class SecretShareEngineCommunicationAgentTestHelper {
  public:
@@ -40,4 +40,4 @@ class SecretShareEngineCommunicationAgentTestHelper {
   std::vector<std::unique_ptr<IPartyCommunicationAgentFactory>> factories_;
 };
 
-} // namespace fbpcf::mpc_framework::engine::communication
+} // namespace fbpcf::engine::communication

--- a/fbpcf/mpc_framework/engine/communication/test/TlsCommunicationUtils.h
+++ b/fbpcf/mpc_framework/engine/communication/test/TlsCommunicationUtils.h
@@ -12,7 +12,7 @@
 #include <fstream>
 #include <ostream>
 
-namespace fbpcf::mpc_framework::engine::communication {
+namespace fbpcf::engine::communication {
 
 // creates a cert file, key file, and passphrase file
 // in the provided directory
@@ -88,4 +88,4 @@ inline void deleteTlsFiles(std::string dir) {
   remove((dir + "/cert.pem").c_str());
 }
 
-} // namespace fbpcf::mpc_framework::engine::communication
+} // namespace fbpcf::engine::communication

--- a/fbpcf/mpc_framework/engine/test/SecretShareEngineTest.cpp
+++ b/fbpcf/mpc_framework/engine/test/SecretShareEngineTest.cpp
@@ -20,7 +20,7 @@
 #include "fbpcf/mpc_framework/engine/SecretShareEngineFactory.h"
 #include "fbpcf/mpc_framework/engine/communication/test/AgentFactoryCreationHelper.h"
 
-namespace fbpcf::mpc_framework::engine {
+namespace fbpcf::engine {
 
 std::vector<bool> testHelper(
     int numberOfParty,
@@ -408,4 +408,4 @@ TEST(SecretShareEngineTest, TestBatchFreeANDtWithDummyComponents) {
   }
 }
 
-} // namespace fbpcf::mpc_framework::engine
+} // namespace fbpcf::engine

--- a/fbpcf/mpc_framework/engine/test/SecretShareEngineTestHelper.h
+++ b/fbpcf/mpc_framework/engine/test/SecretShareEngineTestHelper.h
@@ -18,7 +18,7 @@
 #include "fbpcf/mpc_framework/engine/util/AesPrgFactory.h"
 #include "fbpcf/mpc_framework/engine/util/aes.h"
 
-namespace fbpcf::mpc_framework::engine {
+namespace fbpcf::engine {
 
 class SecretShareEngineTestHelper {
  public:
@@ -99,4 +99,4 @@ class SecretShareEngineTestHelper {
       factories_;
 };
 
-} // namespace fbpcf::mpc_framework::engine
+} // namespace fbpcf::engine

--- a/fbpcf/mpc_framework/engine/tuple_generator/DummyProductShareGenerator.cpp
+++ b/fbpcf/mpc_framework/engine/tuple_generator/DummyProductShareGenerator.cpp
@@ -7,7 +7,7 @@
 
 #include "fbpcf/mpc_framework/engine/tuple_generator/DummyProductShareGenerator.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::insecure {
+namespace fbpcf::engine::tuple_generator::insecure {
 
 std::vector<bool> DummyProductShareGenerator::generateBooleanProductShares(
     const std::vector<bool>& left,
@@ -26,4 +26,4 @@ std::vector<bool> DummyProductShareGenerator::generateBooleanProductShares(
   return rst;
 }
 
-} // namespace fbpcf::mpc_framework::engine::tuple_generator::insecure
+} // namespace fbpcf::engine::tuple_generator::insecure

--- a/fbpcf/mpc_framework/engine/tuple_generator/DummyProductShareGenerator.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/DummyProductShareGenerator.h
@@ -11,7 +11,7 @@
 #include "fbpcf/mpc_framework/engine/communication/IPartyCommunicationAgent.h"
 #include "fbpcf/mpc_framework/engine/tuple_generator/IProductShareGenerator.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::insecure {
+namespace fbpcf::engine::tuple_generator::insecure {
 
 /**
  * This is a Dummy product shares generator. It will generate shares with
@@ -39,4 +39,4 @@ class DummyProductShareGenerator final : public IProductShareGenerator {
   std::unique_ptr<communication::IPartyCommunicationAgent> agent_;
 };
 
-} // namespace fbpcf::mpc_framework::engine::tuple_generator::insecure
+} // namespace fbpcf::engine::tuple_generator::insecure

--- a/fbpcf/mpc_framework/engine/tuple_generator/DummyProductShareGeneratorFactory.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/DummyProductShareGeneratorFactory.h
@@ -12,7 +12,7 @@
 #include "fbpcf/mpc_framework/engine/tuple_generator/DummyProductShareGenerator.h"
 #include "fbpcf/mpc_framework/engine/tuple_generator/IProductShareGeneratorFactory.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::insecure {
+namespace fbpcf::engine::tuple_generator::insecure {
 
 /**
  * This object always generates Dummy product share generators
@@ -32,4 +32,4 @@ class DummyProductShareGeneratorFactory final
   communication::IPartyCommunicationAgentFactory& factory_;
 };
 
-} // namespace fbpcf::mpc_framework::engine::tuple_generator::insecure
+} // namespace fbpcf::engine::tuple_generator::insecure

--- a/fbpcf/mpc_framework/engine/tuple_generator/DummyTupleGenerator.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/DummyTupleGenerator.h
@@ -8,7 +8,7 @@
 #pragma once
 #include "fbpcf/mpc_framework/engine/tuple_generator/ITupleGenerator.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::insecure {
+namespace fbpcf::engine::tuple_generator::insecure {
 
 /**
  A dummy boolean tuple generator, always generate tuple (0, 0,0 )
@@ -28,4 +28,4 @@ class DummyTupleGenerator final : public ITupleGenerator {
   }
 };
 
-} // namespace fbpcf::mpc_framework::engine::tuple_generator::insecure
+} // namespace fbpcf::engine::tuple_generator::insecure

--- a/fbpcf/mpc_framework/engine/tuple_generator/DummyTupleGeneratorFactory.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/DummyTupleGeneratorFactory.h
@@ -12,7 +12,7 @@
 #include "fbpcf/mpc_framework/engine/tuple_generator/ITupleGeneratorFactory.h"
 #include "fbpcf/mpc_framework/engine/util/IPrgFactory.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::insecure {
+namespace fbpcf::engine::tuple_generator::insecure {
 
 /**
  * This factory creates dummy tuple generators
@@ -28,4 +28,4 @@ class DummyTupleGeneratorFactory final : public ITupleGeneratorFactory {
   }
 };
 
-} // namespace fbpcf::mpc_framework::engine::tuple_generator::insecure
+} // namespace fbpcf::engine::tuple_generator::insecure

--- a/fbpcf/mpc_framework/engine/tuple_generator/IProductShareGenerator.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/IProductShareGenerator.h
@@ -9,7 +9,7 @@
 #include <cstdint>
 #include <vector>
 
-namespace fbpcf::mpc_framework::engine::tuple_generator {
+namespace fbpcf::engine::tuple_generator {
 
 /**
  * This object generates product shares, namely, a party holds bits a1, b1 and
@@ -37,4 +37,4 @@ class IProductShareGenerator {
   virtual std::pair<uint64_t, uint64_t> getTrafficStatistics() const = 0;
 };
 
-} // namespace fbpcf::mpc_framework::engine::tuple_generator
+} // namespace fbpcf::engine::tuple_generator

--- a/fbpcf/mpc_framework/engine/tuple_generator/IProductShareGeneratorFactory.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/IProductShareGeneratorFactory.h
@@ -11,7 +11,7 @@
 #include "fbpcf/mpc_framework/engine/communication/IPartyCommunicationAgent.h"
 #include "fbpcf/mpc_framework/engine/tuple_generator/IProductShareGenerator.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator {
+namespace fbpcf::engine::tuple_generator {
 
 /**
  * This is the API for an object that generates product shares. namely, a party
@@ -31,4 +31,4 @@ class IProductShareGeneratorFactory {
   virtual std::unique_ptr<IProductShareGenerator> create(int id) = 0;
 };
 
-} // namespace fbpcf::mpc_framework::engine::tuple_generator
+} // namespace fbpcf::engine::tuple_generator

--- a/fbpcf/mpc_framework/engine/tuple_generator/ITupleGenerator.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/ITupleGenerator.h
@@ -10,7 +10,7 @@
 #include <stdint.h>
 #include <vector>
 
-namespace fbpcf::mpc_framework::engine::tuple_generator {
+namespace fbpcf::engine::tuple_generator {
 
 const uint64_t kDefaultBufferSize = 16384;
 
@@ -68,4 +68,4 @@ class ITupleGenerator {
   virtual std::pair<uint64_t, uint64_t> getTrafficStatistics() const = 0;
 };
 
-} // namespace fbpcf::mpc_framework::engine::tuple_generator
+} // namespace fbpcf::engine::tuple_generator

--- a/fbpcf/mpc_framework/engine/tuple_generator/ITupleGeneratorFactory.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/ITupleGeneratorFactory.h
@@ -10,7 +10,7 @@
 
 #include "fbpcf/mpc_framework/engine/tuple_generator/ITupleGenerator.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator {
+namespace fbpcf::engine::tuple_generator {
 
 /**
  * This is the API for a tuple generator that generates tuples.
@@ -26,4 +26,4 @@ class ITupleGeneratorFactory {
   virtual std::unique_ptr<ITupleGenerator> create() = 0;
 };
 
-} // namespace fbpcf::mpc_framework::engine::tuple_generator
+} // namespace fbpcf::engine::tuple_generator

--- a/fbpcf/mpc_framework/engine/tuple_generator/ProductShareGenerator.cpp
+++ b/fbpcf/mpc_framework/engine/tuple_generator/ProductShareGenerator.cpp
@@ -9,7 +9,7 @@
 #include <assert.h>
 #include <vector>
 
-namespace fbpcf::mpc_framework::engine::tuple_generator {
+namespace fbpcf::engine::tuple_generator {
 
 /**
  * product share generation algorithm:
@@ -46,4 +46,4 @@ std::vector<bool> ProductShareGenerator::generateBooleanProductShares(
   return result;
 }
 
-} // namespace fbpcf::mpc_framework::engine::tuple_generator
+} // namespace fbpcf::engine::tuple_generator

--- a/fbpcf/mpc_framework/engine/tuple_generator/ProductShareGenerator.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/ProductShareGenerator.h
@@ -10,7 +10,7 @@
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/IBidirectionObliviousTransfer.h"
 #include "fbpcf/mpc_framework/engine/util/IPrg.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator {
+namespace fbpcf::engine::tuple_generator {
 
 /**
  * This is a product shares generator that uses OT as underlying object to
@@ -44,4 +44,4 @@ class ProductShareGenerator final : public IProductShareGenerator {
       bidirectionObliviousTransfer_;
 };
 
-} // namespace fbpcf::mpc_framework::engine::tuple_generator
+} // namespace fbpcf::engine::tuple_generator

--- a/fbpcf/mpc_framework/engine/tuple_generator/ProductShareGeneratorFactory.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/ProductShareGeneratorFactory.h
@@ -14,7 +14,7 @@
 #include "fbpcf/mpc_framework/engine/util/IPrgFactory.h"
 #include "fbpcf/mpc_framework/engine/util/util.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator {
+namespace fbpcf::engine::tuple_generator {
 
 /**
  * This object always generates the product share generators that run with an
@@ -43,4 +43,4 @@ class ProductShareGeneratorFactory final
       otFactory_;
 };
 
-} // namespace fbpcf::mpc_framework::engine::tuple_generator
+} // namespace fbpcf::engine::tuple_generator

--- a/fbpcf/mpc_framework/engine/tuple_generator/TupleGenerator.cpp
+++ b/fbpcf/mpc_framework/engine/tuple_generator/TupleGenerator.cpp
@@ -9,7 +9,7 @@
 
 #include "fbpcf/mpc_framework/engine/tuple_generator/TupleGenerator.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator {
+namespace fbpcf::engine::tuple_generator {
 
 TupleGenerator::TupleGenerator(
     std::map<int, std::unique_ptr<IProductShareGenerator>>&&
@@ -66,4 +66,4 @@ std::pair<uint64_t, uint64_t> TupleGenerator::getTrafficStatistics() const {
   return rst;
 }
 
-} // namespace fbpcf::mpc_framework::engine::tuple_generator
+} // namespace fbpcf::engine::tuple_generator

--- a/fbpcf/mpc_framework/engine/tuple_generator/TupleGenerator.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/TupleGenerator.h
@@ -15,7 +15,7 @@
 #include "fbpcf/mpc_framework/engine/util/AsyncBuffer.h"
 #include "fbpcf/mpc_framework/engine/util/IPrg.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator {
+namespace fbpcf::engine::tuple_generator {
 
 /**
  * This object uses product share generators to generate tuples.
@@ -51,4 +51,4 @@ class TupleGenerator final : public ITupleGenerator {
   util::AsyncBuffer<BooleanTuple> asyncBuffer_;
 };
 
-} // namespace fbpcf::mpc_framework::engine::tuple_generator
+} // namespace fbpcf::engine::tuple_generator

--- a/fbpcf/mpc_framework/engine/tuple_generator/TupleGeneratorFactory.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/TupleGeneratorFactory.h
@@ -14,7 +14,7 @@
 #include "fbpcf/mpc_framework/engine/util/IPrgFactory.h"
 #include "fbpcf/mpc_framework/engine/util/util.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator {
+namespace fbpcf::engine::tuple_generator {
 
 /**
  * This factory creates real tuple generators
@@ -59,4 +59,4 @@ class TupleGeneratorFactory final : public ITupleGeneratorFactory {
   int numberOfParty_;
 };
 
-} // namespace fbpcf::mpc_framework::engine::tuple_generator
+} // namespace fbpcf::engine::tuple_generator

--- a/fbpcf/mpc_framework/engine/tuple_generator/TwoPartyTupleGenerator.cpp
+++ b/fbpcf/mpc_framework/engine/tuple_generator/TwoPartyTupleGenerator.cpp
@@ -8,7 +8,7 @@
 #include "fbpcf/mpc_framework/engine/tuple_generator/TwoPartyTupleGenerator.h"
 #include "fbpcf/mpc_framework/engine/util/util.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator {
+namespace fbpcf::engine::tuple_generator {
 
 TwoPartyTupleGenerator::TwoPartyTupleGenerator(
     std::unique_ptr<oblivious_transfer::IRandomCorrelatedObliviousTransfer>
@@ -105,4 +105,4 @@ std::pair<uint64_t, uint64_t> TwoPartyTupleGenerator::getTrafficStatistics()
   return rst;
 }
 
-} // namespace fbpcf::mpc_framework::engine::tuple_generator
+} // namespace fbpcf::engine::tuple_generator

--- a/fbpcf/mpc_framework/engine/tuple_generator/TwoPartyTupleGenerator.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/TwoPartyTupleGenerator.h
@@ -14,7 +14,7 @@
 #include "fbpcf/mpc_framework/engine/util/AsyncBuffer.h"
 #include "fbpcf/mpc_framework/engine/util/aes.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator {
+namespace fbpcf::engine::tuple_generator {
 
 class TwoPartyTupleGenerator final : public ITupleGenerator {
  public:
@@ -50,4 +50,4 @@ class TwoPartyTupleGenerator final : public ITupleGenerator {
   util::AsyncBuffer<BooleanTuple> buffer_;
 };
 
-} // namespace fbpcf::mpc_framework::engine::tuple_generator
+} // namespace fbpcf::engine::tuple_generator

--- a/fbpcf/mpc_framework/engine/tuple_generator/TwoPartyTupleGeneratorFactory.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/TwoPartyTupleGeneratorFactory.h
@@ -15,7 +15,7 @@
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/IRandomCorrelatedObliviousTransfer.h"
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/IRandomCorrelatedObliviousTransferFactory.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator {
+namespace fbpcf::engine::tuple_generator {
 
 class TwoPartyTupleGeneratorFactory final : public ITupleGeneratorFactory {
  public:
@@ -65,4 +65,4 @@ class TwoPartyTupleGeneratorFactory final : public ITupleGeneratorFactory {
   uint64_t bufferSize_;
 };
 
-} // namespace fbpcf::mpc_framework::engine::tuple_generator
+} // namespace fbpcf::engine::tuple_generator

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/DummyBaseObliviousTransfer.cpp
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/DummyBaseObliviousTransfer.cpp
@@ -7,8 +7,7 @@
 
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/DummyBaseObliviousTransfer.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
-    insecure {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer::insecure {
 
 std::pair<std::vector<__m128i>, std::vector<__m128i>>
 DummyBaseObliviousTransfer::send(
@@ -33,4 +32,4 @@ std::vector<__m128i> DummyBaseObliviousTransfer::receive(
 }
 
 } // namespace
-  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::insecure
+  // fbpcf::engine::tuple_generator::oblivious_transfer::insecure

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/DummyBaseObliviousTransfer.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/DummyBaseObliviousTransfer.h
@@ -9,8 +9,7 @@
 #include "fbpcf/mpc_framework/engine/communication/IPartyCommunicationAgent.h"
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/IBaseObliviousTransfer.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
-    insecure {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer::insecure {
 
 /**
  * This is a dummy base oblivious transfer object. An ideal object will realize
@@ -57,4 +56,4 @@ class DummyBaseObliviousTransfer final : public IBaseObliviousTransfer {
 };
 
 } // namespace
-  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::insecure
+  // fbpcf::engine::tuple_generator::oblivious_transfer::insecure

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/DummyBaseObliviousTransferFactory.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/DummyBaseObliviousTransferFactory.h
@@ -10,8 +10,7 @@
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/DummyBaseObliviousTransfer.h"
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/IBaseObliviousTransferFactory.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
-    insecure {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer::insecure {
 
 /**
  * Create a base oblivious transfer with a particular party.
@@ -30,4 +29,4 @@ class DummyBaseObliviousTransferFactory final
 };
 
 } // namespace
-  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::insecure
+  // fbpcf::engine::tuple_generator::oblivious_transfer::insecure

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/DummyBidirectionObliviousTransfer.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/DummyBidirectionObliviousTransfer.h
@@ -9,8 +9,7 @@
 #include "fbpcf/mpc_framework/engine/communication/IPartyCommunicationAgent.h"
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/IBidirectionObliviousTransfer.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
-    insecure {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer::insecure {
 
 /**
  * This is a Dummy oblivious transfer object. A Dummy object will realize the
@@ -45,6 +44,6 @@ class DummyBidirectionObliviousTransfer final
 };
 
 } // namespace
-  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::insecure
+  // fbpcf::engine::tuple_generator::oblivious_transfer::insecure
 
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/DummyBidirectionObliviousTransfer_impl.h"

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/DummyBidirectionObliviousTransferFactory.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/DummyBidirectionObliviousTransferFactory.h
@@ -12,8 +12,7 @@
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/DummyBidirectionObliviousTransfer.h"
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/IBidirectionObliviousTransferFactory.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
-    insecure {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer::insecure {
 
 template <class T>
 class DummyBidirectionObliviousTransferFactory final
@@ -33,4 +32,4 @@ class DummyBidirectionObliviousTransferFactory final
 };
 
 } // namespace
-  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::insecure
+  // fbpcf::engine::tuple_generator::oblivious_transfer::insecure

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/DummyBidirectionObliviousTransfer_impl.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/DummyBidirectionObliviousTransfer_impl.h
@@ -7,8 +7,7 @@
 
 #pragma once
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
-    insecure {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer::insecure {
 
 template <class T>
 std::vector<T> DummyBidirectionObliviousTransfer<T>::biDirectionOT(
@@ -42,4 +41,4 @@ std::vector<T> DummyBidirectionObliviousTransfer<T>::biDirectionOT(
 }
 
 } // namespace
-  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::insecure
+  // fbpcf::engine::tuple_generator::oblivious_transfer::insecure

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/DummyRandomCorrelatedObliviousTransfer.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/DummyRandomCorrelatedObliviousTransfer.h
@@ -9,8 +9,7 @@
 
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/IFlexibleRandomCorrelatedObliviousTransfer.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
-    insecure {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer::insecure {
 
 /**
  * A Dummy Random Correlated Oblivious Transfer. It only outputs 0 vectors;
@@ -49,4 +48,4 @@ class DummyRandomCorrelatedObliviousTransfer final
 };
 
 } // namespace
-  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::insecure
+  // fbpcf::engine::tuple_generator::oblivious_transfer::insecure

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/DummyRandomCorrelatedObliviousTransferFactory.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/DummyRandomCorrelatedObliviousTransferFactory.h
@@ -14,8 +14,7 @@
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/DummyRandomCorrelatedObliviousTransfer.h"
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/IFlexibleRandomCorrelatedObliviousTransferFactory.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
-    insecure {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer::insecure {
 
 class DummyRandomCorrelatedObliviousTransferFactory final
     : public IFlexibleRandomCorrelatedObliviousTransferFactory {
@@ -35,4 +34,4 @@ class DummyRandomCorrelatedObliviousTransferFactory final
 };
 
 } // namespace
-  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::insecure
+  // fbpcf::engine::tuple_generator::oblivious_transfer::insecure

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/EmpShRandomCorrelatedObliviousTransfer.cpp
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/EmpShRandomCorrelatedObliviousTransfer.cpp
@@ -11,7 +11,7 @@
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/EmpShRandomCorrelatedObliviousTransfer.h"
 #include "fbpcf/mpc_framework/engine/util/EmpNetworkAdapter.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer {
 
 EmpShRandomCorrelatedObliviousTransfer::EmpShRandomCorrelatedObliviousTransfer(
     __m128i delta,
@@ -70,4 +70,4 @@ std::vector<__m128i> EmpShRandomCorrelatedObliviousTransfer::rcot(
   }
 }
 
-} // namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer
+} // namespace fbpcf::engine::tuple_generator::oblivious_transfer

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/EmpShRandomCorrelatedObliviousTransfer.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/EmpShRandomCorrelatedObliviousTransfer.h
@@ -14,7 +14,7 @@
 #include "fbpcf/mpc_framework/engine/util/EmpNetworkAdapter.h"
 #include "fbpcf/mpc_framework/engine/util/IPrg.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer {
 
 /**
  * This object is a wrapper that align our RCOT APIs and emp::IKNP APIs.
@@ -65,4 +65,4 @@ class EmpShRandomCorrelatedObliviousTransfer final
   std::unique_ptr<util::IPrg> prg_;
 };
 
-} // namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer
+} // namespace fbpcf::engine::tuple_generator::oblivious_transfer

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/EmpShRandomCorrelatedObliviousTransferFactory.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/EmpShRandomCorrelatedObliviousTransferFactory.h
@@ -14,7 +14,7 @@
 #include "fbpcf/mpc_framework/engine/util/IPrgFactory.h"
 #include "fbpcf/mpc_framework/engine/util/util.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer {
 
 class EmpShRandomCorrelatedObliviousTransferFactory final
     : public IFlexibleRandomCorrelatedObliviousTransferFactory {
@@ -41,4 +41,4 @@ class EmpShRandomCorrelatedObliviousTransferFactory final
   std::unique_ptr<util::IPrgFactory> prgFactory_;
 };
 
-} // namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer
+} // namespace fbpcf::engine::tuple_generator::oblivious_transfer

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ExtenderBasedRandomCorrelatedObliviousTransfer.cpp
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ExtenderBasedRandomCorrelatedObliviousTransfer.cpp
@@ -7,7 +7,7 @@
 
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ExtenderBasedRandomCorrelatedObliviousTransfer.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer {
 
 ExtenderBasedRandomCorrelatedObliviousTransfer::
     ExtenderBasedRandomCorrelatedObliviousTransfer(
@@ -64,4 +64,4 @@ void ExtenderBasedRandomCorrelatedObliviousTransfer::extendRcot() {
   otIndex_ = 0;
 }
 
-} // namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer
+} // namespace fbpcf::engine::tuple_generator::oblivious_transfer

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ExtenderBasedRandomCorrelatedObliviousTransfer.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ExtenderBasedRandomCorrelatedObliviousTransfer.h
@@ -12,7 +12,7 @@
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/IRandomCorrelatedObliviousTransfer.h"
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/IRcotExtender.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer {
 
 /**
  * A Random Correlated Oblivious Transfer from a RCOT extender. This object
@@ -69,4 +69,4 @@ class ExtenderBasedRandomCorrelatedObliviousTransfer final
   int64_t otIndex_;
 };
 
-} // namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer
+} // namespace fbpcf::engine::tuple_generator::oblivious_transfer

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ExtenderBasedRandomCorrelatedObliviousTransferFactory.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ExtenderBasedRandomCorrelatedObliviousTransferFactory.h
@@ -13,7 +13,7 @@
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/IRandomCorrelatedObliviousTransferFactory.h"
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/IRcotExtenderFactory.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer {
 
 class ExtenderBasedRandomCorrelatedObliviousTransferFactory final
     : public IRandomCorrelatedObliviousTransferFactory {
@@ -83,4 +83,4 @@ class ExtenderBasedRandomCorrelatedObliviousTransferFactory final
   int64_t weight_;
 };
 
-} // namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer
+} // namespace fbpcf::engine::tuple_generator::oblivious_transfer

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/IBaseObliviousTransfer.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/IBaseObliviousTransfer.h
@@ -11,7 +11,7 @@
 #include <memory>
 #include "fbpcf/mpc_framework/engine/communication/IPartyCommunicationAgent.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer {
 
 /**
  * A base oblivious transfer interface
@@ -47,4 +47,4 @@ class IBaseObliviousTransfer {
   extractCommunicationAgent() = 0;
 };
 
-} // namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer
+} // namespace fbpcf::engine::tuple_generator::oblivious_transfer

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/IBaseObliviousTransferFactory.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/IBaseObliviousTransferFactory.h
@@ -9,7 +9,7 @@
 #include "fbpcf/mpc_framework/engine/communication/IPartyCommunicationAgent.h"
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/IBaseObliviousTransfer.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer {
 
 /**
  * Create a base oblivious transfer with a particular party.
@@ -24,4 +24,4 @@ class IBaseObliviousTransferFactory {
       std::unique_ptr<communication::IPartyCommunicationAgent> agent) = 0;
 };
 
-} // namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer
+} // namespace fbpcf::engine::tuple_generator::oblivious_transfer

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/IBidirectionObliviousTransfer.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/IBidirectionObliviousTransfer.h
@@ -10,7 +10,7 @@
 #include <memory>
 #include <vector>
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer {
 
 /**
  * The Bi-direction Oblivious transfer API.
@@ -45,4 +45,4 @@ class IBidirectionObliviousTransfer {
   virtual std::pair<uint64_t, uint64_t> getTrafficStatistics() const = 0;
 };
 
-} // namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer
+} // namespace fbpcf::engine::tuple_generator::oblivious_transfer

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/IBidirectionObliviousTransferFactory.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/IBidirectionObliviousTransferFactory.h
@@ -9,7 +9,7 @@
 #include "fbpcf/mpc_framework/engine/communication/IPartyCommunicationAgent.h"
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/IBidirectionObliviousTransfer.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer {
 
 template <class T>
 class IBidirectionObliviousTransferFactory {
@@ -24,4 +24,4 @@ class IBidirectionObliviousTransferFactory {
   virtual std::unique_ptr<IBidirectionObliviousTransfer<T>> create(int id) = 0;
 };
 
-} // namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer
+} // namespace fbpcf::engine::tuple_generator::oblivious_transfer

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/IFlexibleRandomCorrelatedObliviousTransfer.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/IFlexibleRandomCorrelatedObliviousTransfer.h
@@ -10,7 +10,7 @@
 #include "fbpcf/mpc_framework/engine/communication/IPartyCommunicationAgent.h"
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/IRandomCorrelatedObliviousTransfer.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer {
 
 /**
  * A flexible RCOT allows to extract the communication it uses before destroy
@@ -25,4 +25,4 @@ class IFlexibleRandomCorrelatedObliviousTransfer
   extractCommunicationAgent() = 0;
 };
 
-} // namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer
+} // namespace fbpcf::engine::tuple_generator::oblivious_transfer

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/IFlexibleRandomCorrelatedObliviousTransferFactory.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/IFlexibleRandomCorrelatedObliviousTransferFactory.h
@@ -14,7 +14,7 @@
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/IFlexibleRandomCorrelatedObliviousTransfer.h"
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/IRandomCorrelatedObliviousTransferFactory.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer {
 
 class IFlexibleRandomCorrelatedObliviousTransferFactory
     : public IRandomCorrelatedObliviousTransferFactory {
@@ -46,4 +46,4 @@ class IFlexibleRandomCorrelatedObliviousTransferFactory
       std::unique_ptr<communication::IPartyCommunicationAgent> agent) = 0;
 };
 
-} // namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer
+} // namespace fbpcf::engine::tuple_generator::oblivious_transfer

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/IRandomCorrelatedObliviousTransfer.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/IRandomCorrelatedObliviousTransfer.h
@@ -11,7 +11,7 @@
 #include <vector>
 #include "fbpcf/mpc_framework/engine/util/util.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer {
 
 /**
  * The Random Correlated Oblivious Transfer API.
@@ -37,4 +37,4 @@ class IRandomCorrelatedObliviousTransfer {
   virtual std::pair<uint64_t, uint64_t> getTrafficStatistics() const = 0;
 };
 
-} // namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer
+} // namespace fbpcf::engine::tuple_generator::oblivious_transfer

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/IRandomCorrelatedObliviousTransferFactory.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/IRandomCorrelatedObliviousTransferFactory.h
@@ -13,7 +13,7 @@
 #include "fbpcf/mpc_framework/engine/communication/IPartyCommunicationAgent.h"
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/IRandomCorrelatedObliviousTransfer.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer {
 
 class IRandomCorrelatedObliviousTransferFactory {
  public:
@@ -33,4 +33,4 @@ class IRandomCorrelatedObliviousTransferFactory {
       std::unique_ptr<communication::IPartyCommunicationAgent> agent) = 0;
 };
 
-} // namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer
+} // namespace fbpcf::engine::tuple_generator::oblivious_transfer

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/IknpShRandomCorrelatedObliviousTransfer.cpp
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/IknpShRandomCorrelatedObliviousTransfer.cpp
@@ -11,7 +11,7 @@
 #include <stdexcept>
 #include "fbpcf/mpc_framework/engine/util/util.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer {
 
 IknpShRandomCorrelatedObliviousTransfer::
     IknpShRandomCorrelatedObliviousTransfer(
@@ -211,4 +211,4 @@ std::vector<__m128i> IknpShRandomCorrelatedObliviousTransfer::rcot(
   return rst;
 }
 
-} // namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer
+} // namespace fbpcf::engine::tuple_generator::oblivious_transfer

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/IknpShRandomCorrelatedObliviousTransfer.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/IknpShRandomCorrelatedObliviousTransfer.h
@@ -15,7 +15,7 @@
 #include "fbpcf/mpc_framework/engine/util/EmpNetworkAdapter.h"
 #include "fbpcf/mpc_framework/engine/util/IPrgFactory.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer {
 
 /**
  * This object is an in-house implementation of IKNP protocol
@@ -78,4 +78,4 @@ class IknpShRandomCorrelatedObliviousTransfer
   std::unique_ptr<util::IPrg> choiceBitPrg_;
 };
 
-} // namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer
+} // namespace fbpcf::engine::tuple_generator::oblivious_transfer

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/IknpShRandomCorrelatedObliviousTransferFactory.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/IknpShRandomCorrelatedObliviousTransferFactory.h
@@ -14,7 +14,7 @@
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/IknpShRandomCorrelatedObliviousTransfer.h"
 #include "fbpcf/mpc_framework/engine/util/AesPrgFactory.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer {
 class IknpShRandomCorrelatedObliviousTransferFactory final
     : public IFlexibleRandomCorrelatedObliviousTransferFactory {
  public:
@@ -46,4 +46,4 @@ class IknpShRandomCorrelatedObliviousTransferFactory final
   std::unique_ptr<IBaseObliviousTransferFactory> baseOtFactory_;
 };
 
-} // namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer
+} // namespace fbpcf::engine::tuple_generator::oblivious_transfer

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/NpBaseObliviousTransfer.cpp
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/NpBaseObliviousTransfer.cpp
@@ -10,7 +10,7 @@
 #include <openssl/sha.h>
 #include <stdexcept>
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer {
 
 NpBaseObliviousTransfer::NpBaseObliviousTransfer(
     std::unique_ptr<communication::IPartyCommunicationAgent> agent)
@@ -359,4 +359,4 @@ std::vector<__m128i> NpBaseObliviousTransfer::receive(
   return m;
 }
 
-} // namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer
+} // namespace fbpcf::engine::tuple_generator::oblivious_transfer

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/NpBaseObliviousTransfer.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/NpBaseObliviousTransfer.h
@@ -14,7 +14,7 @@
 #include "fbpcf/mpc_framework/engine/communication/IPartyCommunicationAgent.h"
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/IBaseObliviousTransfer.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer {
 
 /**
  * This is a NP(NP stands for the authors' names - Naor and Pinkas) base
@@ -71,4 +71,4 @@ class NpBaseObliviousTransfer : public IBaseObliviousTransfer {
   std::unique_ptr<BIGNUM, std::function<void(BIGNUM*)>> order_;
 };
 
-} // namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer
+} // namespace fbpcf::engine::tuple_generator::oblivious_transfer

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/NpBaseObliviousTransferFactory.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/NpBaseObliviousTransferFactory.h
@@ -10,7 +10,7 @@
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/IBaseObliviousTransferFactory.h"
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/NpBaseObliviousTransfer.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer {
 
 /**
  * Create a base oblivious transfer with a particular party.
@@ -28,4 +28,4 @@ class NpBaseObliviousTransferFactory final
   }
 };
 
-} // namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer
+} // namespace fbpcf::engine::tuple_generator::oblivious_transfer

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/RcotBasedBidirectionObliviousTransfer.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/RcotBasedBidirectionObliviousTransfer.h
@@ -14,7 +14,7 @@
 #include "fbpcf/mpc_framework/engine/util/aes.h"
 #include "fbpcf/mpc_framework/engine/util/util.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer {
 
 /**
  * This is an Rcot based oblivious transfer object.
@@ -49,6 +49,6 @@ class RcotBasedBidirectionObliviousTransfer final
   std::unique_ptr<IRandomCorrelatedObliviousTransfer> receiverRcot_;
 };
 
-} // namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer
+} // namespace fbpcf::engine::tuple_generator::oblivious_transfer
 
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/RcotBasedBidirectionObliviousTransfer_impl.h"

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/RcotBasedBidirectionObliviousTransferFactory.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/RcotBasedBidirectionObliviousTransferFactory.h
@@ -16,7 +16,7 @@
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/RcotBasedBidirectionObliviousTransfer.h"
 #include "fbpcf/mpc_framework/engine/util/util.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer {
 
 template <class T>
 class RcotBasedBidirectionObliviousTransferFactory final
@@ -58,4 +58,4 @@ class RcotBasedBidirectionObliviousTransferFactory final
   std::unique_ptr<IRandomCorrelatedObliviousTransferFactory> rcotFactory_;
 };
 
-} // namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer
+} // namespace fbpcf::engine::tuple_generator::oblivious_transfer

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/RcotBasedBidirectionObliviousTransfer_impl.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/RcotBasedBidirectionObliviousTransfer_impl.h
@@ -13,7 +13,7 @@
 #include <thread>
 #include <vector>
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer {
 
 template <class T>
 RcotBasedBidirectionObliviousTransfer<T>::RcotBasedBidirectionObliviousTransfer(
@@ -117,4 +117,4 @@ RcotBasedBidirectionObliviousTransfer<T>::getTrafficStatistics() const {
   return rst;
 }
 
-} // namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer
+} // namespace fbpcf::engine::tuple_generator::oblivious_transfer

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/RcotHelper.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/RcotHelper.h
@@ -19,7 +19,7 @@
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/TenLocalLinearMatrixMultiplierFactory.h"
 #include "fbpcf/mpc_framework/engine/util/AesPrgFactory.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer {
 
 inline std::unique_ptr<IFlexibleRandomCorrelatedObliviousTransferFactory>
 createClassicRcotFactory() {
@@ -45,4 +45,4 @@ createFerretRcotFactory(
       weight);
 }
 
-} // namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer
+} // namespace fbpcf::engine::tuple_generator::oblivious_transfer

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/DummyMatrixMultiplier.cpp
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/DummyMatrixMultiplier.cpp
@@ -7,8 +7,7 @@
 
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/DummyMatrixMultiplier.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
-    ferret::insecure {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer::ferret::insecure {
 
 std::vector<__m128i> DummyMatrixMultiplier::multiplyWithRandomMatrix(
     __m128i /*seed*/,
@@ -22,4 +21,4 @@ std::vector<__m128i> DummyMatrixMultiplier::multiplyWithRandomMatrix(
 }
 
 } // namespace
-  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::ferret::insecure
+  // fbpcf::engine::tuple_generator::oblivious_transfer::ferret::insecure

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/DummyMatrixMultiplier.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/DummyMatrixMultiplier.h
@@ -9,8 +9,7 @@
 
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/IMatrixMultiplier.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
-    ferret::insecure {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer::ferret::insecure {
 
 /**
  * This is merely a dummy calculator - it won't actually generate any random
@@ -29,4 +28,4 @@ class DummyMatrixMultiplier final : public IMatrixMultiplier {
 };
 
 } // namespace
-  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::ferret::insecure
+  // fbpcf::engine::tuple_generator::oblivious_transfer::ferret::insecure

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/DummyMatrixMultiplierFactory.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/DummyMatrixMultiplierFactory.h
@@ -13,8 +13,7 @@
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/DummyMatrixMultiplier.h"
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/IMatrixMultiplierFactory.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
-    ferret::insecure {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer::ferret::insecure {
 
 class DummyMatrixMultiplierFactory final : public IMatrixMultiplierFactory {
  public:
@@ -24,4 +23,4 @@ class DummyMatrixMultiplierFactory final : public IMatrixMultiplierFactory {
 };
 
 } // namespace
-  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::ferret::insecure
+  // fbpcf::engine::tuple_generator::oblivious_transfer::ferret::insecure

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/DummyMultiPointCot.cpp
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/DummyMultiPointCot.cpp
@@ -14,8 +14,7 @@
 
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/DummyMultiPointCot.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
-    ferret::insecure {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer::ferret::insecure {
 
 void DummyMultiPointCot::senderInit(
     __m128i delta,
@@ -77,4 +76,4 @@ std::vector<int64_t> DummyMultiPointCot::getRandomPositions() {
 }
 
 } // namespace
-  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::ferret::insecure
+  // fbpcf::engine::tuple_generator::oblivious_transfer::ferret::insecure

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/DummyMultiPointCot.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/DummyMultiPointCot.h
@@ -11,8 +11,7 @@
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/IMultiPointCot.h"
 #include "fbpcf/mpc_framework/engine/util/IPrg.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
-    ferret::insecure {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer::ferret::insecure {
 
 /**
  * A Dummy MPCOT implementation. "Dummy" means it realize the desired
@@ -72,4 +71,4 @@ class DummyMultiPointCot final : public IMultiPointCot {
 };
 
 } // namespace
-  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::ferret::insecure
+  // fbpcf::engine::tuple_generator::oblivious_transfer::ferret::insecure

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/DummyMultiPointCotFactory.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/DummyMultiPointCotFactory.h
@@ -15,8 +15,7 @@
 #include "fbpcf/mpc_framework/engine/util/IPrgFactory.h"
 #include "fbpcf/mpc_framework/engine/util/util.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
-    ferret::insecure {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer::ferret::insecure {
 
 class DummyMultiPointCotFactory final : public IMultiPointCotFactory {
  public:
@@ -36,4 +35,4 @@ class DummyMultiPointCotFactory final : public IMultiPointCotFactory {
 };
 
 } // namespace
-  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::ferret::insecure
+  // fbpcf::engine::tuple_generator::oblivious_transfer::ferret::insecure

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/DummyRcotExtender.cpp
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/DummyRcotExtender.cpp
@@ -9,8 +9,7 @@
 
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/DummyRcotExtender.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
-    ferret::insecure {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer::ferret::insecure {
 
 int DummyRcotExtender::senderInit(
     __m128i /*delta*/,
@@ -58,4 +57,4 @@ std::vector<__m128i> DummyRcotExtender::receiverExtendRcot(
 }
 
 } // namespace
-  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::ferret::insecure
+  // fbpcf::engine::tuple_generator::oblivious_transfer::ferret::insecure

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/DummyRcotExtender.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/DummyRcotExtender.h
@@ -9,8 +9,7 @@
 #include "fbpcf/mpc_framework/engine/communication/IPartyCommunicationAgent.h"
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/IRcotExtender.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
-    ferret::insecure {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer::ferret::insecure {
 
 /**
  * This is  a dummy Rcot extender. It won't do anything but simply copy-paste
@@ -70,4 +69,4 @@ class DummyRcotExtender final : public IRcotExtender {
 };
 
 } // namespace
-  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::ferret::insecure
+  // fbpcf::engine::tuple_generator::oblivious_transfer::ferret::insecure

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/DummyRcotExtenderFactory.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/DummyRcotExtenderFactory.h
@@ -13,8 +13,7 @@
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/DummyRcotExtender.h"
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/IRcotExtenderFactory.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
-    ferret::insecure {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer::ferret::insecure {
 
 class DummyRcotExtenderFactory final : public IRcotExtenderFactory {
  public:
@@ -24,4 +23,4 @@ class DummyRcotExtenderFactory final : public IRcotExtenderFactory {
 };
 
 } // namespace
-  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::ferret::insecure
+  // fbpcf::engine::tuple_generator::oblivious_transfer::ferret::insecure

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/DummySinglePointCot.cpp
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/DummySinglePointCot.cpp
@@ -14,8 +14,7 @@
 #include <random>
 #include "fbpcf/mpc_framework/engine/util/util.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
-    ferret::insecure {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer::ferret::insecure {
 
 void DummySinglePointCot::senderInit(__m128i delta) {
   delta_ = delta;
@@ -62,4 +61,4 @@ std::vector<__m128i> DummySinglePointCot::receiverExtend(
 }
 
 } // namespace
-  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::ferret::insecure
+  // fbpcf::engine::tuple_generator::oblivious_transfer::ferret::insecure

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/DummySinglePointCot.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/DummySinglePointCot.h
@@ -12,8 +12,7 @@
 #include "fbpcf/mpc_framework/engine/util/IPrg.h"
 #include "fbpcf/mpc_framework/engine/util/util.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
-    ferret::insecure {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer::ferret::insecure {
 
 /**
  * This is a dummy single point COT.
@@ -63,4 +62,4 @@ class DummySinglePointCot final : public ISinglePointCot {
 };
 
 } // namespace
-  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::ferret::insecure
+  // fbpcf::engine::tuple_generator::oblivious_transfer::ferret::insecure

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/DummySinglePointCotFactory.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/DummySinglePointCotFactory.h
@@ -14,8 +14,7 @@
 #include "fbpcf/mpc_framework/engine/util/IPrgFactory.h"
 #include "fbpcf/mpc_framework/engine/util/util.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
-    ferret::insecure {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer::ferret::insecure {
 
 class DummySinglePointCotFactory final : public ISinglePointCotFactory {
  public:
@@ -35,4 +34,4 @@ class DummySinglePointCotFactory final : public ISinglePointCotFactory {
 };
 
 } // namespace
-  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::ferret::insecure
+  // fbpcf::engine::tuple_generator::oblivious_transfer::ferret::insecure

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/IMatrixMultiplier.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/IMatrixMultiplier.h
@@ -9,8 +9,7 @@
 #include <emmintrin.h>
 #include <vector>
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
-    ferret {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer::ferret {
 
 /**
  * This object is to hide the complicated matrix multiplication, which is
@@ -36,4 +35,4 @@ class IMatrixMultiplier {
 };
 
 } // namespace
-  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::ferret
+  // fbpcf::engine::tuple_generator::oblivious_transfer::ferret

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/IMatrixMultiplierFactory.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/IMatrixMultiplierFactory.h
@@ -12,8 +12,7 @@
 #include "fbpcf/mpc_framework/engine/communication/IPartyCommunicationAgent.h"
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/IMatrixMultiplier.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
-    ferret {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer::ferret {
 
 class IMatrixMultiplierFactory {
  public:
@@ -22,4 +21,4 @@ class IMatrixMultiplierFactory {
 };
 
 } // namespace
-  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::ferret
+  // fbpcf::engine::tuple_generator::oblivious_transfer::ferret

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/IMultiPointCot.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/IMultiPointCot.h
@@ -10,8 +10,7 @@
 #include <vector>
 #include "fbpcf/mpc_framework/engine/util/util.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
-    ferret {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer::ferret {
 
 /**
  * APIs for the ideal multi point cot. See details at
@@ -65,4 +64,4 @@ class IMultiPointCot {
 };
 
 } // namespace
-  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::ferret
+  // fbpcf::engine::tuple_generator::oblivious_transfer::ferret

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/IMultiPointCotFactory.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/IMultiPointCotFactory.h
@@ -12,8 +12,7 @@
 #include "fbpcf/mpc_framework/engine/communication/IPartyCommunicationAgent.h"
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/IMultiPointCot.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
-    ferret {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer::ferret {
 
 class IMultiPointCotFactory {
  public:
@@ -23,4 +22,4 @@ class IMultiPointCotFactory {
 };
 
 } // namespace
-  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::ferret
+  // fbpcf::engine::tuple_generator::oblivious_transfer::ferret

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/IRcotExtender.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/IRcotExtender.h
@@ -13,8 +13,7 @@
 #include "fbpcf/mpc_framework/engine/communication/IPartyCommunicationAgent.h"
 #include "fbpcf/mpc_framework/engine/util/util.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
-    ferret {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer::ferret {
 
 /**
  * This is the API of a Rcot extender. It can extend k Rcot results to n Rcot
@@ -84,4 +83,4 @@ class IRcotExtender {
 };
 
 } // namespace
-  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::ferret
+  // fbpcf::engine::tuple_generator::oblivious_transfer::ferret

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/IRcotExtenderFactory.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/IRcotExtenderFactory.h
@@ -12,8 +12,7 @@
 #include "fbpcf/mpc_framework/engine/communication/IPartyCommunicationAgent.h"
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/IRcotExtender.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
-    ferret {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer::ferret {
 
 class IRcotExtenderFactory {
  public:
@@ -22,4 +21,4 @@ class IRcotExtenderFactory {
 };
 
 } // namespace
-  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::ferret
+  // fbpcf::engine::tuple_generator::oblivious_transfer::ferret

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/ISinglePointCot.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/ISinglePointCot.h
@@ -11,8 +11,7 @@
 #include <vector>
 #include "fbpcf/mpc_framework/engine/util/util.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
-    ferret {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer::ferret {
 
 /**
  * APIs for the ideal single point cot. This is a randomized one, meaning the
@@ -63,4 +62,4 @@ class ISinglePointCot {
 };
 
 } // namespace
-  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::ferret
+  // fbpcf::engine::tuple_generator::oblivious_transfer::ferret

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/ISinglePointCotFactory.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/ISinglePointCotFactory.h
@@ -12,8 +12,7 @@
 #include "fbpcf/mpc_framework/engine/communication/IPartyCommunicationAgent.h"
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/ISinglePointCot.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
-    ferret {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer::ferret {
 
 class ISinglePointCotFactory {
  public:
@@ -23,4 +22,4 @@ class ISinglePointCotFactory {
 };
 
 } // namespace
-  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::ferret
+  // fbpcf::engine::tuple_generator::oblivious_transfer::ferret

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/RcotExtender.cpp
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/RcotExtender.cpp
@@ -18,8 +18,7 @@
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/RcotExtender.h"
 #include "fbpcf/mpc_framework/engine/util/util.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
-    ferret {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer::ferret {
 
 RcotExtender::RcotExtender(
     std::unique_ptr<IMatrixMultiplier> MatrixMultiplier,
@@ -109,4 +108,4 @@ std::vector<__m128i> RcotExtender::extendRcot(
 }
 
 } // namespace
-  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::ferret
+  // fbpcf::engine::tuple_generator::oblivious_transfer::ferret

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/RcotExtender.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/RcotExtender.h
@@ -15,8 +15,7 @@
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/IMultiPointCotFactory.h"
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/IRcotExtender.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
-    ferret {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer::ferret {
 
 /**
  * This is a COT extender in hybrid of an abstract LPN calculator and
@@ -92,4 +91,4 @@ class RcotExtender final : public IRcotExtender {
 };
 
 } // namespace
-  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::ferret
+  // fbpcf::engine::tuple_generator::oblivious_transfer::ferret

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/RcotExtenderFactory.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/RcotExtenderFactory.h
@@ -15,8 +15,7 @@
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/IRcotExtenderFactory.h"
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/RcotExtender.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
-    ferret {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer::ferret {
 
 class RcotExtenderFactory final : public IRcotExtenderFactory {
  public:
@@ -37,4 +36,4 @@ class RcotExtenderFactory final : public IRcotExtenderFactory {
 };
 
 } // namespace
-  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::ferret
+  // fbpcf::engine::tuple_generator::oblivious_transfer::ferret

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/RegularErrorMultiPointCot.cpp
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/RegularErrorMultiPointCot.cpp
@@ -18,8 +18,7 @@
 
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/RegularErrorMultiPointCot.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
-    ferret {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer::ferret {
 
 void RegularErrorMultiPointCot::init(int64_t length, int64_t weight) {
   assert(length % weight == 0);
@@ -89,4 +88,4 @@ std::vector<__m128i> RegularErrorMultiPointCot::receiverExtend(
 }
 
 } // namespace
-  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::ferret
+  // fbpcf::engine::tuple_generator::oblivious_transfer::ferret

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/RegularErrorMultiPointCot.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/RegularErrorMultiPointCot.h
@@ -12,8 +12,7 @@
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/ISinglePointCot.h"
 #include "fbpcf/mpc_framework/engine/util/IPrg.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
-    ferret {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer::ferret {
 
 const int64_t kExtendedSize = 10805248;
 const int64_t kWeight = 1319;
@@ -94,4 +93,4 @@ class RegularErrorMultiPointCot final : public IMultiPointCot {
 };
 
 } // namespace
-  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::ferret
+  // fbpcf::engine::tuple_generator::oblivious_transfer::ferret

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/RegularErrorMultiPointCotFactory.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/RegularErrorMultiPointCotFactory.h
@@ -15,8 +15,7 @@
 #include "fbpcf/mpc_framework/engine/util/IPrgFactory.h"
 #include "fbpcf/mpc_framework/engine/util/util.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
-    ferret {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer::ferret {
 
 class RegularErrorMultiPointCotFactory final : public IMultiPointCotFactory {
  public:
@@ -36,4 +35,4 @@ class RegularErrorMultiPointCotFactory final : public IMultiPointCotFactory {
 };
 
 } // namespace
-  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::ferret
+  // fbpcf::engine::tuple_generator::oblivious_transfer::ferret

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/SinglePointCot.cpp
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/SinglePointCot.cpp
@@ -12,8 +12,7 @@
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/SinglePointCot.h"
 #include "fbpcf/mpc_framework/engine/util/util.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
-    ferret {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer::ferret {
 
 std::vector<__m128i> SinglePointCot::constructALayerOfKeyForSender(
     std::vector<__m128i>&& previousLayer,
@@ -127,4 +126,4 @@ std::vector<__m128i> SinglePointCot::receiverExtend(
 }
 
 } // namespace
-  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::ferret
+  // fbpcf::engine::tuple_generator::oblivious_transfer::ferret

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/SinglePointCot.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/SinglePointCot.h
@@ -14,8 +14,7 @@
 #include "fbpcf/mpc_framework/engine/util/aes.h"
 #include "fbpcf/mpc_framework/engine/util/util.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
-    ferret {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer::ferret {
 
 /**
  * This is a real single point COT. See https://eprint.iacr.org/2020/924.pdf for
@@ -73,4 +72,4 @@ class SinglePointCot final : public ISinglePointCot {
 };
 
 } // namespace
-  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::ferret
+  // fbpcf::engine::tuple_generator::oblivious_transfer::ferret

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/SinglePointCotFactory.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/SinglePointCotFactory.h
@@ -14,8 +14,7 @@
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/SinglePointCot.h"
 #include "fbpcf/mpc_framework/engine/util/IPrgFactory.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
-    ferret {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer::ferret {
 
 class SinglePointCotFactory final : public ISinglePointCotFactory {
  public:
@@ -27,4 +26,4 @@ class SinglePointCotFactory final : public ISinglePointCotFactory {
 };
 
 } // namespace
-  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::ferret
+  // fbpcf::engine::tuple_generator::oblivious_transfer::ferret

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/TenLocalLinearMatrixMultiplier.cpp
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/TenLocalLinearMatrixMultiplier.cpp
@@ -10,8 +10,7 @@
 
 #include <emmintrin.h>
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
-    ferret {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer::ferret {
 
 std::vector<__m128i> TenLocalLinearMatrixMultiplier::multiplyWithRandomMatrix(
     __m128i seed,
@@ -49,4 +48,4 @@ std::vector<__m128i> TenLocalLinearMatrixMultiplier::multiplyWithRandomMatrix(
 }
 
 } // namespace
-  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::ferret
+  // fbpcf::engine::tuple_generator::oblivious_transfer::ferret

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/TenLocalLinearMatrixMultiplier.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/TenLocalLinearMatrixMultiplier.h
@@ -10,8 +10,7 @@
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/IMatrixMultiplier.h"
 #include "fbpcf/mpc_framework/engine/util/IPrgFactory.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
-    ferret {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer::ferret {
 
 /**
  * This lpn calculator uses a built-in 10 local linear code generator.
@@ -32,4 +31,4 @@ class TenLocalLinearMatrixMultiplier final : public IMatrixMultiplier {
 };
 
 } // namespace
-  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::ferret
+  // fbpcf::engine::tuple_generator::oblivious_transfer::ferret

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/TenLocalLinearMatrixMultiplierFactory.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/TenLocalLinearMatrixMultiplierFactory.h
@@ -14,8 +14,7 @@
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/TenLocalLinearMatrixMultiplier.h"
 #include "fbpcf/mpc_framework/engine/util/AesPrgFactory.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
-    ferret {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer::ferret {
 
 class TenLocalLinearMatrixMultiplierFactory final
     : public IMatrixMultiplierFactory {
@@ -26,4 +25,4 @@ class TenLocalLinearMatrixMultiplierFactory final
 };
 
 } // namespace
-  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::ferret
+  // fbpcf::engine::tuple_generator::oblivious_transfer::ferret

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/test/MatrixMultiplierTest.cpp
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/test/MatrixMultiplierTest.cpp
@@ -16,8 +16,7 @@
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/IMatrixMultiplier.h"
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/TenLocalLinearMatrixMultiplierFactory.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
-    ferret {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer::ferret {
 int getHammingWeight(uint8_t src) {
   int count = 0;
   for (int i = 0; i < 8; i++) {
@@ -68,4 +67,4 @@ TEST(MatrixMultiplierTest, test10LocalLinearMatrixMultiplier) {
 }
 
 } // namespace
-  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::ferret
+  // fbpcf::engine::tuple_generator::oblivious_transfer::ferret

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/test/MultiPointCotTest.cpp
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/test/MultiPointCotTest.cpp
@@ -21,8 +21,7 @@
 #include "fbpcf/mpc_framework/engine/util/AesPrgFactory.h"
 #include "fbpcf/mpc_framework/test/TestHelper.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
-    ferret {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer::ferret {
 
 void testMpCot(
     std::unique_ptr<IMultiPointCot> sender,
@@ -137,4 +136,4 @@ TEST(MPCotExtenderTest, testRealMPCotWithRealSpcot) {
 }
 
 } // namespace
-  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::ferret
+  // fbpcf::engine::tuple_generator::oblivious_transfer::ferret

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/test/RcotExtenderTest.cpp
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/test/RcotExtenderTest.cpp
@@ -26,8 +26,7 @@
 #include "fbpcf/mpc_framework/engine/util/AesPrgFactory.h"
 #include "fbpcf/mpc_framework/test/TestHelper.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
-    ferret {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer::ferret {
 
 void testRcotExtender(std::unique_ptr<IRcotExtenderFactory> factory) {
   communication::InMemoryPartyCommunicationAgentHost host;
@@ -129,4 +128,4 @@ TEST(RcotExtenderTest, testWithRegularErrorMPCOTandRealSPCOT) {
 }
 
 } // namespace
-  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::ferret
+  // fbpcf::engine::tuple_generator::oblivious_transfer::ferret

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/test/SinglePointCotTest.cpp
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/test/SinglePointCotTest.cpp
@@ -19,8 +19,7 @@
 #include "fbpcf/mpc_framework/engine/util/AesPrgFactory.h"
 #include "fbpcf/mpc_framework/test/TestHelper.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
-    ferret {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer::ferret {
 
 void testSpCot(
     std::unique_ptr<ISinglePointCot> sender,
@@ -107,4 +106,4 @@ TEST(SPCotExtenderTest, testRealSPCot) {
 }
 
 } // namespace
-  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::ferret
+  // fbpcf::engine::tuple_generator::oblivious_transfer::ferret

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/test/benchmarks/BenchmarkMain.cpp
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/test/benchmarks/BenchmarkMain.cpp
@@ -14,8 +14,7 @@
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/test/benchmarks/CotBenchmark.h"
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/test/benchmarks/MatrixMultiplierBenchmark.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
-    ferret {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer::ferret {
 
 BENCHMARK(DummyMatrixMultiplier, n) {
   benchmarkMatrixMultiplier(
@@ -41,8 +40,7 @@ BENCHMARK_COUNTERS(RcotExtender, counters) {
   RcotExtenderBenchmark benchmark;
   benchmark.runBenchmark(counters);
 }
-} // namespace
-  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::ferret
+} // namespace fbpcf::engine::tuple_generator::oblivious_transfer::ferret
 
 int main(int argc, char* argv[]) {
   facebook::initFacebook(&argc, &argv);

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/test/benchmarks/CotBenchmark.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/test/benchmarks/CotBenchmark.h
@@ -20,8 +20,7 @@
 #include "fbpcf/mpc_framework/engine/util/test/benchmarks/NetworkedBenchmark.h"
 #include "fbpcf/mpc_framework/engine/util/util.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
-    ferret {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer::ferret {
 
 inline std::tuple<std::vector<__m128i>, std::vector<__m128i>, __m128i>
 getBaseOT(size_t baseOtSize) {
@@ -186,5 +185,4 @@ class RcotExtenderBenchmark final : public util::NetworkedBenchmark {
   std::vector<__m128i> baseOTReceive_;
 };
 
-} // namespace
-  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::ferret
+} // namespace fbpcf::engine::tuple_generator::oblivious_transfer::ferret

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/test/benchmarks/MatrixMultiplierBenchmark.cpp
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/test/benchmarks/MatrixMultiplierBenchmark.cpp
@@ -10,8 +10,7 @@
 
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/test/benchmarks/MatrixMultiplierBenchmark.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
-    ferret {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer::ferret {
 
 void MatrixMultiplierBenchmark::setup(
     std::unique_ptr<IMatrixMultiplierFactory> factory,
@@ -36,4 +35,4 @@ std::vector<__m128i> MatrixMultiplierBenchmark::benchmark() const {
 }
 
 } // namespace
-  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::ferret
+  // fbpcf::engine::tuple_generator::oblivious_transfer::ferret

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/test/benchmarks/MatrixMultiplierBenchmark.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/test/benchmarks/MatrixMultiplierBenchmark.h
@@ -16,8 +16,7 @@
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/RegularErrorMultiPointCot.h"
 #include "fbpcf/mpc_framework/engine/util/AesPrgFactory.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
-    ferret {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer::ferret {
 
 class MatrixMultiplierBenchmark {
  public:
@@ -58,4 +57,4 @@ inline void benchmarkMatrixMultiplier(
   folly::doNotOptimizeAway(rst);
 }
 } // namespace
-  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::ferret
+  // fbpcf::engine::tuple_generator::oblivious_transfer::ferret

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/test/BaseObliviousTransferTest.cpp
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/test/BaseObliviousTransferTest.cpp
@@ -18,7 +18,7 @@
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/NpBaseObliviousTransferFactory.h"
 #include "fbpcf/mpc_framework/test/TestHelper.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer {
 
 void testBaseObliviousTransfer(
     std::unique_ptr<IBaseObliviousTransferFactory> factory0,
@@ -130,4 +130,4 @@ TEST(BaseObliviousTransferTest, testNpBaseOT) {
       std::make_unique<NpBaseObliviousTransferFactory>());
 }
 
-} // namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer
+} // namespace fbpcf::engine::tuple_generator::oblivious_transfer

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/test/BidirectionObliviousTransferTest.cpp
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/test/BidirectionObliviousTransferTest.cpp
@@ -29,7 +29,7 @@
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/TenLocalLinearMatrixMultiplierFactory.h"
 #include "fbpcf/mpc_framework/engine/util/AesPrgFactory.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer {
 
 TEST(DummyBidirectionObliviousTransferTest, testBiDirectionOT) {
   auto factorys = communication::getInMemoryAgentFactory(2);
@@ -312,4 +312,4 @@ TEST(
           ferret::kBaseSize,
           ferret::kWeight));
 }
-} // namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer
+} // namespace fbpcf::engine::tuple_generator::oblivious_transfer

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/test/RandomCorrelatedObliviousTransferTest.cpp
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/test/RandomCorrelatedObliviousTransferTest.cpp
@@ -33,7 +33,7 @@
 #include "fbpcf/mpc_framework/engine/util/AesPrgFactory.h"
 #include "fbpcf/mpc_framework/test/TestHelper.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer {
+namespace fbpcf::engine::tuple_generator::oblivious_transfer {
 void testRandomCorrelatedObliviousTransfer(
     std::unique_ptr<IRandomCorrelatedObliviousTransferFactory> factory0,
     std::unique_ptr<IRandomCorrelatedObliviousTransferFactory> factory1) {
@@ -353,4 +353,4 @@ TEST(
           ferret::kWeight));
 }
 
-} // namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer
+} // namespace fbpcf::engine::tuple_generator::oblivious_transfer

--- a/fbpcf/mpc_framework/engine/tuple_generator/test/ProductShareGeneratorTest.cpp
+++ b/fbpcf/mpc_framework/engine/tuple_generator/test/ProductShareGeneratorTest.cpp
@@ -29,7 +29,7 @@
 #include "fbpcf/mpc_framework/engine/tuple_generator/test/TupleGeneratorTestHelper.h"
 #include "fbpcf/mpc_framework/engine/util/AesPrgFactory.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator {
+namespace fbpcf::engine::tuple_generator {
 
 void testGenerator(
     std::unique_ptr<IProductShareGeneratorFactory> factory0,
@@ -121,4 +121,4 @@ TEST(ProductShareGenerator, testRealGeneratorWithRealOT) {
                   kTestExtendedSize, kTestBaseSize, kTestWeight))));
 }
 
-} // namespace fbpcf::mpc_framework::engine::tuple_generator
+} // namespace fbpcf::engine::tuple_generator

--- a/fbpcf/mpc_framework/engine/tuple_generator/test/TupleGeneratorTest.cpp
+++ b/fbpcf/mpc_framework/engine/tuple_generator/test/TupleGeneratorTest.cpp
@@ -16,7 +16,7 @@
 #include "fbpcf/mpc_framework/engine/tuple_generator/ITupleGenerator.h"
 #include "fbpcf/mpc_framework/engine/tuple_generator/test/TupleGeneratorTestHelper.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator {
+namespace fbpcf::engine::tuple_generator {
 
 using TupleGeneratorFactoryCreator =
     std::unique_ptr<tuple_generator::ITupleGeneratorFactory>(
@@ -109,4 +109,4 @@ TEST(TupleGeneratorTest, testTwoPartyTupleGeneratorWithRcotExtender) {
   testTupleGenerator(2, createTwoPartyTupleGeneratorFactoryWithRcotExtender);
 }
 
-} // namespace fbpcf::mpc_framework::engine::tuple_generator
+} // namespace fbpcf::engine::tuple_generator

--- a/fbpcf/mpc_framework/engine/tuple_generator/test/TupleGeneratorTestHelper.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/test/TupleGeneratorTestHelper.h
@@ -40,7 +40,7 @@
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/SinglePointCotFactory.h"
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/TenLocalLinearMatrixMultiplierFactory.h"
 
-namespace fbpcf::mpc_framework::engine::tuple_generator {
+namespace fbpcf::engine::tuple_generator {
 const uint64_t kTestExtendedSize = 2048;
 const uint64_t kTestBaseSize = 1024;
 const uint64_t kTestWeight = 16;
@@ -139,4 +139,4 @@ createTwoPartyTupleGeneratorFactoryWithRcotExtender(
       kTestBufferSize);
 }
 
-} // namespace fbpcf::mpc_framework::engine::tuple_generator
+} // namespace fbpcf::engine::tuple_generator

--- a/fbpcf/mpc_framework/engine/util/AesPrg.cpp
+++ b/fbpcf/mpc_framework/engine/util/AesPrg.cpp
@@ -9,7 +9,7 @@
 #include <string.h>
 #include <stdexcept>
 
-namespace fbpcf::mpc_framework::engine::util {
+namespace fbpcf::engine::util {
 
 inline uint64_t ceilDiv(uint64_t a, uint64_t b) {
   return a / b + (a % b != 0);
@@ -55,4 +55,4 @@ std::vector<unsigned char> AesPrg::generateRandomData(uint64_t numBytes) {
   return rstBytes;
 }
 
-} // namespace fbpcf::mpc_framework::engine::util
+} // namespace fbpcf::engine::util

--- a/fbpcf/mpc_framework/engine/util/AesPrg.h
+++ b/fbpcf/mpc_framework/engine/util/AesPrg.h
@@ -22,7 +22,7 @@
 #include "fbpcf/mpc_framework/engine/util/IPrg.h"
 #include "fbpcf/mpc_framework/engine/util/aes.h"
 
-namespace fbpcf::mpc_framework::engine::util {
+namespace fbpcf::engine::util {
 
 class AesPrg final : public IPrg {
  public:
@@ -73,4 +73,4 @@ class AesPrg final : public IPrg {
   std::unique_ptr<AsyncBuffer<unsigned char>> asyncBuffer_ = nullptr;
 };
 
-} // namespace fbpcf::mpc_framework::engine::util
+} // namespace fbpcf::engine::util

--- a/fbpcf/mpc_framework/engine/util/AesPrgFactory.h
+++ b/fbpcf/mpc_framework/engine/util/AesPrgFactory.h
@@ -9,7 +9,7 @@
 #include "fbpcf/mpc_framework/engine/util/AesPrg.h"
 #include "fbpcf/mpc_framework/engine/util/IPrgFactory.h"
 
-namespace fbpcf::mpc_framework::engine::util {
+namespace fbpcf::engine::util {
 
 /**
  * an aes prg factory, always creates aes-based prg.
@@ -26,4 +26,4 @@ class AesPrgFactory final : public IPrgFactory {
   int bufferSize_;
 };
 
-} // namespace fbpcf::mpc_framework::engine::util
+} // namespace fbpcf::engine::util

--- a/fbpcf/mpc_framework/engine/util/AsyncBuffer.h
+++ b/fbpcf/mpc_framework/engine/util/AsyncBuffer.h
@@ -12,7 +12,7 @@
 #include <future>
 #include <vector>
 
-namespace fbpcf::mpc_framework::engine::util {
+namespace fbpcf::engine::util {
 
 /**
  * Holds a buffer that returns the requested amount of data on-demand. Data is
@@ -64,4 +64,4 @@ class AsyncBuffer {
   std::future<std::vector<T>> futureBuffer_;
 };
 
-} // namespace fbpcf::mpc_framework::engine::util
+} // namespace fbpcf::engine::util

--- a/fbpcf/mpc_framework/engine/util/EmpNetworkAdapter.h
+++ b/fbpcf/mpc_framework/engine/util/EmpNetworkAdapter.h
@@ -13,7 +13,7 @@
 
 #include "fbpcf/mpc_framework/engine/communication/IPartyCommunicationAgent.h"
 
-namespace fbpcf::mpc_framework::engine::util {
+namespace fbpcf::engine::util {
 // this object wrapps around our own network object and provides the same API as
 // emp-tool::io
 
@@ -74,4 +74,4 @@ class EmpNetworkAdapter {
   communication::IPartyCommunicationAgent& agent_;
 };
 
-} // namespace fbpcf::mpc_framework::engine::util
+} // namespace fbpcf::engine::util

--- a/fbpcf/mpc_framework/engine/util/IPrg.h
+++ b/fbpcf/mpc_framework/engine/util/IPrg.h
@@ -12,7 +12,7 @@
 #include <cstdint>
 #include "fbpcf/mpc_framework/engine/util/util.h"
 
-namespace fbpcf::mpc_framework::engine::util {
+namespace fbpcf::engine::util {
 
 class IPrg {
  public:
@@ -29,4 +29,4 @@ class IPrg {
   virtual std::vector<unsigned char> getRandomBytes(uint32_t size) = 0;
 };
 
-} // namespace fbpcf::mpc_framework::engine::util
+} // namespace fbpcf::engine::util

--- a/fbpcf/mpc_framework/engine/util/IPrgFactory.h
+++ b/fbpcf/mpc_framework/engine/util/IPrgFactory.h
@@ -11,7 +11,7 @@
 
 #include "fbpcf/mpc_framework/engine/util/IPrg.h"
 
-namespace fbpcf::mpc_framework::engine::util {
+namespace fbpcf::engine::util {
 
 /**
  * prg factory API, create a seeded prg with a given seed
@@ -22,4 +22,4 @@ class IPrgFactory {
   virtual std::unique_ptr<IPrg> create(__m128i seed) const = 0;
 };
 
-} // namespace fbpcf::mpc_framework::engine::util
+} // namespace fbpcf::engine::util

--- a/fbpcf/mpc_framework/engine/util/Masker.h
+++ b/fbpcf/mpc_framework/engine/util/Masker.h
@@ -11,7 +11,7 @@
 #include <vector>
 #include "fbpcf/mpc_framework/engine/util/util.h"
 
-namespace fbpcf::mpc_framework::engine::util {
+namespace fbpcf::engine::util {
 
 template <class T>
 class Masker {
@@ -20,6 +20,6 @@ class Masker {
   static T unmask(__m128i key, bool choice, T correction0, T correction1);
 };
 
-} // namespace fbpcf::mpc_framework::engine::util
+} // namespace fbpcf::engine::util
 
 #include "fbpcf/mpc_framework/engine/util/Masker_impl.h"

--- a/fbpcf/mpc_framework/engine/util/Masker_impl.h
+++ b/fbpcf/mpc_framework/engine/util/Masker_impl.h
@@ -11,7 +11,7 @@
 #include <vector>
 #include "fbpcf/mpc_framework/engine/util/util.h"
 
-namespace fbpcf::mpc_framework::engine::util {
+namespace fbpcf::engine::util {
 
 template <>
 class Masker<bool> {
@@ -25,4 +25,4 @@ class Masker<bool> {
   }
 };
 
-} // namespace fbpcf::mpc_framework::engine::util
+} // namespace fbpcf::engine::util

--- a/fbpcf/mpc_framework/engine/util/aes.cpp
+++ b/fbpcf/mpc_framework/engine/util/aes.cpp
@@ -8,7 +8,7 @@
 #include "fbpcf/mpc_framework/engine/util/aes.h"
 #include <emmintrin.h>
 
-namespace fbpcf::mpc_framework::engine::util {
+namespace fbpcf::engine::util {
 
 __m128i Aes::getFixedKey() {
   return _mm_set_epi64x(0, 0);
@@ -78,4 +78,4 @@ void Aes::inPlaceHash(std::vector<__m128i>& src) const {
   }
 }
 
-} // namespace fbpcf::mpc_framework::engine::util
+} // namespace fbpcf::engine::util

--- a/fbpcf/mpc_framework/engine/util/aes.h
+++ b/fbpcf/mpc_framework/engine/util/aes.h
@@ -13,7 +13,7 @@
 #include <cstdint>
 #include <vector>
 
-namespace fbpcf::mpc_framework::engine::util {
+namespace fbpcf::engine::util {
 
 /*
 AES algorithm can be divided into two parts:
@@ -80,4 +80,4 @@ class Aes {
   }
 };
 
-} // namespace fbpcf::mpc_framework::engine::util
+} // namespace fbpcf::engine::util

--- a/fbpcf/mpc_framework/engine/util/test/AsyncBufferTest.cpp
+++ b/fbpcf/mpc_framework/engine/util/test/AsyncBufferTest.cpp
@@ -9,7 +9,7 @@
 
 #include "fbpcf/mpc_framework/engine/util/AsyncBuffer.h"
 
-namespace fbpcf::mpc_framework::engine::util {
+namespace fbpcf::engine::util {
 
 TEST(AsyncBufferTest, TestGetData) {
   auto index = 0;
@@ -53,4 +53,4 @@ TEST(AsyncBufferTest, TestGetData) {
     EXPECT_EQ(allData.at(i), i);
   }
 }
-} // namespace fbpcf::mpc_framework::engine::util
+} // namespace fbpcf::engine::util

--- a/fbpcf/mpc_framework/engine/util/test/aesTest.cpp
+++ b/fbpcf/mpc_framework/engine/util/test/aesTest.cpp
@@ -11,7 +11,7 @@
 #include <random>
 #include "fbpcf/mpc_framework/engine/util/test/aesTestHelper.h"
 
-namespace fbpcf::mpc_framework::engine::util {
+namespace fbpcf::engine::util {
 
 TEST(aesTest, testEncryptionAndDecryption) {
   std::random_device rd;
@@ -38,4 +38,4 @@ TEST(aesTest, testEncryptionAndDecryption) {
   }
 }
 
-} // namespace fbpcf::mpc_framework::engine::util
+} // namespace fbpcf::engine::util

--- a/fbpcf/mpc_framework/engine/util/test/aesTestHelper.cpp
+++ b/fbpcf/mpc_framework/engine/util/test/aesTestHelper.cpp
@@ -8,7 +8,7 @@
 #include "fbpcf/mpc_framework/engine/util/test/aesTestHelper.h"
 #include <cstdint>
 
-namespace fbpcf::mpc_framework::engine::util {
+namespace fbpcf::engine::util {
 
 void AesTestHelper::switchToDecrypt() {
   // convert the encryption key to the decryption key
@@ -40,4 +40,4 @@ void AesTestHelper::decryptInPlace(std::vector<__m128i>& ciphertext) const {
     dataPointer[i] = _mm_aesdeclast_si128(dataPointer[i], roundKey_.at(kRound));
 }
 
-} // namespace fbpcf::mpc_framework::engine::util
+} // namespace fbpcf::engine::util

--- a/fbpcf/mpc_framework/engine/util/test/aesTestHelper.h
+++ b/fbpcf/mpc_framework/engine/util/test/aesTestHelper.h
@@ -8,7 +8,7 @@
 #pragma once
 #include "fbpcf/mpc_framework/engine/util/aes.h"
 
-namespace fbpcf::mpc_framework::engine::util {
+namespace fbpcf::engine::util {
 
 class AesTestHelper final : public Aes {
  public:
@@ -22,4 +22,4 @@ class AesTestHelper final : public Aes {
   void decryptInPlace(std::vector<__m128i>& ciphertext) const;
 };
 
-} // namespace fbpcf::mpc_framework::engine::util
+} // namespace fbpcf::engine::util

--- a/fbpcf/mpc_framework/engine/util/test/benchmarks/BenchmarkHelper.h
+++ b/fbpcf/mpc_framework/engine/util/test/benchmarks/BenchmarkHelper.h
@@ -17,7 +17,7 @@
 #include "fbpcf/mpc_framework/engine/communication/SocketPartyCommunicationAgentFactory.h"
 #include "folly/logging/xlog.h"
 
-namespace fbpcf::mpc_framework::engine::util {
+namespace fbpcf::engine::util {
 
 inline std::pair<
     std::unique_ptr<communication::IPartyCommunicationAgent>,
@@ -66,4 +66,4 @@ getSocketAgents() {
   throw std::runtime_error("Failed to create socket agents. Out of retries.");
 }
 
-} // namespace fbpcf::mpc_framework::engine::util
+} // namespace fbpcf::engine::util

--- a/fbpcf/mpc_framework/engine/util/test/benchmarks/BenchmarkMain.cpp
+++ b/fbpcf/mpc_framework/engine/util/test/benchmarks/BenchmarkMain.cpp
@@ -15,7 +15,7 @@
 #include "fbpcf/mpc_framework/engine/util/aes.h"
 #include "folly/BenchmarkUtil.h"
 
-namespace fbpcf::mpc_framework::engine::util {
+namespace fbpcf::engine::util {
 
 DEFINE_int64(
     AES_Benchmark_Size,
@@ -111,7 +111,7 @@ BENCHMARK(AesPrg_getRandomDataInPlace, n) {
   }
   folly::doNotOptimizeAway(data);
 }
-} // namespace fbpcf::mpc_framework::engine::util
+} // namespace fbpcf::engine::util
 
 int main(int argc, char* argv[]) {
   facebook::initFacebook(&argc, &argv);

--- a/fbpcf/mpc_framework/engine/util/test/benchmarks/NetworkedBenchmark.h
+++ b/fbpcf/mpc_framework/engine/util/test/benchmarks/NetworkedBenchmark.h
@@ -11,7 +11,7 @@
 
 #include <folly/Benchmark.h>
 
-namespace fbpcf::mpc_framework::engine::util {
+namespace fbpcf::engine::util {
 
 /**
  * A parent class that can be used for writing benchmarks for components that
@@ -46,4 +46,4 @@ class NetworkedBenchmark {
   virtual std::pair<uint64_t, uint64_t> getTrafficStatistics() = 0;
 };
 
-} // namespace fbpcf::mpc_framework::engine::util
+} // namespace fbpcf::engine::util

--- a/fbpcf/mpc_framework/engine/util/test/prgTest.cpp
+++ b/fbpcf/mpc_framework/engine/util/test/prgTest.cpp
@@ -11,7 +11,7 @@
 #include <stdexcept>
 #include "fbpcf/mpc_framework/engine/util/AesPrg.h"
 
-namespace fbpcf::mpc_framework::engine::util {
+namespace fbpcf::engine::util {
 
 TEST(AesPrgTest, testRandomBytesWithSIMDAes) {
   AesPrg prg(_mm_set_epi32(1, 2, 3, 4), 1024);
@@ -47,4 +47,4 @@ TEST(AesPrgTest, testThrow) {
   EXPECT_THROW(prg.getRandomBits(10), std::runtime_error);
 }
 
-} // namespace fbpcf::mpc_framework::engine::util
+} // namespace fbpcf::engine::util

--- a/fbpcf/mpc_framework/engine/util/util.cpp
+++ b/fbpcf/mpc_framework/engine/util/util.cpp
@@ -7,7 +7,7 @@
 
 #include "fbpcf/mpc_framework/engine/util/util.h"
 
-namespace fbpcf::mpc_framework::engine::util {
+namespace fbpcf::engine::util {
 
 Expander::Expander(int64_t index)
     : cipher0_(_mm_set_epi64x(0, (uint64_t)index << 1)),
@@ -30,4 +30,4 @@ std::vector<__m128i> Expander::expand(std::vector<__m128i>&& src) const {
   return rst;
 }
 
-} // namespace fbpcf::mpc_framework::engine::util
+} // namespace fbpcf::engine::util

--- a/fbpcf/mpc_framework/engine/util/util.h
+++ b/fbpcf/mpc_framework/engine/util/util.h
@@ -22,7 +22,7 @@
 
 #include "fbpcf/mpc_framework/engine/util/aes.h"
 
-namespace fbpcf::mpc_framework::engine::util {
+namespace fbpcf::engine::util {
 
 inline bool getLsb(__m128i src) {
   return _mm_extract_epi8(src, 0) & 1;
@@ -127,4 +127,4 @@ class Expander {
   Aes cipher1_;
 };
 
-} // namespace fbpcf::mpc_framework::engine::util
+} // namespace fbpcf::engine::util

--- a/fbpcf/mpc_framework/frontend/Bit.h
+++ b/fbpcf/mpc_framework/frontend/Bit.h
@@ -13,7 +13,7 @@
 #include <vector>
 #include "fbpcf/mpc_framework/scheduler/IScheduler.h"
 
-namespace fbpcf::mpc_framework::frontend {
+namespace fbpcf::frontend {
 
 template <bool isSecret, int schedulerId, bool usingBatch = false>
 class Bit : public scheduler::SchedulerKeeper<schedulerId> {
@@ -129,6 +129,6 @@ class Bit : public scheduler::SchedulerKeeper<schedulerId> {
   friend class Bit<!isSecret, schedulerId, usingBatch>;
 };
 
-} // namespace fbpcf::mpc_framework::frontend
+} // namespace fbpcf::frontend
 
 #include "fbpcf/mpc_framework/frontend/Bit_impl.h"

--- a/fbpcf/mpc_framework/frontend/BitString.h
+++ b/fbpcf/mpc_framework/frontend/BitString.h
@@ -13,7 +13,7 @@
 #include <vector>
 #include "fbpcf/mpc_framework/frontend/Bit.h"
 
-namespace fbpcf::mpc_framework::frontend {
+namespace fbpcf::frontend {
 
 /**
  * BitString type is merely a vector of bits with some basic APIs like bit-wise
@@ -127,6 +127,6 @@ class BitString : public scheduler::SchedulerKeeper<schedulerId> {
   friend class BitString<!isSecret, schedulerId, usingBatch>;
 };
 
-} // namespace fbpcf::mpc_framework::frontend
+} // namespace fbpcf::frontend
 
 #include "fbpcf/mpc_framework/frontend/BitString_impl.h"

--- a/fbpcf/mpc_framework/frontend/BitString_impl.h
+++ b/fbpcf/mpc_framework/frontend/BitString_impl.h
@@ -11,7 +11,7 @@
 #include <vector>
 #include "fbpcf/mpc_framework/frontend/util.h"
 
-namespace fbpcf::mpc_framework::frontend {
+namespace fbpcf::frontend {
 
 template <bool isSecret, int schedulerId, bool usingBatch>
 BitString<isSecret, schedulerId, usingBatch>::BitString(
@@ -160,4 +160,4 @@ BitString<isSecret, schedulerId, usingBatch>::mux(
   return rst;
 }
 
-} // namespace fbpcf::mpc_framework::frontend
+} // namespace fbpcf::frontend

--- a/fbpcf/mpc_framework/frontend/Bit_impl.h
+++ b/fbpcf/mpc_framework/frontend/Bit_impl.h
@@ -10,7 +10,7 @@
 // included for clangd resolution. Should not execute during compilation
 #include "fbpcf/mpc_framework/frontend/Bit.h"
 
-namespace fbpcf::mpc_framework::frontend {
+namespace fbpcf::frontend {
 
 template <bool isSecret, int schedulerId, bool usingBatch>
 void Bit<isSecret, schedulerId, usingBatch>::increaseReferenceCount(
@@ -293,4 +293,4 @@ Bit<isSecret, schedulerId, usingBatch>::extractBit() const {
   }
 }
 
-} // namespace fbpcf::mpc_framework::frontend
+} // namespace fbpcf::frontend

--- a/fbpcf/mpc_framework/frontend/Int.h
+++ b/fbpcf/mpc_framework/frontend/Int.h
@@ -14,7 +14,7 @@
 #include "fbpcf/mpc_framework/frontend/Bit.h"
 #include "fbpcf/mpc_framework/frontend/util.h"
 
-namespace fbpcf::mpc_framework::frontend {
+namespace fbpcf::frontend {
 
 template <
     bool isSigned,
@@ -271,6 +271,6 @@ using Integer =
     typename IntTypeHelper<typename T::type, IsSecret<T>::value, schedulerId>::
         type;
 
-} // namespace fbpcf::mpc_framework::frontend
+} // namespace fbpcf::frontend
 
 #include "fbpcf/mpc_framework/frontend/Int_impl.h"

--- a/fbpcf/mpc_framework/frontend/Int_impl.h
+++ b/fbpcf/mpc_framework/frontend/Int_impl.h
@@ -11,7 +11,7 @@
 #include <vector>
 #include "fbpcf/mpc_framework/frontend/util.h"
 
-namespace fbpcf::mpc_framework::frontend {
+namespace fbpcf::frontend {
 
 template <
     bool isSigned,
@@ -560,4 +560,4 @@ Int<isSigned, width, isSecret, schedulerId, usingBatch>::convertBitsToInt(
   }
 }
 
-} // namespace fbpcf::mpc_framework::frontend
+} // namespace fbpcf::frontend

--- a/fbpcf/mpc_framework/frontend/mpcGame.h
+++ b/fbpcf/mpc_framework/frontend/mpcGame.h
@@ -14,7 +14,7 @@
 #include "fbpcf/mpc_framework/frontend/util.h"
 #include "fbpcf/mpc_framework/scheduler/IScheduler.h"
 
-namespace fbpcf::mpc_framework::frontend {
+namespace fbpcf::frontend {
 
 template <int schedulerId>
 class MpcGame {
@@ -61,4 +61,4 @@ class MpcGame {
       Integer<Secret<BatchedType<Unsigned<width>, usingBatch>>, schedulerId>;
 };
 
-} // namespace fbpcf::mpc_framework::frontend
+} // namespace fbpcf::frontend

--- a/fbpcf/mpc_framework/frontend/test/BitStringTest.cpp
+++ b/fbpcf/mpc_framework/frontend/test/BitStringTest.cpp
@@ -15,7 +15,7 @@
 #include "fbpcf/mpc_framework/scheduler/WireKeeper.h"
 #include "fbpcf/mpc_framework/test/TestHelper.h"
 
-namespace fbpcf::mpc_framework::frontend {
+namespace fbpcf::frontend {
 TEST(StringTest, testInputAndOutput) {
   std::random_device rd;
   std::mt19937_64 e(rd());
@@ -453,4 +453,4 @@ TEST(StringTest, testResizeWithAND) {
   }
 }
 
-} // namespace fbpcf::mpc_framework::frontend
+} // namespace fbpcf::frontend

--- a/fbpcf/mpc_framework/frontend/test/BitTest.cpp
+++ b/fbpcf/mpc_framework/frontend/test/BitTest.cpp
@@ -15,7 +15,7 @@
 #include "fbpcf/mpc_framework/scheduler/WireKeeper.h"
 #include "fbpcf/mpc_framework/test/TestHelper.h"
 
-namespace fbpcf::mpc_framework::frontend {
+namespace fbpcf::frontend {
 
 using namespace ::testing;
 
@@ -591,4 +591,4 @@ TEST(BitTest, testReferenceCountBatch) {
   scheduler::SchedulerKeeper<0>::freeScheduler();
 }
 
-} // namespace fbpcf::mpc_framework::frontend
+} // namespace fbpcf::frontend

--- a/fbpcf/mpc_framework/frontend/test/IntTest.cpp
+++ b/fbpcf/mpc_framework/frontend/test/IntTest.cpp
@@ -15,7 +15,7 @@
 #include "fbpcf/mpc_framework/scheduler/WireKeeper.h"
 #include "fbpcf/mpc_framework/test/TestHelper.h"
 
-namespace fbpcf::mpc_framework::frontend {
+namespace fbpcf::frontend {
 
 TEST(IntTest, testInputAndOutput) {
   const int8_t width = 63;
@@ -1386,4 +1386,4 @@ TEST(IntTest, testSubscriptBatch) {
   }
 }
 
-} // namespace fbpcf::mpc_framework::frontend
+} // namespace fbpcf::frontend

--- a/fbpcf/mpc_framework/frontend/test/schedulerMock.h
+++ b/fbpcf/mpc_framework/frontend/test/schedulerMock.h
@@ -11,7 +11,7 @@
 
 #include "fbpcf/mpc_framework/scheduler/IScheduler.h"
 
-namespace fbpcf::mpc_framework::frontend {
+namespace fbpcf::frontend {
 
 using namespace ::testing;
 
@@ -230,4 +230,4 @@ class schedulerMock final : public scheduler::IScheduler {
   }
 };
 
-} // namespace fbpcf::mpc_framework::frontend
+} // namespace fbpcf::frontend

--- a/fbpcf/mpc_framework/frontend/test/utilTest.cpp
+++ b/fbpcf/mpc_framework/frontend/test/utilTest.cpp
@@ -10,7 +10,7 @@
 
 #include "fbpcf/mpc_framework/frontend/util.h"
 
-namespace fbpcf::mpc_framework::frontend {
+namespace fbpcf::frontend {
 
 TEST(TypeIndicatorTest, testIntegerTypes) {
   const int width = 31;
@@ -27,4 +27,4 @@ TEST(TypeIndicatorTest, testIntegerTypes) {
   EXPECT_FALSE(IsBatch<Unsigned<width>>::value);
 }
 
-} // namespace fbpcf::mpc_framework::frontend
+} // namespace fbpcf::frontend

--- a/fbpcf/mpc_framework/frontend/util.h
+++ b/fbpcf/mpc_framework/frontend/util.h
@@ -10,7 +10,7 @@
 #include <cstdint>
 #include <type_traits>
 
-namespace fbpcf::mpc_framework::frontend {
+namespace fbpcf::frontend {
 
 // a class representing "signed integer"
 template <int8_t intWidth>
@@ -101,4 +101,4 @@ void equalityCheck(OutputT& rst, const InputT1& src1, const InputT2& src2) {
   }
 }
 
-} // namespace fbpcf::mpc_framework::frontend
+} // namespace fbpcf::frontend

--- a/fbpcf/mpc_framework/mpc_std_lib/oram/DifferenceCalculator.h
+++ b/fbpcf/mpc_framework/mpc_std_lib/oram/DifferenceCalculator.h
@@ -12,7 +12,7 @@
 #include "fbpcf/mpc_framework/mpc_std_lib/oram/IDifferenceCalculator.h"
 #include "fbpcf/mpc_framework/mpc_std_lib/util/util.h"
 
-namespace fbpcf::mpc_framework::mpc_std_lib::oram {
+namespace fbpcf::mpc_std_lib::oram {
 
 /**
  * a difference Calculator compute the difference between a randomly
@@ -50,6 +50,6 @@ class DifferenceCalculator final : public IDifferenceCalculator<T> {
   int32_t party1Id_;
 };
 
-} // namespace fbpcf::mpc_framework::mpc_std_lib::oram
+} // namespace fbpcf::mpc_std_lib::oram
 
 #include "fbpcf/mpc_framework/mpc_std_lib/oram/DifferenceCalculator_impl.h"

--- a/fbpcf/mpc_framework/mpc_std_lib/oram/DifferenceCalculatorFactory.h
+++ b/fbpcf/mpc_framework/mpc_std_lib/oram/DifferenceCalculatorFactory.h
@@ -12,7 +12,7 @@
 #include "fbpcf/mpc_framework/mpc_std_lib/oram/DifferenceCalculator.h"
 #include "fbpcf/mpc_framework/mpc_std_lib/oram/IDifferenceCalculatorFactory.h"
 
-namespace fbpcf::mpc_framework::mpc_std_lib::oram {
+namespace fbpcf::mpc_std_lib::oram {
 
 template <typename T, int8_t indicatorSumWidth, int schedulerId>
 class DifferenceCalculatorFactory final
@@ -36,4 +36,4 @@ class DifferenceCalculatorFactory final
   int32_t party1Id_;
 };
 
-} // namespace fbpcf::mpc_framework::mpc_std_lib::oram
+} // namespace fbpcf::mpc_std_lib::oram

--- a/fbpcf/mpc_framework/mpc_std_lib/oram/DifferenceCalculator_impl.h
+++ b/fbpcf/mpc_framework/mpc_std_lib/oram/DifferenceCalculator_impl.h
@@ -9,7 +9,7 @@
 
 #include "fbpcf/mpc_framework/mpc_std_lib/util/util.h"
 
-namespace fbpcf::mpc_framework::mpc_std_lib::oram {
+namespace fbpcf::mpc_std_lib::oram {
 
 template <typename T, int8_t indicatorSumWidth, int schedulerId>
 std::vector<T> DifferenceCalculator<T, indicatorSumWidth, schedulerId>::
@@ -71,4 +71,4 @@ DifferenceCalculator<T, indicatorSumWidth, schedulerId>::recoverIndicators(
   return (indicator0 - indicator1)[indicatorSumWidth - 1];
 }
 
-} // namespace fbpcf::mpc_framework::mpc_std_lib::oram
+} // namespace fbpcf::mpc_std_lib::oram

--- a/fbpcf/mpc_framework/mpc_std_lib/oram/DummyDifferenceCalculator.h
+++ b/fbpcf/mpc_framework/mpc_std_lib/oram/DummyDifferenceCalculator.h
@@ -12,7 +12,7 @@
 #include "fbpcf/mpc_framework/engine/communication/IPartyCommunicationAgent.h"
 #include "fbpcf/mpc_framework/mpc_std_lib/oram/IDifferenceCalculator.h"
 
-namespace fbpcf::mpc_framework::mpc_std_lib::oram::insecure {
+namespace fbpcf::mpc_std_lib::oram::insecure {
 
 /**
  * See design doc
@@ -48,6 +48,6 @@ class DummyDifferenceCalculator final : public IDifferenceCalculator<T> {
       agent_;
 };
 
-} // namespace fbpcf::mpc_framework::mpc_std_lib::oram::insecure
+} // namespace fbpcf::mpc_std_lib::oram::insecure
 
 #include "fbpcf/mpc_framework/mpc_std_lib/oram/DummyDifferenceCalculator_impl.h"

--- a/fbpcf/mpc_framework/mpc_std_lib/oram/DummyDifferenceCalculatorFactory.h
+++ b/fbpcf/mpc_framework/mpc_std_lib/oram/DummyDifferenceCalculatorFactory.h
@@ -12,7 +12,7 @@
 #include "fbpcf/mpc_framework/mpc_std_lib/oram/DummyDifferenceCalculator.h"
 #include "fbpcf/mpc_framework/mpc_std_lib/oram/IDifferenceCalculatorFactory.h"
 
-namespace fbpcf::mpc_framework::mpc_std_lib::oram::insecure {
+namespace fbpcf::mpc_std_lib::oram::insecure {
 
 template <typename T, int8_t indicatorSumWidth>
 class DummyDifferenceCalculatorFactory final
@@ -37,4 +37,4 @@ class DummyDifferenceCalculatorFactory final
   engine::communication::IPartyCommunicationAgentFactory& factory_;
 };
 
-} // namespace fbpcf::mpc_framework::mpc_std_lib::oram::insecure
+} // namespace fbpcf::mpc_std_lib::oram::insecure

--- a/fbpcf/mpc_framework/mpc_std_lib/oram/DummyDifferenceCalculator_impl.h
+++ b/fbpcf/mpc_framework/mpc_std_lib/oram/DummyDifferenceCalculator_impl.h
@@ -9,7 +9,7 @@
 
 #include "fbpcf/mpc_framework/mpc_std_lib/util/util.h"
 
-namespace fbpcf::mpc_framework::mpc_std_lib::oram::insecure {
+namespace fbpcf::mpc_std_lib::oram::insecure {
 
 // this function calculate the difference(s) between two batches of values
 template <typename T, int8_t indicatorSumWidth>
@@ -77,4 +77,4 @@ DummyDifferenceCalculator<T, indicatorSumWidth>::calculateDifferenceBatch(
   return rst;
 }
 
-} // namespace fbpcf::mpc_framework::mpc_std_lib::oram::insecure
+} // namespace fbpcf::mpc_std_lib::oram::insecure

--- a/fbpcf/mpc_framework/mpc_std_lib/oram/DummyObliviousDeltaCalculator.cpp
+++ b/fbpcf/mpc_framework/mpc_std_lib/oram/DummyObliviousDeltaCalculator.cpp
@@ -10,7 +10,7 @@
 #include "fbpcf/mpc_framework/engine/util/util.h"
 #include "fbpcf/mpc_framework/mpc_std_lib/oram/DummyObliviousDeltaCalculator.h"
 
-namespace fbpcf::mpc_framework::mpc_std_lib::oram::insecure {
+namespace fbpcf::mpc_std_lib::oram::insecure {
 std::tuple<std::vector<__m128i>, std::vector<bool>, std::vector<bool>>
 DummyObliviousDeltaCalculator::calculateDelta(
     const std::vector<__m128i>& delta0Shares,
@@ -41,4 +41,4 @@ DummyObliviousDeltaCalculator::calculateDelta(
   return {delta, t0, t1};
 }
 
-} // namespace fbpcf::mpc_framework::mpc_std_lib::oram::insecure
+} // namespace fbpcf::mpc_std_lib::oram::insecure

--- a/fbpcf/mpc_framework/mpc_std_lib/oram/DummyObliviousDeltaCalculator.h
+++ b/fbpcf/mpc_framework/mpc_std_lib/oram/DummyObliviousDeltaCalculator.h
@@ -11,7 +11,7 @@
 #include "fbpcf/mpc_framework/engine/communication/IPartyCommunicationAgent.h"
 #include "fbpcf/mpc_framework/mpc_std_lib/oram/IObliviousDeltaCalculator.h"
 
-namespace fbpcf::mpc_framework::mpc_std_lib::oram::insecure {
+namespace fbpcf::mpc_std_lib::oram::insecure {
 
 /**
  * A dummy implementation of oblivious delta calculator
@@ -39,4 +39,4 @@ class DummyObliviousDeltaCalculator final : public IObliviousDeltaCalculator {
   std::unique_ptr<engine::communication::IPartyCommunicationAgent> agent_;
 };
 
-} // namespace fbpcf::mpc_framework::mpc_std_lib::oram::insecure
+} // namespace fbpcf::mpc_std_lib::oram::insecure

--- a/fbpcf/mpc_framework/mpc_std_lib/oram/DummyObliviousDeltaCalculatorFactory.h
+++ b/fbpcf/mpc_framework/mpc_std_lib/oram/DummyObliviousDeltaCalculatorFactory.h
@@ -12,7 +12,7 @@
 #include "fbpcf/mpc_framework/mpc_std_lib/oram/DummyObliviousDeltaCalculator.h"
 #include "fbpcf/mpc_framework/mpc_std_lib/oram/IObliviousDeltaCalculatorFactory.h"
 
-namespace fbpcf::mpc_framework::mpc_std_lib::oram::insecure {
+namespace fbpcf::mpc_std_lib::oram::insecure {
 
 class DummyObliviousDeltaCalculatorFactory final
     : public IObliviousDeltaCalculatorFactory {
@@ -32,4 +32,4 @@ class DummyObliviousDeltaCalculatorFactory final
   engine::communication::IPartyCommunicationAgentFactory& factory_;
 };
 
-} // namespace fbpcf::mpc_framework::mpc_std_lib::oram::insecure
+} // namespace fbpcf::mpc_std_lib::oram::insecure

--- a/fbpcf/mpc_framework/mpc_std_lib/oram/DummySinglePointArrayGenerator.cpp
+++ b/fbpcf/mpc_framework/mpc_std_lib/oram/DummySinglePointArrayGenerator.cpp
@@ -13,7 +13,7 @@
 #include "fbpcf/mpc_framework/engine/util/util.h"
 #include "fbpcf/mpc_framework/mpc_std_lib/util/util.h"
 
-namespace fbpcf::mpc_framework::mpc_std_lib::oram::insecure {
+namespace fbpcf::mpc_std_lib::oram::insecure {
 
 std::vector<std::pair<std::vector<bool>, std::vector<__m128i>>>
 DummySinglePointArrayGenerator::generateSinglePointArrays(
@@ -56,4 +56,4 @@ DummySinglePointArrayGenerator::generateSinglePointArrays(
   return rst;
 }
 
-} // namespace fbpcf::mpc_framework::mpc_std_lib::oram::insecure
+} // namespace fbpcf::mpc_std_lib::oram::insecure

--- a/fbpcf/mpc_framework/mpc_std_lib/oram/DummySinglePointArrayGenerator.h
+++ b/fbpcf/mpc_framework/mpc_std_lib/oram/DummySinglePointArrayGenerator.h
@@ -11,7 +11,7 @@
 #include "fbpcf/mpc_framework/engine/communication/IPartyCommunicationAgent.h"
 #include "fbpcf/mpc_framework/mpc_std_lib/oram/ISinglePointArrayGenerator.h"
 
-namespace fbpcf::mpc_framework::mpc_std_lib::oram::insecure {
+namespace fbpcf::mpc_std_lib::oram::insecure {
 
 /**
  * A dummy implementation of single point array generator
@@ -45,4 +45,4 @@ class DummySinglePointArrayGenerator final : public ISinglePointArrayGenerator {
   std::unique_ptr<engine::communication::IPartyCommunicationAgent> agent_;
 };
 
-} // namespace fbpcf::mpc_framework::mpc_std_lib::oram::insecure
+} // namespace fbpcf::mpc_std_lib::oram::insecure

--- a/fbpcf/mpc_framework/mpc_std_lib/oram/DummySinglePointArrayGeneratorFactory.h
+++ b/fbpcf/mpc_framework/mpc_std_lib/oram/DummySinglePointArrayGeneratorFactory.h
@@ -12,7 +12,7 @@
 #include "fbpcf/mpc_framework/mpc_std_lib/oram/DummySinglePointArrayGenerator.h"
 #include "fbpcf/mpc_framework/mpc_std_lib/oram/ISinglePointArrayGeneratorFactory.h"
 
-namespace fbpcf::mpc_framework::mpc_std_lib::oram::insecure {
+namespace fbpcf::mpc_std_lib::oram::insecure {
 
 class DummySinglePointArrayGeneratorFactory final
     : public ISinglePointArrayGeneratorFactory {
@@ -36,4 +36,4 @@ class DummySinglePointArrayGeneratorFactory final
   engine::communication::IPartyCommunicationAgentFactory& factory_;
 };
 
-} // namespace fbpcf::mpc_framework::mpc_std_lib::oram::insecure
+} // namespace fbpcf::mpc_std_lib::oram::insecure

--- a/fbpcf/mpc_framework/mpc_std_lib/oram/IDifferenceCalculator.h
+++ b/fbpcf/mpc_framework/mpc_std_lib/oram/IDifferenceCalculator.h
@@ -10,7 +10,7 @@
 #include <vector>
 #include "fbpcf/mpc_framework/mpc_std_lib/util/util.h"
 
-namespace fbpcf::mpc_framework::mpc_std_lib::oram {
+namespace fbpcf::mpc_std_lib::oram {
 
 /**
  * a Difference Calculator computes the difference between a randomly generated
@@ -55,4 +55,4 @@ class IDifferenceCalculator {
   virtual std::pair<uint64_t, uint64_t> getTrafficStatistics() const = 0;
 };
 
-} // namespace fbpcf::mpc_framework::mpc_std_lib::oram
+} // namespace fbpcf::mpc_std_lib::oram

--- a/fbpcf/mpc_framework/mpc_std_lib/oram/IDifferenceCalculatorFactory.h
+++ b/fbpcf/mpc_framework/mpc_std_lib/oram/IDifferenceCalculatorFactory.h
@@ -11,7 +11,7 @@
 #include "fbpcf/mpc_framework/engine/communication/IPartyCommunicationAgent.h"
 #include "fbpcf/mpc_framework/mpc_std_lib/oram/IDifferenceCalculator.h"
 
-namespace fbpcf::mpc_framework::mpc_std_lib::oram {
+namespace fbpcf::mpc_std_lib::oram {
 
 template <typename T>
 class IDifferenceCalculatorFactory {
@@ -21,4 +21,4 @@ class IDifferenceCalculatorFactory {
   virtual std::unique_ptr<IDifferenceCalculator<T>> create() = 0;
 };
 
-} // namespace fbpcf::mpc_framework::mpc_std_lib::oram
+} // namespace fbpcf::mpc_std_lib::oram

--- a/fbpcf/mpc_framework/mpc_std_lib/oram/IObliviousDeltaCalculator.h
+++ b/fbpcf/mpc_framework/mpc_std_lib/oram/IObliviousDeltaCalculator.h
@@ -10,7 +10,7 @@
 #include <emmintrin.h>
 #include <vector>
 
-namespace fbpcf::mpc_framework::mpc_std_lib::oram {
+namespace fbpcf::mpc_std_lib::oram {
 
 /**
  * an oblivious delta calculator obliviously choose between two secret-shared
@@ -38,4 +38,4 @@ class IObliviousDeltaCalculator {
   virtual std::pair<uint64_t, uint64_t> getTrafficStatistics() const = 0;
 };
 
-} // namespace fbpcf::mpc_framework::mpc_std_lib::oram
+} // namespace fbpcf::mpc_std_lib::oram

--- a/fbpcf/mpc_framework/mpc_std_lib/oram/IObliviousDeltaCalculatorFactory.h
+++ b/fbpcf/mpc_framework/mpc_std_lib/oram/IObliviousDeltaCalculatorFactory.h
@@ -11,7 +11,7 @@
 #include "fbpcf/mpc_framework/engine/communication/IPartyCommunicationAgent.h"
 #include "fbpcf/mpc_framework/mpc_std_lib/oram/IObliviousDeltaCalculator.h"
 
-namespace fbpcf::mpc_framework::mpc_std_lib::oram {
+namespace fbpcf::mpc_std_lib::oram {
 
 class IObliviousDeltaCalculatorFactory {
  public:
@@ -20,4 +20,4 @@ class IObliviousDeltaCalculatorFactory {
   virtual std::unique_ptr<IObliviousDeltaCalculator> create() = 0;
 };
 
-} // namespace fbpcf::mpc_framework::mpc_std_lib::oram
+} // namespace fbpcf::mpc_std_lib::oram

--- a/fbpcf/mpc_framework/mpc_std_lib/oram/ISinglePointArrayGenerator.h
+++ b/fbpcf/mpc_framework/mpc_std_lib/oram/ISinglePointArrayGenerator.h
@@ -11,7 +11,7 @@
 #include <cstdint>
 #include <vector>
 
-namespace fbpcf::mpc_framework::mpc_std_lib::oram {
+namespace fbpcf::mpc_std_lib::oram {
 
 /**
  * a single point array generator allow two parties jointly generate a pair of
@@ -42,4 +42,4 @@ class ISinglePointArrayGenerator {
   virtual std::pair<uint64_t, uint64_t> getTrafficStatistics() const = 0;
 };
 
-} // namespace fbpcf::mpc_framework::mpc_std_lib::oram
+} // namespace fbpcf::mpc_std_lib::oram

--- a/fbpcf/mpc_framework/mpc_std_lib/oram/ISinglePointArrayGeneratorFactory.h
+++ b/fbpcf/mpc_framework/mpc_std_lib/oram/ISinglePointArrayGeneratorFactory.h
@@ -10,7 +10,7 @@
 #include <memory>
 #include "fbpcf/mpc_framework/mpc_std_lib/oram/ISinglePointArrayGenerator.h"
 
-namespace fbpcf::mpc_framework::mpc_std_lib::oram {
+namespace fbpcf::mpc_std_lib::oram {
 
 class ISinglePointArrayGeneratorFactory {
  public:
@@ -19,4 +19,4 @@ class ISinglePointArrayGeneratorFactory {
   virtual std::unique_ptr<ISinglePointArrayGenerator> create() = 0;
 };
 
-} // namespace fbpcf::mpc_framework::mpc_std_lib::oram
+} // namespace fbpcf::mpc_std_lib::oram

--- a/fbpcf/mpc_framework/mpc_std_lib/oram/IWriteOnlyOram.h
+++ b/fbpcf/mpc_framework/mpc_std_lib/oram/IWriteOnlyOram.h
@@ -9,7 +9,7 @@
 
 #include <vector>
 
-namespace fbpcf::mpc_framework::mpc_std_lib::oram {
+namespace fbpcf::mpc_std_lib::oram {
 
 /*
  * a write-only oram for type T, T must be an addable type and there are
@@ -67,4 +67,4 @@ class IWriteOnlyOram {
   virtual std::pair<uint64_t, uint64_t> getTrafficStatistics() const = 0;
 };
 
-} // namespace fbpcf::mpc_framework::mpc_std_lib::oram
+} // namespace fbpcf::mpc_std_lib::oram

--- a/fbpcf/mpc_framework/mpc_std_lib/oram/IWriteOnlyOramFactory.h
+++ b/fbpcf/mpc_framework/mpc_std_lib/oram/IWriteOnlyOramFactory.h
@@ -10,7 +10,7 @@
 #include <memory>
 #include "fbpcf/mpc_framework/mpc_std_lib/oram/IWriteOnlyOram.h"
 
-namespace fbpcf::mpc_framework::mpc_std_lib::oram {
+namespace fbpcf::mpc_std_lib::oram {
 
 template <typename T>
 class IWriteOnlyOramFactory {
@@ -25,4 +25,4 @@ class IWriteOnlyOramFactory {
   virtual uint32_t getMaxBatchSize(size_t size, uint8_t concurrency) = 0;
 };
 
-} // namespace fbpcf::mpc_framework::mpc_std_lib::oram
+} // namespace fbpcf::mpc_std_lib::oram

--- a/fbpcf/mpc_framework/mpc_std_lib/oram/LinearOram.h
+++ b/fbpcf/mpc_framework/mpc_std_lib/oram/LinearOram.h
@@ -14,7 +14,7 @@
 #include "fbpcf/mpc_framework/mpc_std_lib/oram/IWriteOnlyOram.h"
 #include "fbpcf/mpc_framework/mpc_std_lib/util/util.h"
 
-namespace fbpcf::mpc_framework::mpc_std_lib::oram {
+namespace fbpcf::mpc_std_lib::oram {
 
 /**
  *A linear ORAM behaviors the same way as the ideal ORAM functionality when
@@ -115,6 +115,6 @@ class LinearOram final : public IWriteOnlyOram<T> {
       const frontend::Bit<true, schedulerId, true>& condition) const;
 };
 
-} // namespace fbpcf::mpc_framework::mpc_std_lib::oram
+} // namespace fbpcf::mpc_std_lib::oram
 
 #include "fbpcf/mpc_framework/mpc_std_lib/oram/LinearOram_impl.h"

--- a/fbpcf/mpc_framework/mpc_std_lib/oram/LinearOramFactory.h
+++ b/fbpcf/mpc_framework/mpc_std_lib/oram/LinearOramFactory.h
@@ -16,7 +16,7 @@
 #include "fbpcf/mpc_framework/mpc_std_lib/oram/IWriteOnlyOramFactory.h"
 #include "fbpcf/mpc_framework/mpc_std_lib/oram/LinearOram.h"
 
-namespace fbpcf::mpc_framework::mpc_std_lib::oram {
+namespace fbpcf::mpc_std_lib::oram {
 
 template <typename T, int schedulerId>
 class LinearOramFactory final : public IWriteOnlyOramFactory<T> {
@@ -68,15 +68,14 @@ std::unique_ptr<IWriteOnlyOramFactory<T>> getSecureLinearOramFactory(
     int32_t party0Id,
     int32_t party1Id,
     engine::communication::IPartyCommunicationAgentFactory& factory) {
-  return std::make_unique<
-      fbpcf::mpc_framework::mpc_std_lib::oram::LinearOramFactory<
-          fbpcf::mpc_framework::mpc_std_lib::util::AggregationValue,
-          schedulerId>>(
+  return std::make_unique<fbpcf::mpc_std_lib::oram::LinearOramFactory<
+      fbpcf::mpc_std_lib::util::AggregationValue,
+      schedulerId>>(
       amIParty0 ? IWriteOnlyOram<T>::Role::Alice : IWriteOnlyOram<T>::Role::Bob,
       amIParty0 ? party0Id : party0Id,
       amIParty0 ? party1Id : party0Id,
       factory,
-      std::make_unique<fbpcf::mpc_framework::engine::util::AesPrgFactory>());
+      std::make_unique<fbpcf::engine::util::AesPrgFactory>());
 }
 
-} // namespace fbpcf::mpc_framework::mpc_std_lib::oram
+} // namespace fbpcf::mpc_std_lib::oram

--- a/fbpcf/mpc_framework/mpc_std_lib/oram/LinearOram_impl.h
+++ b/fbpcf/mpc_framework/mpc_std_lib/oram/LinearOram_impl.h
@@ -11,7 +11,7 @@
 #include <stdexcept>
 #include "fbpcf/mpc_framework/mpc_std_lib/util/util.h"
 
-namespace fbpcf::mpc_framework::mpc_std_lib::oram {
+namespace fbpcf::mpc_std_lib::oram {
 
 template <typename T, int schedulerId>
 T LinearOram<T, schedulerId>::publicRead(size_t publicIndex, Role receiver)
@@ -144,4 +144,4 @@ LinearOram<T, schedulerId>::conditionalExpansionOneLayer(
   return rst;
 }
 
-} // namespace fbpcf::mpc_framework::mpc_std_lib::oram
+} // namespace fbpcf::mpc_std_lib::oram

--- a/fbpcf/mpc_framework/mpc_std_lib/oram/ObliviousDeltaCalculator.h
+++ b/fbpcf/mpc_framework/mpc_std_lib/oram/ObliviousDeltaCalculator.h
@@ -12,7 +12,7 @@
 #include "fbpcf/mpc_framework/mpc_std_lib/oram/IObliviousDeltaCalculator.h"
 #include "fbpcf/mpc_framework/mpc_std_lib/util/util.h"
 
-namespace fbpcf::mpc_framework::mpc_std_lib::oram {
+namespace fbpcf::mpc_std_lib::oram {
 
 /**
  * A secure implementation of oblivious delta calculator
@@ -49,6 +49,6 @@ class ObliviousDeltaCalculator final : public IObliviousDeltaCalculator {
   int32_t party1Id_;
 };
 
-} // namespace fbpcf::mpc_framework::mpc_std_lib::oram
+} // namespace fbpcf::mpc_std_lib::oram
 
 #include "fbpcf/mpc_framework/mpc_std_lib/oram/ObliviousDeltaCalculator_impl.h"

--- a/fbpcf/mpc_framework/mpc_std_lib/oram/ObliviousDeltaCalculatorFactory.h
+++ b/fbpcf/mpc_framework/mpc_std_lib/oram/ObliviousDeltaCalculatorFactory.h
@@ -12,7 +12,7 @@
 #include "fbpcf/mpc_framework/mpc_std_lib/oram/IObliviousDeltaCalculatorFactory.h"
 #include "fbpcf/mpc_framework/mpc_std_lib/oram/ObliviousDeltaCalculator.h"
 
-namespace fbpcf::mpc_framework::mpc_std_lib::oram {
+namespace fbpcf::mpc_std_lib::oram {
 
 template <int schedulerId>
 class ObliviousDeltaCalculatorFactory final
@@ -35,4 +35,4 @@ class ObliviousDeltaCalculatorFactory final
   int32_t party1Id_;
 };
 
-} // namespace fbpcf::mpc_framework::mpc_std_lib::oram
+} // namespace fbpcf::mpc_std_lib::oram

--- a/fbpcf/mpc_framework/mpc_std_lib/oram/ObliviousDeltaCalculator_impl.h
+++ b/fbpcf/mpc_framework/mpc_std_lib/oram/ObliviousDeltaCalculator_impl.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-namespace fbpcf::mpc_framework::mpc_std_lib::oram {
+namespace fbpcf::mpc_std_lib::oram {
 
 template <int schedulerId>
 std::tuple<std::vector<__m128i>, std::vector<bool>, std::vector<bool>>
@@ -72,4 +72,4 @@ ObliviousDeltaCalculator<schedulerId>::calculateDelta(
   return {delta, t0, t1};
 }
 
-} // namespace fbpcf::mpc_framework::mpc_std_lib::oram
+} // namespace fbpcf::mpc_std_lib::oram

--- a/fbpcf/mpc_framework/mpc_std_lib/oram/SinglePointArrayGenerator.cpp
+++ b/fbpcf/mpc_framework/mpc_std_lib/oram/SinglePointArrayGenerator.cpp
@@ -12,7 +12,7 @@
 #include "fbpcf/mpc_framework/engine/util/util.h"
 #include "fbpcf/mpc_framework/mpc_std_lib/util/util.h"
 
-namespace fbpcf::mpc_framework::mpc_std_lib::oram {
+namespace fbpcf::mpc_std_lib::oram {
 
 std::vector<std::pair<std::vector<bool>, std::vector<__m128i>>>
 SinglePointArrayGenerator::generateSinglePointArrays(
@@ -94,4 +94,4 @@ ISinglePointArrayGenerator::ArrayType SinglePointArrayGenerator::expandArray(
   return rst;
 }
 
-} // namespace fbpcf::mpc_framework::mpc_std_lib::oram
+} // namespace fbpcf::mpc_std_lib::oram

--- a/fbpcf/mpc_framework/mpc_std_lib/oram/SinglePointArrayGenerator.h
+++ b/fbpcf/mpc_framework/mpc_std_lib/oram/SinglePointArrayGenerator.h
@@ -17,7 +17,7 @@
 #include "fbpcf/mpc_framework/mpc_std_lib/oram/IObliviousDeltaCalculator.h"
 #include "fbpcf/mpc_framework/mpc_std_lib/oram/ISinglePointArrayGenerator.h"
 
-namespace fbpcf::mpc_framework::mpc_std_lib::oram {
+namespace fbpcf::mpc_std_lib::oram {
 
 /**
  * A single point array generator allow two parties jointly generate a pair of
@@ -59,4 +59,4 @@ class SinglePointArrayGenerator final : public ISinglePointArrayGenerator {
   std::unique_ptr<engine::util::Expander> expander_;
 };
 
-} // namespace fbpcf::mpc_framework::mpc_std_lib::oram
+} // namespace fbpcf::mpc_std_lib::oram

--- a/fbpcf/mpc_framework/mpc_std_lib/oram/SinglePointArrayGeneratorFactory.h
+++ b/fbpcf/mpc_framework/mpc_std_lib/oram/SinglePointArrayGeneratorFactory.h
@@ -13,7 +13,7 @@
 #include "fbpcf/mpc_framework/mpc_std_lib/oram/ISinglePointArrayGeneratorFactory.h"
 #include "fbpcf/mpc_framework/mpc_std_lib/oram/SinglePointArrayGenerator.h"
 
-namespace fbpcf::mpc_framework::mpc_std_lib::oram {
+namespace fbpcf::mpc_std_lib::oram {
 
 class SinglePointArrayGeneratorFactory final
     : public ISinglePointArrayGeneratorFactory {
@@ -35,4 +35,4 @@ class SinglePointArrayGeneratorFactory final
   std::unique_ptr<IObliviousDeltaCalculatorFactory> obliviousCalculatrFactory_;
 };
 
-} // namespace fbpcf::mpc_framework::mpc_std_lib::oram
+} // namespace fbpcf::mpc_std_lib::oram

--- a/fbpcf/mpc_framework/mpc_std_lib/oram/WriteOnlyOram.h
+++ b/fbpcf/mpc_framework/mpc_std_lib/oram/WriteOnlyOram.h
@@ -13,7 +13,7 @@
 #include "fbpcf/mpc_framework/mpc_std_lib/oram/IWriteOnlyOram.h"
 #include "fbpcf/mpc_framework/mpc_std_lib/util/util.h"
 
-namespace fbpcf::mpc_framework::mpc_std_lib::oram {
+namespace fbpcf::mpc_std_lib::oram {
 
 template <typename T>
 class WriteOnlyOram final : public IWriteOnlyOram<T> {
@@ -77,6 +77,6 @@ class WriteOnlyOram final : public IWriteOnlyOram<T> {
   std::vector<T> memory_;
 };
 
-} // namespace fbpcf::mpc_framework::mpc_std_lib::oram
+} // namespace fbpcf::mpc_std_lib::oram
 
 #include "fbpcf/mpc_framework/mpc_std_lib/oram/WriteOnlyOram_impl.h"

--- a/fbpcf/mpc_framework/mpc_std_lib/oram/WriteOnlyOramFactory.h
+++ b/fbpcf/mpc_framework/mpc_std_lib/oram/WriteOnlyOramFactory.h
@@ -17,7 +17,7 @@
 #include "fbpcf/mpc_framework/mpc_std_lib/oram/SinglePointArrayGeneratorFactory.h"
 #include "fbpcf/mpc_framework/mpc_std_lib/oram/WriteOnlyOram.h"
 
-namespace fbpcf::mpc_framework::mpc_std_lib::oram {
+namespace fbpcf::mpc_std_lib::oram {
 
 template <typename T>
 class WriteOnlyOramFactory final : public IWriteOnlyOramFactory<T> {
@@ -94,4 +94,4 @@ std::unique_ptr<IWriteOnlyOramFactory<T>> getSecureWriteOnlyOramFactory(
           amIParty0, party0Id, party1Id));
 }
 
-} // namespace fbpcf::mpc_framework::mpc_std_lib::oram
+} // namespace fbpcf::mpc_std_lib::oram

--- a/fbpcf/mpc_framework/mpc_std_lib/oram/WriteOnlyOram_impl.h
+++ b/fbpcf/mpc_framework/mpc_std_lib/oram/WriteOnlyOram_impl.h
@@ -11,7 +11,7 @@
 #include <stdexcept>
 #include "fbpcf/mpc_framework/mpc_std_lib/util/util.h"
 
-namespace fbpcf::mpc_framework::mpc_std_lib::oram {
+namespace fbpcf::mpc_std_lib::oram {
 
 template <typename T>
 T WriteOnlyOram<T>::publicRead(size_t publicIndex, Role receiver) const {
@@ -113,4 +113,4 @@ std::vector<std::vector<T>> WriteOnlyOram<T>::generateMasks(
   return rst;
 }
 
-} // namespace fbpcf::mpc_framework::mpc_std_lib::oram
+} // namespace fbpcf::mpc_std_lib::oram

--- a/fbpcf/mpc_framework/mpc_std_lib/oram/test/DifferenceCalculatorTest.cpp
+++ b/fbpcf/mpc_framework/mpc_std_lib/oram/test/DifferenceCalculatorTest.cpp
@@ -22,7 +22,7 @@
 #include "fbpcf/mpc_framework/mpc_std_lib/util/test/util.h"
 #include "fbpcf/mpc_framework/mpc_std_lib/util/util.h"
 
-namespace fbpcf::mpc_framework::mpc_std_lib::oram {
+namespace fbpcf::mpc_std_lib::oram {
 
 template <typename T>
 struct InputType {
@@ -169,4 +169,4 @@ TEST(DifferenceCalculatorTest, testDifferenceCalculator) {
           1>>(false, 0, 1));
 }
 
-} // namespace fbpcf::mpc_framework::mpc_std_lib::oram
+} // namespace fbpcf::mpc_std_lib::oram

--- a/fbpcf/mpc_framework/mpc_std_lib/oram/test/ObliviousDeltaCalculatorTest.cpp
+++ b/fbpcf/mpc_framework/mpc_std_lib/oram/test/ObliviousDeltaCalculatorTest.cpp
@@ -22,7 +22,7 @@
 #include "fbpcf/mpc_framework/mpc_std_lib/oram/test/util.h"
 #include "fbpcf/mpc_framework/test/TestHelper.h"
 
-namespace fbpcf::mpc_framework::mpc_std_lib::oram {
+namespace fbpcf::mpc_std_lib::oram {
 
 struct ObliviousDeltaCalculatorInputType {
   std::vector<__m128i> delta0Shares;
@@ -99,7 +99,7 @@ OutputType obliviousDeltaCalculatorHelper(
 }
 
 void testEq(const OutputType& src1, const OutputType& src2) {
-  mpc_framework::testEq(std::get<0>(src1), std::get<0>(src2));
+  fbpcf::testEq(std::get<0>(src1), std::get<0>(src2));
   testVectorEq(std::get<1>(src1), std::get<1>(src2));
   testVectorEq(std::get<2>(src1), std::get<2>(src2));
 }
@@ -147,4 +147,4 @@ TEST(ObliviousDeltaCalculatorTest, testObliviousDeltaCalculator) {
   testObliviousDeltaCalculator(std::move(factory0), std::move(factory1));
 }
 
-} // namespace fbpcf::mpc_framework::mpc_std_lib::oram
+} // namespace fbpcf::mpc_std_lib::oram

--- a/fbpcf/mpc_framework/mpc_std_lib/oram/test/SinglePointArrayGeneratorTest.cpp
+++ b/fbpcf/mpc_framework/mpc_std_lib/oram/test/SinglePointArrayGeneratorTest.cpp
@@ -27,7 +27,7 @@
 #include "fbpcf/mpc_framework/mpc_std_lib/oram/test/util.h"
 #include "fbpcf/mpc_framework/mpc_std_lib/util/util.h"
 
-namespace fbpcf::mpc_framework::mpc_std_lib::oram {
+namespace fbpcf::mpc_std_lib::oram {
 
 std::tuple<std::vector<bool>, std::vector<bool>, uint32_t>
 generateSharedRandomBoolVector(size_t length) {
@@ -150,4 +150,4 @@ TEST(
   testSinglePointArrayGenerator(std::move(factory0), std::move(factory1));
 }
 
-} // namespace fbpcf::mpc_framework::mpc_std_lib::oram
+} // namespace fbpcf::mpc_std_lib::oram

--- a/fbpcf/mpc_framework/mpc_std_lib/oram/test/WriteOnlyORAMTest.cpp
+++ b/fbpcf/mpc_framework/mpc_std_lib/oram/test/WriteOnlyORAMTest.cpp
@@ -34,7 +34,7 @@
 #include "fbpcf/mpc_framework/mpc_std_lib/util/test/util.h"
 #include "fbpcf/mpc_framework/mpc_std_lib/util/util.h"
 
-namespace fbpcf::mpc_framework::mpc_std_lib::oram {
+namespace fbpcf::mpc_std_lib::oram {
 
 struct WritingType {
   std::vector<std::vector<bool>> indexShares;
@@ -327,4 +327,4 @@ TEST(LinearORAMTest, TestLinearOram) {
       *factories[0], *factories[1]);
 }
 
-} // namespace fbpcf::mpc_framework::mpc_std_lib::oram
+} // namespace fbpcf::mpc_std_lib::oram

--- a/fbpcf/mpc_framework/mpc_std_lib/oram/test/util.h
+++ b/fbpcf/mpc_framework/mpc_std_lib/oram/test/util.h
@@ -23,7 +23,7 @@
 #include "fbpcf/mpc_framework/scheduler/WireKeeper.h"
 #include "fbpcf/mpc_framework/test/TestHelper.h"
 
-namespace fbpcf::mpc_framework::mpc_std_lib::oram {
+namespace fbpcf::mpc_std_lib::oram {
 
 inline std::pair<std::vector<uint32_t>, std::vector<std::vector<bool>>>
 generateTestDataForComparison(uint32_t batchSize, uint32_t range) {
@@ -72,4 +72,4 @@ comparisonTestHelper(
   return {rst, value};
 }
 
-} // namespace fbpcf::mpc_framework::mpc_std_lib::oram
+} // namespace fbpcf::mpc_std_lib::oram

--- a/fbpcf/mpc_framework/mpc_std_lib/shuffler/IShuffler.h
+++ b/fbpcf/mpc_framework/mpc_std_lib/shuffler/IShuffler.h
@@ -9,7 +9,7 @@
 
 #include "fbpcf/mpc_framework/mpc_std_lib/util/util.h"
 
-namespace fbpcf::mpc_framework::mpc_std_lib::shuffler {
+namespace fbpcf::mpc_std_lib::shuffler {
 
 /*
  * A shuffler will shuffle a number of values, and output them in
@@ -35,4 +35,4 @@ class IShuffler {
   virtual T shuffle(const T& src) const = 0;
 };
 
-} // namespace fbpcf::mpc_framework::mpc_std_lib::shuffler
+} // namespace fbpcf::mpc_std_lib::shuffler

--- a/fbpcf/mpc_framework/mpc_std_lib/shuffler/IShufflerFactory.h
+++ b/fbpcf/mpc_framework/mpc_std_lib/shuffler/IShufflerFactory.h
@@ -9,7 +9,7 @@
 
 #include "fbpcf/mpc_framework/mpc_std_lib/shuffler/IShuffler.h"
 
-namespace fbpcf::mpc_framework::mpc_std_lib::shuffler {
+namespace fbpcf::mpc_std_lib::shuffler {
 
 template <typename T>
 class IShufflerFactory {
@@ -18,4 +18,4 @@ class IShufflerFactory {
   virtual std::unique_ptr<IShuffler<T>> create() = 0;
 };
 
-} // namespace fbpcf::mpc_framework::mpc_std_lib::shuffler
+} // namespace fbpcf::mpc_std_lib::shuffler

--- a/fbpcf/mpc_framework/mpc_std_lib/shuffler/NonShuffler.h
+++ b/fbpcf/mpc_framework/mpc_std_lib/shuffler/NonShuffler.h
@@ -9,7 +9,7 @@
 
 #include "fbpcf/mpc_framework/mpc_std_lib/shuffler/IShuffler.h"
 
-namespace fbpcf::mpc_framework::mpc_std_lib::shuffler::insecure {
+namespace fbpcf::mpc_std_lib::shuffler::insecure {
 
 /**
  * This shuffler doesn't do anything but simply output the input. It is only
@@ -23,4 +23,4 @@ class NonShuffler final : public IShuffler<T> {
   }
 };
 
-} // namespace fbpcf::mpc_framework::mpc_std_lib::shuffler::insecure
+} // namespace fbpcf::mpc_std_lib::shuffler::insecure

--- a/fbpcf/mpc_framework/mpc_std_lib/shuffler/NonShufflerFactory.h
+++ b/fbpcf/mpc_framework/mpc_std_lib/shuffler/NonShufflerFactory.h
@@ -10,7 +10,7 @@
 #include "fbpcf/mpc_framework/mpc_std_lib/shuffler/IShufflerFactory.h"
 #include "fbpcf/mpc_framework/mpc_std_lib/shuffler/NonShuffler.h"
 
-namespace fbpcf::mpc_framework::mpc_std_lib::shuffler::insecure {
+namespace fbpcf::mpc_std_lib::shuffler::insecure {
 
 template <typename T>
 class NonShufflerFactory final : public IShufflerFactory<T> {
@@ -20,4 +20,4 @@ class NonShufflerFactory final : public IShufflerFactory<T> {
   }
 };
 
-} // namespace fbpcf::mpc_framework::mpc_std_lib::shuffler::insecure
+} // namespace fbpcf::mpc_std_lib::shuffler::insecure

--- a/fbpcf/mpc_framework/mpc_std_lib/util/aggregationValue_impl.h
+++ b/fbpcf/mpc_framework/mpc_std_lib/util/aggregationValue_impl.h
@@ -13,7 +13,7 @@
 #include <random>
 #include <stdexcept>
 
-namespace fbpcf::mpc_framework::mpc_std_lib::util {
+namespace fbpcf::mpc_std_lib::util {
 
 /**
  * functions added here are helpers to support a write-only ORAM for
@@ -273,4 +273,4 @@ class MpcAdapters<AggregationValue, schedulerId> {
   }
 };
 
-} // namespace fbpcf::mpc_framework::mpc_std_lib::util
+} // namespace fbpcf::mpc_std_lib::util

--- a/fbpcf/mpc_framework/mpc_std_lib/util/test/UtilFunctionTests.cpp
+++ b/fbpcf/mpc_framework/mpc_std_lib/util/test/UtilFunctionTests.cpp
@@ -20,7 +20,7 @@
 #include "fbpcf/mpc_framework/mpc_std_lib/util/test/util.h"
 #include "fbpcf/mpc_framework/mpc_std_lib/util/util.h"
 
-namespace fbpcf::mpc_framework::mpc_std_lib::util {
+namespace fbpcf::mpc_std_lib::util {
 
 template <typename T>
 void testConvertingBits() {
@@ -49,4 +49,4 @@ TEST(ConvertingBitsTest, testConvertingBitsForM128iVector) {
   testEq(v, convertedV);
 }
 
-} // namespace fbpcf::mpc_framework::mpc_std_lib::util
+} // namespace fbpcf::mpc_std_lib::util

--- a/fbpcf/mpc_framework/mpc_std_lib/util/test/util.h
+++ b/fbpcf/mpc_framework/mpc_std_lib/util/test/util.h
@@ -16,7 +16,7 @@
 #include "fbpcf/mpc_framework/mpc_std_lib/util/util.h"
 #include "fbpcf/mpc_framework/test/TestHelper.h"
 
-namespace fbpcf::mpc_framework::mpc_std_lib::util {
+namespace fbpcf::mpc_std_lib::util {
 // the 3 returned valeus are: true value, first share, second share
 template <typename T>
 std::tuple<T, T, T> getRandomData(std::mt19937_64& e);
@@ -54,4 +54,4 @@ getRandomData<AggregationValue>(std::mt19937_64& e) {
   return {value, valueShare0, valueShare1};
 }
 
-} // namespace fbpcf::mpc_framework::mpc_std_lib::util
+} // namespace fbpcf::mpc_std_lib::util

--- a/fbpcf/mpc_framework/mpc_std_lib/util/uint32_impl.h
+++ b/fbpcf/mpc_framework/mpc_std_lib/util/uint32_impl.h
@@ -12,7 +12,7 @@
 #include <cstdint>
 #include <stdexcept>
 
-namespace fbpcf::mpc_framework::mpc_std_lib::util {
+namespace fbpcf::mpc_std_lib::util {
 
 template <>
 class Adapters<uint32_t> {
@@ -122,4 +122,4 @@ MpcAdapters<uint32_t, schedulerId>::obliviousSwap(
   return {rst1, rst2};
 }
 
-} // namespace fbpcf::mpc_framework::mpc_std_lib::util
+} // namespace fbpcf::mpc_std_lib::util

--- a/fbpcf/mpc_framework/mpc_std_lib/util/util.cpp
+++ b/fbpcf/mpc_framework/mpc_std_lib/util/util.cpp
@@ -9,7 +9,7 @@
 #include <smmintrin.h>
 #include <stdexcept>
 
-namespace fbpcf::mpc_framework::mpc_std_lib::util {
+namespace fbpcf::mpc_std_lib::util {
 
 std::vector<bool> convertToBits(__m128i src) {
   std::vector<bool> rst(128);
@@ -63,4 +63,4 @@ std::vector<__m128i> convertFromBits(
   return rst;
 }
 
-} // namespace fbpcf::mpc_framework::mpc_std_lib::util
+} // namespace fbpcf::mpc_std_lib::util

--- a/fbpcf/mpc_framework/mpc_std_lib/util/util.h
+++ b/fbpcf/mpc_framework/mpc_std_lib/util/util.h
@@ -13,7 +13,7 @@
 #include "fbpcf/mpc_framework/frontend/Bit.h"
 #include "fbpcf/mpc_framework/frontend/Int.h"
 
-namespace fbpcf::mpc_framework::mpc_std_lib::util {
+namespace fbpcf::mpc_std_lib::util {
 
 /*
  * these helpers are for non-MPC part
@@ -61,7 +61,7 @@ std::vector<std::vector<bool>> convertToBits(const std::vector<__m128i>& src);
 
 std::vector<__m128i> convertFromBits(const std::vector<std::vector<bool>>& src);
 
-} // namespace fbpcf::mpc_framework::mpc_std_lib::util
+} // namespace fbpcf::mpc_std_lib::util
 
 #include "fbpcf/mpc_framework/mpc_std_lib/util/uint32_impl.h"
 

--- a/fbpcf/mpc_framework/scheduler/EagerScheduler.cpp
+++ b/fbpcf/mpc_framework/scheduler/EagerScheduler.cpp
@@ -9,7 +9,7 @@
 #include <stdexcept>
 #include <string>
 
-namespace fbpcf::mpc_framework::scheduler {
+namespace fbpcf::scheduler {
 
 EagerScheduler::EagerScheduler(
     std::unique_ptr<engine::ISecretShareEngine> engine,
@@ -310,4 +310,4 @@ std::pair<uint64_t, uint64_t> EagerScheduler::getTrafficStatistics() const {
   return engine_->getTrafficStatistics();
 }
 
-} // namespace fbpcf::mpc_framework::scheduler
+} // namespace fbpcf::scheduler

--- a/fbpcf/mpc_framework/scheduler/EagerScheduler.h
+++ b/fbpcf/mpc_framework/scheduler/EagerScheduler.h
@@ -11,7 +11,7 @@
 #include "fbpcf/mpc_framework/scheduler/IScheduler.h"
 #include "fbpcf/mpc_framework/scheduler/IWireKeeper.h"
 
-namespace fbpcf::mpc_framework::scheduler {
+namespace fbpcf::scheduler {
 
 /**
  * An "eager" scheduler immediately carries out all computations upon
@@ -298,4 +298,4 @@ class EagerScheduler final : public IScheduler {
   std::unique_ptr<IWireKeeper> wireKeeper_;
 };
 
-} // namespace fbpcf::mpc_framework::scheduler
+} // namespace fbpcf::scheduler

--- a/fbpcf/mpc_framework/scheduler/IAllocator.h
+++ b/fbpcf/mpc_framework/scheduler/IAllocator.h
@@ -14,7 +14,7 @@
  * An instance of this class provides operations for allocating and freeing
  * memory.
  */
-namespace fbpcf::mpc_framework::scheduler {
+namespace fbpcf::scheduler {
 
 template <typename T>
 class IAllocator {
@@ -43,4 +43,4 @@ class IAllocator {
   }
 };
 
-} // namespace fbpcf::mpc_framework::scheduler
+} // namespace fbpcf::scheduler

--- a/fbpcf/mpc_framework/scheduler/IArithmeticScheduler.h
+++ b/fbpcf/mpc_framework/scheduler/IArithmeticScheduler.h
@@ -9,7 +9,7 @@
 
 #include "fbpcf/mpc_framework/scheduler/IScheduler.h"
 
-namespace fbpcf::mpc_framework::scheduler {
+namespace fbpcf::scheduler {
 
 class IArithmeticScheduler : public IScheduler {
   /**
@@ -282,4 +282,4 @@ class IArithmeticScheduler : public IScheduler {
   virtual void decreaseReferenceCountBatch(WireId<Arithmetic> id) = 0;
 };
 
-} // namespace fbpcf::mpc_framework::scheduler
+} // namespace fbpcf::scheduler

--- a/fbpcf/mpc_framework/scheduler/IScheduler.h
+++ b/fbpcf/mpc_framework/scheduler/IScheduler.h
@@ -12,7 +12,7 @@
 #include <optional>
 #include <vector>
 
-namespace fbpcf::mpc_framework::scheduler {
+namespace fbpcf::scheduler {
 /**
  * A scheduler is the object that process all frontend computation.
  * It takes in computation requests from the frontend, (possibly passes these
@@ -424,4 +424,4 @@ class SchedulerKeeper {
   inline static std::unique_ptr<IScheduler> scheduler_;
 };
 
-} // namespace fbpcf::mpc_framework::scheduler
+} // namespace fbpcf::scheduler

--- a/fbpcf/mpc_framework/scheduler/IWireKeeper.h
+++ b/fbpcf/mpc_framework/scheduler/IWireKeeper.h
@@ -12,7 +12,7 @@
 
 #include "fbpcf/mpc_framework/scheduler/IScheduler.h"
 
-namespace fbpcf::mpc_framework::scheduler {
+namespace fbpcf::scheduler {
 /**
  * A wire keeper is the object that stores all the live wires and free
  * upon request.
@@ -166,4 +166,4 @@ class IWireKeeper {
   };
 };
 
-} // namespace fbpcf::mpc_framework::scheduler
+} // namespace fbpcf::scheduler

--- a/fbpcf/mpc_framework/scheduler/LazyScheduler.cpp
+++ b/fbpcf/mpc_framework/scheduler/LazyScheduler.cpp
@@ -16,7 +16,7 @@
 #include "fbpcf/mpc_framework/scheduler/gate_keeper/IGate.h"
 #include "fbpcf/mpc_framework/scheduler/gate_keeper/INormalGate.h"
 
-namespace fbpcf::mpc_framework::scheduler {
+namespace fbpcf::scheduler {
 
 LazyScheduler::LazyScheduler(
     std::unique_ptr<engine::ISecretShareEngine> engine,
@@ -323,4 +323,4 @@ void LazyScheduler::executeOneLevel() {
   }
 }
 
-} // namespace fbpcf::mpc_framework::scheduler
+} // namespace fbpcf::scheduler

--- a/fbpcf/mpc_framework/scheduler/LazyScheduler.h
+++ b/fbpcf/mpc_framework/scheduler/LazyScheduler.h
@@ -12,7 +12,7 @@
 #include "fbpcf/mpc_framework/scheduler/IWireKeeper.h"
 #include "fbpcf/mpc_framework/scheduler/gate_keeper/IGateKeeper.h"
 
-namespace fbpcf::mpc_framework::scheduler {
+namespace fbpcf::scheduler {
 
 /**
  * A "lazy" scheduler decouples the execution of the frontend
@@ -315,4 +315,4 @@ class LazyScheduler final : public IScheduler {
   void executeOneLevel();
 };
 
-} // namespace fbpcf::mpc_framework::scheduler
+} // namespace fbpcf::scheduler

--- a/fbpcf/mpc_framework/scheduler/NetworkPlaintextScheduler.cpp
+++ b/fbpcf/mpc_framework/scheduler/NetworkPlaintextScheduler.cpp
@@ -11,7 +11,7 @@
 #include <fbpcf/mpc_framework/scheduler/PlaintextScheduler.h>
 #include "fbpcf/mpc_framework/scheduler/NetworkPlaintextScheduler.h"
 
-namespace fbpcf::mpc_framework::scheduler {
+namespace fbpcf::scheduler {
 
 NetworkPlaintextScheduler::NetworkPlaintextScheduler(
     int myId,
@@ -123,4 +123,4 @@ std::vector<bool> NetworkPlaintextScheduler::extractBooleanSecretShareBatch(
   }
 }
 
-} // namespace fbpcf::mpc_framework::scheduler
+} // namespace fbpcf::scheduler

--- a/fbpcf/mpc_framework/scheduler/NetworkPlaintextScheduler.h
+++ b/fbpcf/mpc_framework/scheduler/NetworkPlaintextScheduler.h
@@ -15,7 +15,7 @@
 #include "fbpcf/mpc_framework/scheduler/IScheduler.h"
 #include "fbpcf/mpc_framework/scheduler/IWireKeeper.h"
 
-namespace fbpcf::mpc_framework::scheduler {
+namespace fbpcf::scheduler {
 
 /**
  * A scheduler that carries out computations in plaintext over the network.
@@ -93,4 +93,4 @@ class NetworkPlaintextScheduler final : public PlaintextScheduler {
           agentMap_;
 };
 
-} // namespace fbpcf::mpc_framework::scheduler
+} // namespace fbpcf::scheduler

--- a/fbpcf/mpc_framework/scheduler/PlaintextScheduler.cpp
+++ b/fbpcf/mpc_framework/scheduler/PlaintextScheduler.cpp
@@ -10,7 +10,7 @@
 
 #include "fbpcf/mpc_framework/scheduler/PlaintextScheduler.h"
 
-namespace fbpcf::mpc_framework::scheduler {
+namespace fbpcf::scheduler {
 
 PlaintextScheduler::PlaintextScheduler(std::unique_ptr<IWireKeeper> wireKeeper)
     : wireKeeper_{std::move(wireKeeper)} {}
@@ -330,4 +330,4 @@ PlaintextScheduler::validateAndComputeBatchCompositeAND(
   gateCounter += leftValue.size() * rights.size();
   return returnWires;
 }
-} // namespace fbpcf::mpc_framework::scheduler
+} // namespace fbpcf::scheduler

--- a/fbpcf/mpc_framework/scheduler/PlaintextScheduler.h
+++ b/fbpcf/mpc_framework/scheduler/PlaintextScheduler.h
@@ -11,7 +11,7 @@
 #include "fbpcf/mpc_framework/scheduler/IScheduler.h"
 #include "fbpcf/mpc_framework/scheduler/IWireKeeper.h"
 
-namespace fbpcf::mpc_framework::scheduler {
+namespace fbpcf::scheduler {
 /**
  * A plaintext scheduler will simply keep a book of all wires, and immediately
  * carry out all computations upon request without an underlying engine. This
@@ -315,4 +315,4 @@ class PlaintextScheduler : public IScheduler {
       uint64_t& gateCounter);
 };
 
-} // namespace fbpcf::mpc_framework::scheduler
+} // namespace fbpcf::scheduler

--- a/fbpcf/mpc_framework/scheduler/SchedulerHelper.h
+++ b/fbpcf/mpc_framework/scheduler/SchedulerHelper.h
@@ -19,7 +19,7 @@
 #include "fbpcf/mpc_framework/scheduler/WireKeeper.h"
 #include "fbpcf/mpc_framework/scheduler/gate_keeper/GateKeeper.h"
 
-namespace fbpcf::mpc_framework::scheduler {
+namespace fbpcf::scheduler {
 
 template <bool unsafe>
 inline std::unique_ptr<IScheduler> createPlaintextScheduler(
@@ -132,4 +132,4 @@ inline std::unique_ptr<IScheduler> createLazySchedulerWithInsecureEngine(
       std::make_unique<GateKeeper>(wireKeeper));
 }
 
-} // namespace fbpcf::mpc_framework::scheduler
+} // namespace fbpcf::scheduler

--- a/fbpcf/mpc_framework/scheduler/UnorderedMapAllocator.h
+++ b/fbpcf/mpc_framework/scheduler/UnorderedMapAllocator.h
@@ -11,7 +11,7 @@
 
 #include "fbpcf/mpc_framework/scheduler/IAllocator.h"
 
-namespace fbpcf::mpc_framework::scheduler {
+namespace fbpcf::scheduler {
 
 /**
  * This class uses an std::unordered_map as its underlying storage.
@@ -65,4 +65,4 @@ class UnorderedMapAllocator final : public IAllocator<T> {
   uint64_t nextId_ = 1;
 };
 
-} // namespace fbpcf::mpc_framework::scheduler
+} // namespace fbpcf::scheduler

--- a/fbpcf/mpc_framework/scheduler/VectorArenaAllocator.h
+++ b/fbpcf/mpc_framework/scheduler/VectorArenaAllocator.h
@@ -15,7 +15,7 @@
 
 #include "fbpcf/mpc_framework/scheduler/IAllocator.h"
 
-namespace fbpcf::mpc_framework::scheduler {
+namespace fbpcf::scheduler {
 
 /**
  * This class provides access to a large, contiguous block of memory that is
@@ -116,4 +116,4 @@ class VectorArenaAllocator final : public IAllocator<T> {
   }
 };
 
-} // namespace fbpcf::mpc_framework::scheduler
+} // namespace fbpcf::scheduler

--- a/fbpcf/mpc_framework/scheduler/WireKeeper.cpp
+++ b/fbpcf/mpc_framework/scheduler/WireKeeper.cpp
@@ -12,7 +12,7 @@
 #include <string>
 #include "fbpcf/mpc_framework/scheduler/IScheduler.h"
 
-namespace fbpcf::mpc_framework::scheduler {
+namespace fbpcf::scheduler {
 
 IScheduler::WireId<IScheduler::Boolean> WireKeeper::allocateBooleanValue(
     bool v,
@@ -206,4 +206,4 @@ void WireKeeper::decreaseBatchReferenceCount(
     intBatchAllocator_->free(id.getId());
   }
 }
-} // namespace fbpcf::mpc_framework::scheduler
+} // namespace fbpcf::scheduler

--- a/fbpcf/mpc_framework/scheduler/WireKeeper.h
+++ b/fbpcf/mpc_framework/scheduler/WireKeeper.h
@@ -20,7 +20,7 @@
 #include "fbpcf/mpc_framework/scheduler/UnorderedMapAllocator.h"
 #include "fbpcf/mpc_framework/scheduler/VectorArenaAllocator.h"
 
-namespace fbpcf::mpc_framework::scheduler {
+namespace fbpcf::scheduler {
 
 class WireKeeper final : public IWireKeeper {
  public:
@@ -245,4 +245,4 @@ class WireKeeper final : public IWireKeeper {
       intBatchAllocator_;
 };
 
-} // namespace fbpcf::mpc_framework::scheduler
+} // namespace fbpcf::scheduler

--- a/fbpcf/mpc_framework/scheduler/gate_keeper/BatchCompositeGate.h
+++ b/fbpcf/mpc_framework/scheduler/gate_keeper/BatchCompositeGate.h
@@ -13,7 +13,7 @@
 
 #include "fbpcf/mpc_framework/scheduler/gate_keeper/ICompositeGate.h"
 
-namespace fbpcf::mpc_framework::scheduler {
+namespace fbpcf::scheduler {
 
 class BatchCompositeGate final : public ICompositeGate {
  public:
@@ -95,4 +95,4 @@ class BatchCompositeGate final : public ICompositeGate {
   }
 };
 
-} // namespace fbpcf::mpc_framework::scheduler
+} // namespace fbpcf::scheduler

--- a/fbpcf/mpc_framework/scheduler/gate_keeper/BatchNormalGate.h
+++ b/fbpcf/mpc_framework/scheduler/gate_keeper/BatchNormalGate.h
@@ -11,7 +11,7 @@
 
 #include "fbpcf/mpc_framework/scheduler/gate_keeper/INormalGate.h"
 
-namespace fbpcf::mpc_framework::scheduler {
+namespace fbpcf::scheduler {
 
 template <IScheduler::WireType T>
 class BatchNormalGate final : public INormalGate<T> {
@@ -168,4 +168,4 @@ class BatchNormalGate final : public INormalGate<T> {
   }
 };
 
-} // namespace fbpcf::mpc_framework::scheduler
+} // namespace fbpcf::scheduler

--- a/fbpcf/mpc_framework/scheduler/gate_keeper/CompositeGate.h
+++ b/fbpcf/mpc_framework/scheduler/gate_keeper/CompositeGate.h
@@ -13,7 +13,7 @@
 
 #include "fbpcf/mpc_framework/scheduler/gate_keeper/ICompositeGate.h"
 
-namespace fbpcf::mpc_framework::scheduler {
+namespace fbpcf::scheduler {
 
 class CompositeGate final : public ICompositeGate {
  public:
@@ -94,4 +94,4 @@ class CompositeGate final : public ICompositeGate {
   }
 };
 
-} // namespace fbpcf::mpc_framework::scheduler
+} // namespace fbpcf::scheduler

--- a/fbpcf/mpc_framework/scheduler/gate_keeper/GateKeeper.cpp
+++ b/fbpcf/mpc_framework/scheduler/gate_keeper/GateKeeper.cpp
@@ -13,7 +13,7 @@
 #include "fbpcf/mpc_framework/scheduler/gate_keeper/IGate.h"
 #include "fbpcf/mpc_framework/scheduler/gate_keeper/NormalGate.h"
 
-namespace fbpcf::mpc_framework::scheduler {
+namespace fbpcf::scheduler {
 GateKeeper::GateKeeper(std::shared_ptr<IWireKeeper> wireKeeper)
     : wireKeeper_{wireKeeper} {}
 
@@ -216,4 +216,4 @@ uint32_t GateKeeper::getFirstAvailableLevelForNewWire(
       std::max(minAvailableLeft, minAvailableRight),
       minAvailableFirstUnexecuted);
 }
-} // namespace fbpcf::mpc_framework::scheduler
+} // namespace fbpcf::scheduler

--- a/fbpcf/mpc_framework/scheduler/gate_keeper/GateKeeper.h
+++ b/fbpcf/mpc_framework/scheduler/gate_keeper/GateKeeper.h
@@ -12,7 +12,7 @@
 
 #include "fbpcf/mpc_framework/scheduler/gate_keeper/IGateKeeper.h"
 
-namespace fbpcf::mpc_framework::scheduler {
+namespace fbpcf::scheduler {
 
 class GateKeeper : public IGateKeeper {
  public:
@@ -135,4 +135,4 @@ class GateKeeper : public IGateKeeper {
   const uint32_t kMaxUnexecutedGates = 100000;
 };
 
-} // namespace fbpcf::mpc_framework::scheduler
+} // namespace fbpcf::scheduler

--- a/fbpcf/mpc_framework/scheduler/gate_keeper/ICompositeGate.h
+++ b/fbpcf/mpc_framework/scheduler/gate_keeper/ICompositeGate.h
@@ -16,7 +16,7 @@
 #include "fbpcf/mpc_framework/scheduler/IWireKeeper.h"
 #include "fbpcf/mpc_framework/scheduler/gate_keeper/IGate.h"
 
-namespace fbpcf::mpc_framework::scheduler {
+namespace fbpcf::scheduler {
 
 /**
  * This class executes composite gates in a circuit. i.e. where one value is
@@ -160,4 +160,4 @@ class ICompositeGate : public IGate {
       IScheduler::WireId<IScheduler::Boolean> wire) = 0;
 };
 
-} // namespace fbpcf::mpc_framework::scheduler
+} // namespace fbpcf::scheduler

--- a/fbpcf/mpc_framework/scheduler/gate_keeper/IGate.h
+++ b/fbpcf/mpc_framework/scheduler/gate_keeper/IGate.h
@@ -11,7 +11,7 @@
 
 #include "fbpcf/mpc_framework/engine/ISecretShareEngine.h"
 
-namespace fbpcf::mpc_framework::scheduler {
+namespace fbpcf::scheduler {
 
 /**
  * Base interface for Gates in a boolean circuit. It is used to encapsulate
@@ -46,4 +46,4 @@ class IGate {
 
  protected:
 };
-} // namespace fbpcf::mpc_framework::scheduler
+} // namespace fbpcf::scheduler

--- a/fbpcf/mpc_framework/scheduler/gate_keeper/IGateKeeper.h
+++ b/fbpcf/mpc_framework/scheduler/gate_keeper/IGateKeeper.h
@@ -12,7 +12,7 @@
 #include "fbpcf/mpc_framework/scheduler/gate_keeper/IGate.h"
 #include "fbpcf/mpc_framework/scheduler/gate_keeper/INormalGate.h"
 
-namespace fbpcf::mpc_framework::scheduler {
+namespace fbpcf::scheduler {
 
 /**
  * This object stores gates for a circuit that have yet to be executed.
@@ -92,4 +92,4 @@ class IGateKeeper {
   }
 };
 
-} // namespace fbpcf::mpc_framework::scheduler
+} // namespace fbpcf::scheduler

--- a/fbpcf/mpc_framework/scheduler/gate_keeper/INormalGate.h
+++ b/fbpcf/mpc_framework/scheduler/gate_keeper/INormalGate.h
@@ -14,7 +14,7 @@
 #include "fbpcf/mpc_framework/scheduler/IWireKeeper.h"
 #include "fbpcf/mpc_framework/scheduler/gate_keeper/IGate.h"
 
-namespace fbpcf::mpc_framework::scheduler {
+namespace fbpcf::scheduler {
 
 /**
  * This class executes gates in a circuit. There are subclasses for batched and
@@ -139,4 +139,4 @@ class INormalGate : public IGate {
   virtual void decreaseReferenceCount(IScheduler::WireId<T> wire) = 0;
 };
 
-} // namespace fbpcf::mpc_framework::scheduler
+} // namespace fbpcf::scheduler

--- a/fbpcf/mpc_framework/scheduler/gate_keeper/NormalGate.h
+++ b/fbpcf/mpc_framework/scheduler/gate_keeper/NormalGate.h
@@ -11,7 +11,7 @@
 
 #include "fbpcf/mpc_framework/scheduler/gate_keeper/INormalGate.h"
 
-namespace fbpcf::mpc_framework::scheduler {
+namespace fbpcf::scheduler {
 
 template <IScheduler::WireType T>
 class NormalGate final : public INormalGate<T> {
@@ -148,4 +148,4 @@ class NormalGate final : public INormalGate<T> {
   }
 };
 
-} // namespace fbpcf::mpc_framework::scheduler
+} // namespace fbpcf::scheduler

--- a/fbpcf/mpc_framework/scheduler/gate_keeper/test/GateKeeperTest.cpp
+++ b/fbpcf/mpc_framework/scheduler/gate_keeper/test/GateKeeperTest.cpp
@@ -13,7 +13,7 @@
 #include "fbpcf/mpc_framework/scheduler/gate_keeper/GateKeeper.h"
 #include "fbpcf/mpc_framework/scheduler/gate_keeper/INormalGate.h"
 
-namespace fbpcf::mpc_framework::scheduler {
+namespace fbpcf::scheduler {
 
 const bool unsafe = false;
 
@@ -213,4 +213,4 @@ TEST(GateKeeperTest, TestCompositeGates) {
   // check level 131
   testLevel(gateKeeper->popFirstUnexecutedLevel(), {}, {wires4});
 }
-} // namespace fbpcf::mpc_framework::scheduler
+} // namespace fbpcf::scheduler

--- a/fbpcf/mpc_framework/scheduler/test/AllocatorTest.cpp
+++ b/fbpcf/mpc_framework/scheduler/test/AllocatorTest.cpp
@@ -11,7 +11,7 @@
 #include "fbpcf/mpc_framework/scheduler/UnorderedMapAllocator.h"
 #include "fbpcf/mpc_framework/scheduler/VectorArenaAllocator.h"
 
-namespace fbpcf::mpc_framework::scheduler {
+namespace fbpcf::scheduler {
 
 template <typename T>
 void testAllocator(std::unique_ptr<IAllocator<T>> arena) {
@@ -53,4 +53,4 @@ TEST(SafeVectorArenaAllocatorTest, testAllocator) {
 TEST(UnorderedMapAllocatorTest, testAllocator) {
   testAllocator<int64_t>(std::make_unique<UnorderedMapAllocator<int64_t>>());
 }
-} // namespace fbpcf::mpc_framework::scheduler
+} // namespace fbpcf::scheduler

--- a/fbpcf/mpc_framework/scheduler/test/SchedulerTest.cpp
+++ b/fbpcf/mpc_framework/scheduler/test/SchedulerTest.cpp
@@ -18,7 +18,7 @@
 #include "fbpcf/mpc_framework/scheduler/gate_keeper/GateKeeper.h"
 #include "fbpcf/mpc_framework/test/TestHelper.h"
 
-namespace fbpcf::mpc_framework::scheduler {
+namespace fbpcf::scheduler {
 
 const bool unsafe = false;
 const int numberOfParties = 2;
@@ -705,4 +705,4 @@ TEST_P(CompositeSchedulerTestFixture, testCompositeANDBatch) {
       });
 }
 
-} // namespace fbpcf::mpc_framework::scheduler
+} // namespace fbpcf::scheduler

--- a/fbpcf/mpc_framework/scheduler/test/WireKeeperTest.cpp
+++ b/fbpcf/mpc_framework/scheduler/test/WireKeeperTest.cpp
@@ -12,7 +12,7 @@
 #include <stdexcept>
 #include "fbpcf/mpc_framework/test/TestHelper.h"
 
-namespace fbpcf::mpc_framework::scheduler {
+namespace fbpcf::scheduler {
 
 void wireKeeperTestAllocateSetAndGet(std::unique_ptr<IWireKeeper> wireKeeper) {
   // Non batch API: Bool
@@ -249,4 +249,4 @@ TEST(SafeVectorArenaWireKeeperTest, testReferenceCount) {
   wireKeeperTestReferenceCount(
       WireKeeper::createWithVectorArena</*unsafe*/ false>());
 }
-} // namespace fbpcf::mpc_framework::scheduler
+} // namespace fbpcf::scheduler

--- a/fbpcf/mpc_framework/test/TestHelper.h
+++ b/fbpcf/mpc_framework/test/TestHelper.h
@@ -16,7 +16,7 @@
 #include "fbpcf/mpc_framework/scheduler/IScheduler.h"
 #include "fbpcf/mpc_framework/scheduler/SchedulerHelper.h"
 
-namespace fbpcf::mpc_framework {
+namespace fbpcf {
 
 template <typename T>
 inline void testVectorEq(
@@ -88,37 +88,33 @@ const bool unsafe = true;
 
 template <int schedulerId0, int schedulerId1>
 void setupRealBackend(
-    mpc_framework::engine::communication::IPartyCommunicationAgentFactory&
-        factory0,
-    mpc_framework::engine::communication::IPartyCommunicationAgentFactory&
-        factory1) {
+    engine::communication::IPartyCommunicationAgentFactory& factory0,
+    engine::communication::IPartyCommunicationAgentFactory& factory1) {
   auto task0 =
       [](std::reference_wrapper<
-          mpc_framework::engine::communication::IPartyCommunicationAgentFactory>
-             factory) {
+          engine::communication::IPartyCommunicationAgentFactory> factory) {
         scheduler::SchedulerKeeper<schedulerId0>::setScheduler(
-            mpc_framework::scheduler::createEagerSchedulerWithInsecureEngine<
-                unsafe>(0, factory));
+            scheduler::createEagerSchedulerWithInsecureEngine<unsafe>(
+                0, factory));
       };
   auto task1 =
       [](std::reference_wrapper<
-          mpc_framework::engine::communication::IPartyCommunicationAgentFactory>
-             factory) {
+          engine::communication::IPartyCommunicationAgentFactory> factory) {
         scheduler::SchedulerKeeper<schedulerId1>::setScheduler(
-            mpc_framework::scheduler::createEagerSchedulerWithInsecureEngine<
-                unsafe>(1, factory));
+            scheduler::createEagerSchedulerWithInsecureEngine<unsafe>(
+                1, factory));
       };
 
   auto future0 = std::async(
       task0,
-      std::reference_wrapper<mpc_framework::engine::communication::
-                                 IPartyCommunicationAgentFactory>(factory0));
+      std::reference_wrapper<
+          engine::communication::IPartyCommunicationAgentFactory>(factory0));
   auto future1 = std::async(
       task1,
-      std::reference_wrapper<mpc_framework::engine::communication::
-                                 IPartyCommunicationAgentFactory>(factory1));
+      std::reference_wrapper<
+          engine::communication::IPartyCommunicationAgentFactory>(factory1));
   future0.get();
   future1.get();
 }
 
-} // namespace fbpcf::mpc_framework
+} // namespace fbpcf

--- a/fbpcf/test/billionaire_problem/BillionaireProblemGame.h
+++ b/fbpcf/test/billionaire_problem/BillionaireProblemGame.h
@@ -11,7 +11,7 @@
 #include <type_traits>
 #include "fbpcf/mpc_framework/frontend/mpcGame.h"
 
-namespace fbpcf::mpc_games::billionaire_problem {
+namespace fbpcf::billionaire_problem {
 
 /**
  * A variant of the classic "Millionaire Problem":
@@ -70,6 +70,6 @@ class BillionaireProblemGame
   };
 };
 
-} // namespace fbpcf::mpc_games::billionaire_problem
+} // namespace fbpcf::billionaire_problem
 
-#include "fbpcf/mpc_games/billionaire_problem/BillionaireProblemGame_impl.h"
+#include "fbpcf/test/billionaire_problem/BillionaireProblemGame_impl.h"

--- a/fbpcf/test/billionaire_problem/BillionaireProblemGame.h
+++ b/fbpcf/test/billionaire_problem/BillionaireProblemGame.h
@@ -31,15 +31,14 @@ namespace fbpcf::billionaire_problem {
  * See BillionaireProblemGameTest.cpp for a concrete usage of this class.
  */
 template <int schedulerId, bool usingBatch>
-class BillionaireProblemGame
-    : public mpc_framework::frontend::MpcGame<schedulerId> {
-  using SecUnsignedInt = typename mpc_framework::frontend::MpcGame<
+class BillionaireProblemGame : public frontend::MpcGame<schedulerId> {
+  using SecUnsignedInt = typename frontend::MpcGame<
       schedulerId>::template SecUnsignedInt<32, usingBatch>;
 
  public:
   explicit BillionaireProblemGame(
-      std::unique_ptr<mpc_framework::scheduler::IScheduler> scheduler)
-      : mpc_framework::frontend::MpcGame<schedulerId>(std::move(scheduler)) {}
+      std::unique_ptr<scheduler::IScheduler> scheduler)
+      : frontend::MpcGame<schedulerId>(std::move(scheduler)) {}
 
   using AssetsType = typename std::
       conditional<usingBatch, std::vector<uint32_t>, uint32_t>::type;

--- a/fbpcf/test/billionaire_problem/BillionaireProblemGame_impl.h
+++ b/fbpcf/test/billionaire_problem/BillionaireProblemGame_impl.h
@@ -8,9 +8,9 @@
 #pragma once
 
 #include "fbpcf/mpc_framework/frontend/mpcGame.h"
-#include "fbpcf/mpc_games/billionaire_problem/BillionaireProblemGame.h"
+#include "fbpcf/test/billionaire_problem/BillionaireProblemGame.h"
 
-namespace fbpcf::mpc_games::billionaire_problem {
+namespace fbpcf::billionaire_problem {
 
 template <int schedulerId, bool usingBatch>
 typename BillionaireProblemGame<schedulerId, usingBatch>::CompareResult
@@ -44,4 +44,4 @@ BillionaireProblemGame<schedulerId, usingBatch>::SecAssetsLists::
   return cash_ + stock_ + property_;
 }
 
-} // namespace fbpcf::mpc_games::billionaire_problem
+} // namespace fbpcf::billionaire_problem

--- a/fbpcf/test/billionaire_problem/test/BillionaireProblemGameTest.cpp
+++ b/fbpcf/test/billionaire_problem/test/BillionaireProblemGameTest.cpp
@@ -41,12 +41,11 @@ template <int schedulerId>
 std::pair<bool, uint64_t> runWithScheduler(
     int myId,
     std::reference_wrapper<
-        mpc_framework::engine::communication::IPartyCommunicationAgentFactory>
-        factory,
+        engine::communication::IPartyCommunicationAgentFactory> factory,
     // TODO T101868337 - Use a scheduler factory here
-    std::unique_ptr<mpc_framework::scheduler::IScheduler> schedulerCreator(
+    std::unique_ptr<scheduler::IScheduler> schedulerCreator(
         int myId,
-        mpc_framework::engine::communication::IPartyCommunicationAgentFactory&
+        engine::communication::IPartyCommunicationAgentFactory&
             communicationAgentFactory)) {
   std::random_device rd;
   std::mt19937_64 e(rd());
@@ -73,27 +72,25 @@ std::pair<bool, uint64_t> runWithScheduler(
   return {mpcResult, myTotalAssets};
 }
 
-void testWithScheduler(
-    std::unique_ptr<mpc_framework::scheduler::IScheduler> schedulerCreator(
-        int myId,
-        mpc_framework::engine::communication::IPartyCommunicationAgentFactory&
-            communicationAgentFactory)) {
-  auto factories =
-      mpc_framework::engine::communication::getInMemoryAgentFactory(2);
+void testWithScheduler(std::unique_ptr<scheduler::IScheduler> schedulerCreator(
+    int myId,
+    engine::communication::IPartyCommunicationAgentFactory&
+        communicationAgentFactory)) {
+  auto factories = engine::communication::getInMemoryAgentFactory(2);
 
   auto future0 = std::async(
       runWithScheduler<0>,
       0,
-      std::reference_wrapper<mpc_framework::engine::communication::
-                                 IPartyCommunicationAgentFactory>(
+      std::reference_wrapper<
+          engine::communication::IPartyCommunicationAgentFactory>(
           *factories[0]),
       schedulerCreator);
 
   auto future1 = std::async(
       runWithScheduler<1>,
       1,
-      std::reference_wrapper<mpc_framework::engine::communication::
-                                 IPartyCommunicationAgentFactory>(
+      std::reference_wrapper<
+          engine::communication::IPartyCommunicationAgentFactory>(
           *factories[1]),
       schedulerCreator);
 
@@ -104,18 +101,15 @@ void testWithScheduler(
 }
 
 TEST(BillionaireProblemTest, testWithNetworkPlaintextScheduler) {
-  testWithScheduler(
-      mpc_framework::scheduler::createNetworkPlaintextScheduler<unsafe>);
+  testWithScheduler(scheduler::createNetworkPlaintextScheduler<unsafe>);
 }
 
 TEST(BillionaireProblemTest, testWithEagerScheduler) {
-  testWithScheduler(
-      mpc_framework::scheduler::createEagerSchedulerWithRealEngine);
+  testWithScheduler(scheduler::createEagerSchedulerWithRealEngine);
 }
 
 TEST(BillionaireProblemTest, testWithLazyScheduler) {
-  testWithScheduler(
-      mpc_framework::scheduler::createLazySchedulerWithRealEngine);
+  testWithScheduler(scheduler::createLazySchedulerWithRealEngine);
 }
 
 template <int schedulerId>
@@ -123,12 +117,10 @@ std::pair<std::vector<bool>, std::vector<uint64_t>> runBatchWithScheduler(
     int size,
     int myId,
     std::reference_wrapper<
-        mpc_framework::engine::communication::IPartyCommunicationAgentFactory>
-        factory,
-    std::unique_ptr<mpc_framework::scheduler::IScheduler> schedulerCreator(
+        engine::communication::IPartyCommunicationAgentFactory> factory,
+    std::unique_ptr<scheduler::IScheduler> schedulerCreator(
         int,
-        mpc_framework::engine::communication::
-            IPartyCommunicationAgentFactory&)) {
+        engine::communication::IPartyCommunicationAgentFactory&)) {
   auto scheduler = schedulerCreator(myId, factory);
   std::random_device rd;
   std::mt19937_64 e(rd());
@@ -167,12 +159,10 @@ std::pair<std::vector<bool>, std::vector<uint64_t>> runBatchWithScheduler(
 }
 
 void testBatchBillionaireProblem(
-    std::unique_ptr<mpc_framework::scheduler::IScheduler> schedulerCreator(
+    std::unique_ptr<scheduler::IScheduler> schedulerCreator(
         int,
-        mpc_framework::engine::communication::
-            IPartyCommunicationAgentFactory&)) {
-  auto factories =
-      mpc_framework::engine::communication::getInMemoryAgentFactory(2);
+        engine::communication::IPartyCommunicationAgentFactory&)) {
+  auto factories = engine::communication::getInMemoryAgentFactory(2);
 
   int size = 16384;
 
@@ -180,8 +170,8 @@ void testBatchBillionaireProblem(
       runBatchWithScheduler<0>,
       size,
       0,
-      std::reference_wrapper<mpc_framework::engine::communication::
-                                 IPartyCommunicationAgentFactory>(
+      std::reference_wrapper<
+          engine::communication::IPartyCommunicationAgentFactory>(
           *factories[0]),
       schedulerCreator);
 
@@ -189,8 +179,8 @@ void testBatchBillionaireProblem(
       runBatchWithScheduler<1>,
       size,
       1,
-      std::reference_wrapper<mpc_framework::engine::communication::
-                                 IPartyCommunicationAgentFactory>(
+      std::reference_wrapper<
+          engine::communication::IPartyCommunicationAgentFactory>(
           *factories[1]),
       schedulerCreator);
 
@@ -207,27 +197,23 @@ void testBatchBillionaireProblem(
 
 TEST(BillionaireProblemTest, testBatchWithNetworkPlaintextScheduler) {
   testBatchBillionaireProblem(
-      mpc_framework::scheduler::createNetworkPlaintextScheduler<unsafe>);
+      scheduler::createNetworkPlaintextScheduler<unsafe>);
 }
 
 TEST(BillionaireProblemTest, testBatchWithEagerSchedulerAndFERRET) {
-  testBatchBillionaireProblem(
-      mpc_framework::scheduler::createEagerSchedulerWithRealEngine);
+  testBatchBillionaireProblem(scheduler::createEagerSchedulerWithRealEngine);
 }
 
 TEST(BillionaireProblemTest, testBatchWithEagerSchedulerAndClassicOT) {
-  testBatchBillionaireProblem(
-      mpc_framework::scheduler::createEagerSchedulerWithClassicOT);
+  testBatchBillionaireProblem(scheduler::createEagerSchedulerWithClassicOT);
 }
 
 TEST(BillionaireProblemTest, testBatchWithLazySchedulerAndFERRET) {
-  testBatchBillionaireProblem(
-      mpc_framework::scheduler::createLazySchedulerWithRealEngine);
+  testBatchBillionaireProblem(scheduler::createLazySchedulerWithRealEngine);
 }
 
 TEST(BillionaireProblemTest, testBatchWithLazySchedulerAndClassicOT) {
-  testBatchBillionaireProblem(
-      mpc_framework::scheduler::createLazySchedulerWithClassicOT);
+  testBatchBillionaireProblem(scheduler::createLazySchedulerWithClassicOT);
 }
 
 } // namespace fbpcf::billionaire_problem

--- a/fbpcf/test/billionaire_problem/test/BillionaireProblemGameTest.cpp
+++ b/fbpcf/test/billionaire_problem/test/BillionaireProblemGameTest.cpp
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "fbpcf/mpc_games/billionaire_problem/BillionaireProblemGame.h"
+#include "fbpcf/test/billionaire_problem/BillionaireProblemGame.h"
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <functional>
@@ -24,7 +24,7 @@
 #include "fbpcf/mpc_framework/engine/communication/InMemoryPartyCommunicationAgentFactory.h"
 #include "fbpcf/mpc_framework/scheduler/EagerScheduler.h"
 
-namespace fbpcf::mpc_games::billionaire_problem {
+namespace fbpcf::billionaire_problem {
 
 const bool unsafe = true;
 
@@ -230,4 +230,4 @@ TEST(BillionaireProblemTest, testBatchWithLazySchedulerAndClassicOT) {
       mpc_framework::scheduler::createLazySchedulerWithClassicOT);
 }
 
-} // namespace fbpcf::mpc_games::billionaire_problem
+} // namespace fbpcf::billionaire_problem

--- a/fbpcf/unified_data_process/adapter/Adapter.h
+++ b/fbpcf/unified_data_process/adapter/Adapter.h
@@ -9,9 +9,9 @@
 
 #include "fbpcf/mpc_framework/frontend/BitString.h"
 #include "fbpcf/mpc_framework/mpc_std_lib/shuffler/IShuffler.h"
-#include "fbpcf/mpc_games/unified_data_process/adapter/IAdapter.h"
+#include "fbpcf/unified_data_process/adapter/IAdapter.h"
 
-namespace fbpcf::mpc_games::udp::adapter {
+namespace fbpcf::udp::adapter {
 
 template <int schedulerId>
 class Adapter final : public IAdapter {
@@ -42,6 +42,6 @@ class Adapter final : public IAdapter {
       shuffler_;
 };
 
-} // namespace fbpcf::mpc_games::udp::adapter
+} // namespace fbpcf::udp::adapter
 
-#include "fbpcf/mpc_games/unified_data_process/adapter/Adapter_impl.h"
+#include "fbpcf/unified_data_process/adapter/Adapter_impl.h"

--- a/fbpcf/unified_data_process/adapter/Adapter.h
+++ b/fbpcf/unified_data_process/adapter/Adapter.h
@@ -15,17 +15,16 @@ namespace fbpcf::udp::adapter {
 
 template <int schedulerId>
 class Adapter final : public IAdapter {
-  using SecBit = mpc_framework::frontend::Bit<true, schedulerId, true>;
-  using PubBit = mpc_framework::frontend::Bit<false, schedulerId, true>;
-  using SecString = mpc_framework::frontend::BitString<true, schedulerId, true>;
+  using SecBit = frontend::Bit<true, schedulerId, true>;
+  using PubBit = frontend::Bit<false, schedulerId, true>;
+  using SecString = frontend::BitString<true, schedulerId, true>;
 
  public:
   Adapter(
       bool amIParty0,
       int32_t party0Id,
       int32_t party1Id,
-      std::unique_ptr<
-          mpc_framework::mpc_std_lib::shuffler::IShuffler<SecString>> shuffler)
+      std::unique_ptr<mpc_std_lib::shuffler::IShuffler<SecString>> shuffler)
       : amIParty0_(amIParty0),
         party0Id_(party0Id),
         party1Id_(party1Id),
@@ -38,8 +37,7 @@ class Adapter final : public IAdapter {
   bool amIParty0_;
   int32_t party0Id_;
   int32_t party1Id_;
-  std::unique_ptr<mpc_framework::mpc_std_lib::shuffler::IShuffler<SecString>>
-      shuffler_;
+  std::unique_ptr<mpc_std_lib::shuffler::IShuffler<SecString>> shuffler_;
 };
 
 } // namespace fbpcf::udp::adapter

--- a/fbpcf/unified_data_process/adapter/AdapterFactory.h
+++ b/fbpcf/unified_data_process/adapter/AdapterFactory.h
@@ -14,15 +14,14 @@ namespace fbpcf::udp::adapter {
 
 template <int schedulerId>
 class AdapterFactory final : public IAdapterFactory {
-  using SecString = mpc_framework::frontend::BitString<true, schedulerId, true>;
+  using SecString = frontend::BitString<true, schedulerId, true>;
 
  public:
   AdapterFactory(
       bool amIParty0,
       int32_t party0Id,
       int32_t party1Id,
-      std::unique_ptr<
-          mpc_framework::mpc_std_lib::shuffler::IShufflerFactory<SecString>>
+      std::unique_ptr<mpc_std_lib::shuffler::IShufflerFactory<SecString>>
           shufflerFactory)
       : amIParty0_(amIParty0),
         party0Id_(party0Id),
@@ -37,8 +36,7 @@ class AdapterFactory final : public IAdapterFactory {
   bool amIParty0_;
   int32_t party0Id_;
   int32_t party1Id_;
-  std::unique_ptr<
-      mpc_framework::mpc_std_lib::shuffler::IShufflerFactory<SecString>>
+  std::unique_ptr<mpc_std_lib::shuffler::IShufflerFactory<SecString>>
       shufflerFactory_;
 };
 

--- a/fbpcf/unified_data_process/adapter/AdapterFactory.h
+++ b/fbpcf/unified_data_process/adapter/AdapterFactory.h
@@ -7,10 +7,10 @@
 
 #pragma once
 
-#include "fbpcf/mpc_games/unified_data_process/adapter/Adapter.h"
-#include "fbpcf/mpc_games/unified_data_process/adapter/IAdapterFactory.h"
+#include "fbpcf/unified_data_process/adapter/Adapter.h"
+#include "fbpcf/unified_data_process/adapter/IAdapterFactory.h"
 
-namespace fbpcf::mpc_games::udp::adapter {
+namespace fbpcf::udp::adapter {
 
 template <int schedulerId>
 class AdapterFactory final : public IAdapterFactory {
@@ -42,4 +42,4 @@ class AdapterFactory final : public IAdapterFactory {
       shufflerFactory_;
 };
 
-} // namespace fbpcf::mpc_games::udp::adapter
+} // namespace fbpcf::udp::adapter

--- a/fbpcf/unified_data_process/adapter/Adapter_impl.h
+++ b/fbpcf/unified_data_process/adapter/Adapter_impl.h
@@ -8,9 +8,9 @@
 #pragma once
 
 #include <cmath>
-#include "fbpcf/mpc_games/unified_data_process/adapter/Adapter.h"
+#include "fbpcf/unified_data_process/adapter/Adapter.h"
 
-namespace fbpcf::mpc_games::udp::adapter {
+namespace fbpcf::udp::adapter {
 
 template <int schedulerId>
 std::vector<int64_t> Adapter<schedulerId>::adapt(
@@ -88,4 +88,4 @@ std::vector<int64_t> Adapter<schedulerId>::adapt(
   return rst;
 }
 
-} // namespace fbpcf::mpc_games::udp::adapter
+} // namespace fbpcf::udp::adapter

--- a/fbpcf/unified_data_process/adapter/IAdapter.h
+++ b/fbpcf/unified_data_process/adapter/IAdapter.h
@@ -10,7 +10,7 @@
 #include <stdint.h>
 #include <vector>
 
-namespace fbpcf::mpc_games::udp::adapter {
+namespace fbpcf::udp::adapter {
 
 /*
  * An adapter converts a union-like mapping result into an intersection-like
@@ -34,4 +34,4 @@ class IAdapter {
       const std::vector<int64_t>& unionMap) const = 0;
 };
 
-} // namespace fbpcf::mpc_games::udp::adapter
+} // namespace fbpcf::udp::adapter

--- a/fbpcf/unified_data_process/adapter/IAdapterFactory.h
+++ b/fbpcf/unified_data_process/adapter/IAdapterFactory.h
@@ -7,9 +7,9 @@
 
 #pragma once
 
-#include "fbpcf/mpc_games/unified_data_process/adapter/IAdapter.h"
+#include "fbpcf/unified_data_process/adapter/IAdapter.h"
 
-namespace fbpcf::mpc_games::udp::adapter {
+namespace fbpcf::udp::adapter {
 
 class IAdapterFactory {
  public:
@@ -17,4 +17,4 @@ class IAdapterFactory {
   virtual std::unique_ptr<IAdapter> create() = 0;
 };
 
-} // namespace fbpcf::mpc_games::udp::adapter
+} // namespace fbpcf::udp::adapter

--- a/fbpcf/unified_data_process/adapter/test/AdapterTest.cpp
+++ b/fbpcf/unified_data_process/adapter/test/AdapterTest.cpp
@@ -110,24 +110,21 @@ void adapterTest(
 }
 
 TEST(AdapterTest, testAdapterWithNonShuffler) {
-  auto agentFactories =
-      mpc_framework::engine::communication::getInMemoryAgentFactory(2);
-  mpc_framework::setupRealBackend<0, 1>(*agentFactories[0], *agentFactories[1]);
+  auto agentFactories = engine::communication::getInMemoryAgentFactory(2);
+  setupRealBackend<0, 1>(*agentFactories[0], *agentFactories[1]);
   AdapterFactory<0> factory0(
       true,
       0,
       1,
-      std::make_unique<
-          mpc_framework::mpc_std_lib::shuffler::insecure::NonShufflerFactory<
-              mpc_framework::frontend::BitString<true, 0, true>>>());
+      std::make_unique<mpc_std_lib::shuffler::insecure::NonShufflerFactory<
+          frontend::BitString<true, 0, true>>>());
 
   AdapterFactory<1> factory1(
       false,
       0,
       1,
-      std::make_unique<
-          mpc_framework::mpc_std_lib::shuffler::insecure::NonShufflerFactory<
-              mpc_framework::frontend::BitString<true, 1, true>>>());
+      std::make_unique<mpc_std_lib::shuffler::insecure::NonShufflerFactory<
+          frontend::BitString<true, 1, true>>>());
 
   adapterTest(factory0.create(), factory1.create());
 }

--- a/fbpcf/unified_data_process/adapter/test/AdapterTest.cpp
+++ b/fbpcf/unified_data_process/adapter/test/AdapterTest.cpp
@@ -17,9 +17,9 @@
 #include "fbpcf/mpc_framework/mpc_std_lib/shuffler/NonShufflerFactory.h"
 #include "fbpcf/mpc_framework/scheduler/SchedulerHelper.h"
 #include "fbpcf/mpc_framework/test/TestHelper.h"
-#include "fbpcf/mpc_games/unified_data_process/adapter/AdapterFactory.h"
+#include "fbpcf/unified_data_process/adapter/AdapterFactory.h"
 
-namespace fbpcf::mpc_games::udp::adapter {
+namespace fbpcf::udp::adapter {
 
 std::vector<int64_t> generateShuffledIndex(size_t size) {
   std::vector<int64_t> rst(size);
@@ -132,4 +132,4 @@ TEST(AdapterTest, testAdapterWithNonShuffler) {
   adapterTest(factory0.create(), factory1.create());
 }
 
-} // namespace fbpcf::mpc_games::udp::adapter
+} // namespace fbpcf::udp::adapter

--- a/fbpcf/unified_data_process/data_processor/DummyDataProcessor.h
+++ b/fbpcf/unified_data_process/data_processor/DummyDataProcessor.h
@@ -22,8 +22,7 @@ class DummyDataProcessor final : public IDataProcessor<schedulerId> {
   explicit DummyDataProcessor(
       int32_t myId,
       int32_t partnerId,
-      std::unique_ptr<
-          fbpcf::mpc_framework::engine::communication::IPartyCommunicationAgent>
+      std::unique_ptr<fbpcf::engine::communication::IPartyCommunicationAgent>
           agent)
       : myId_(myId), partnerId_(partnerId), agent_(std::move(agent)) {}
 
@@ -45,8 +44,7 @@ class DummyDataProcessor final : public IDataProcessor<schedulerId> {
  private:
   int32_t myId_;
   int32_t partnerId_;
-  std::unique_ptr<
-      fbpcf::mpc_framework::engine::communication::IPartyCommunicationAgent>
+  std::unique_ptr<fbpcf::engine::communication::IPartyCommunicationAgent>
       agent_;
 };
 

--- a/fbpcf/unified_data_process/data_processor/DummyDataProcessor.h
+++ b/fbpcf/unified_data_process/data_processor/DummyDataProcessor.h
@@ -8,9 +8,9 @@
 #pragma once
 
 #include "fbpcf/mpc_framework/engine/communication/IPartyCommunicationAgent.h"
-#include "fbpcf/mpc_games/unified_data_process/data_processor/IDataProcessor.h"
+#include "fbpcf/unified_data_process/data_processor/IDataProcessor.h"
 
-namespace fbpcf::mpc_games::udp::data_processor::insecure {
+namespace fbpcf::udp::data_processor::insecure {
 
 /**
  * This is an insecure implementation. This object is only meant to be used as a
@@ -50,6 +50,6 @@ class DummyDataProcessor final : public IDataProcessor<schedulerId> {
       agent_;
 };
 
-} // namespace fbpcf::mpc_games::udp::data_processor::insecure
+} // namespace fbpcf::udp::data_processor::insecure
 
-#include "fbpcf/mpc_games/unified_data_process/data_processor/DummyDataProcessor_impl.h"
+#include "fbpcf/unified_data_process/data_processor/DummyDataProcessor_impl.h"

--- a/fbpcf/unified_data_process/data_processor/DummyDataProcessorFactory.h
+++ b/fbpcf/unified_data_process/data_processor/DummyDataProcessorFactory.h
@@ -9,10 +9,10 @@
 
 #include <memory>
 #include "fbpcf/mpc_framework/engine/communication/IPartyCommunicationAgentFactory.h"
-#include "fbpcf/mpc_games/unified_data_process/data_processor/DummyDataProcessor.h"
-#include "fbpcf/mpc_games/unified_data_process/data_processor/IDataProcessorFactory.h"
+#include "fbpcf/unified_data_process/data_processor/DummyDataProcessor.h"
+#include "fbpcf/unified_data_process/data_processor/IDataProcessorFactory.h"
 
-namespace fbpcf::mpc_games::udp::data_processor::insecure {
+namespace fbpcf::udp::data_processor::insecure {
 
 template <int schedulerId>
 class DummyDataProcessorFactory final
@@ -37,4 +37,4 @@ class DummyDataProcessorFactory final
       agentFactory_;
 };
 
-} // namespace fbpcf::mpc_games::udp::data_processor::insecure
+} // namespace fbpcf::udp::data_processor::insecure

--- a/fbpcf/unified_data_process/data_processor/DummyDataProcessorFactory.h
+++ b/fbpcf/unified_data_process/data_processor/DummyDataProcessorFactory.h
@@ -21,8 +21,8 @@ class DummyDataProcessorFactory final
   DummyDataProcessorFactory(
       int32_t myId,
       int32_t partnerId,
-      fbpcf::mpc_framework::engine::communication::
-          IPartyCommunicationAgentFactory& agentFactory)
+      fbpcf::engine::communication::IPartyCommunicationAgentFactory&
+          agentFactory)
       : myId_(myId), partnerId_(partnerId), agentFactory_(agentFactory) {}
 
   std::unique_ptr<IDataProcessor<schedulerId>> create() {
@@ -33,8 +33,7 @@ class DummyDataProcessorFactory final
  private:
   int32_t myId_;
   int32_t partnerId_;
-  fbpcf::mpc_framework::engine::communication::IPartyCommunicationAgentFactory&
-      agentFactory_;
+  fbpcf::engine::communication::IPartyCommunicationAgentFactory& agentFactory_;
 };
 
 } // namespace fbpcf::udp::data_processor::insecure

--- a/fbpcf/unified_data_process/data_processor/DummyDataProcessor_impl.h
+++ b/fbpcf/unified_data_process/data_processor/DummyDataProcessor_impl.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-namespace fbpcf::mpc_games::udp::data_processor::insecure {
+namespace fbpcf::udp::data_processor::insecure {
 
 template <int schedulerId>
 typename IDataProcessor<schedulerId>::SecString
@@ -51,4 +51,4 @@ DummyDataProcessor<schedulerId>::processPeersData(
   return typename IDataProcessor<schedulerId>::SecString(myShare, myId_);
 }
 
-} // namespace fbpcf::mpc_games::udp::data_processor::insecure
+} // namespace fbpcf::udp::data_processor::insecure

--- a/fbpcf/unified_data_process/data_processor/IDataProcessor.h
+++ b/fbpcf/unified_data_process/data_processor/IDataProcessor.h
@@ -11,7 +11,7 @@
 #include <vector>
 #include "fbpcf/mpc_framework/frontend/BitString.h"
 
-namespace fbpcf::mpc_games::udp::data_processor {
+namespace fbpcf::udp::data_processor {
 
 /**
  * A data processor can generate the secret shares of the data of the matched
@@ -53,4 +53,4 @@ class IDataProcessor {
       size_t dataWidth) = 0;
 };
 
-} // namespace fbpcf::mpc_games::udp::data_processor
+} // namespace fbpcf::udp::data_processor

--- a/fbpcf/unified_data_process/data_processor/IDataProcessor.h
+++ b/fbpcf/unified_data_process/data_processor/IDataProcessor.h
@@ -21,9 +21,8 @@ namespace fbpcf::udp::data_processor {
 template <int schedulerId>
 class IDataProcessor {
  public:
-  using SecString = mpc_framework::frontend::BitString<true, schedulerId, true>;
-  using PubString =
-      mpc_framework::frontend::BitString<false, schedulerId, true>;
+  using SecString = frontend::BitString<true, schedulerId, true>;
+  using PubString = frontend::BitString<false, schedulerId, true>;
 
   virtual ~IDataProcessor() = default;
 

--- a/fbpcf/unified_data_process/data_processor/IDataProcessorFactory.h
+++ b/fbpcf/unified_data_process/data_processor/IDataProcessorFactory.h
@@ -8,9 +8,9 @@
 #pragma once
 
 #include <memory>
-#include "fbpcf/mpc_games/unified_data_process/data_processor/IDataProcessor.h"
+#include "fbpcf/unified_data_process/data_processor/IDataProcessor.h"
 
-namespace fbpcf::mpc_games::udp::data_processor {
+namespace fbpcf::udp::data_processor {
 
 template <int schedulerId>
 class IDataProcessorFactory {
@@ -19,4 +19,4 @@ class IDataProcessorFactory {
   virtual std::unique_ptr<IDataProcessor<schedulerId>> create() = 0;
 };
 
-} // namespace fbpcf::mpc_games::udp::data_processor
+} // namespace fbpcf::udp::data_processor

--- a/fbpcf/unified_data_process/data_processor/test/DataProcessorTest.cpp
+++ b/fbpcf/unified_data_process/data_processor/test/DataProcessorTest.cpp
@@ -16,9 +16,9 @@
 #include "fbpcf/mpc_framework/engine/communication/test/AgentFactoryCreationHelper.h"
 #include "fbpcf/mpc_framework/scheduler/SchedulerHelper.h"
 #include "fbpcf/mpc_framework/test/TestHelper.h"
-#include "fbpcf/mpc_games/unified_data_process/data_processor/DummyDataProcessorFactory.h"
+#include "fbpcf/unified_data_process/data_processor/DummyDataProcessorFactory.h"
 
-namespace fbpcf::mpc_games::udp::data_processor {
+namespace fbpcf::udp::data_processor {
 
 std::tuple<
     std::vector<std::vector<uint8_t>>,
@@ -111,4 +111,4 @@ TEST(DummyDataProcessor, testDummyDataProcessor) {
   testDataProcessor(factory0.create(), factory1.create());
 }
 
-} // namespace fbpcf::mpc_games::udp::data_processor
+} // namespace fbpcf::udp::data_processor

--- a/fbpcf/unified_data_process/data_processor/test/DataProcessorTest.cpp
+++ b/fbpcf/unified_data_process/data_processor/test/DataProcessorTest.cpp
@@ -97,14 +97,13 @@ void testDataProcessor(
   future1.get();
   auto rst = future0.get();
   for (size_t i = 0; i < outputSize; i++) {
-    fbpcf::mpc_framework::testVectorEq(rst.at(i), expectedOutput.at(i));
+    fbpcf::testVectorEq(rst.at(i), expectedOutput.at(i));
   }
 }
 
 TEST(DummyDataProcessor, testDummyDataProcessor) {
-  auto agentFactories =
-      mpc_framework::engine::communication::getInMemoryAgentFactory(2);
-  mpc_framework::setupRealBackend<0, 1>(*agentFactories[0], *agentFactories[1]);
+  auto agentFactories = engine::communication::getInMemoryAgentFactory(2);
+  setupRealBackend<0, 1>(*agentFactories[0], *agentFactories[1]);
 
   insecure::DummyDataProcessorFactory<0> factory0(0, 1, *agentFactories[0]);
   insecure::DummyDataProcessorFactory<1> factory1(1, 0, *agentFactories[1]);


### PR DESCRIPTION
Summary:
As title.
This diff is created via the following step:
1. run `grep -rl "mpc_framework::" . | xargs sed -i 's/mpc_framework:://g'` under `fbpcf/` and `identity/`

Differential Revision: D34705327

