### PR TITLE
Update workflows to use "legacy_runner" label

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   # Push image to GitHub Packages.
   push:
-    runs-on: self-hosted
+    runs-on: [self-hosted, legacy_runner]
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   ubuntu:
-    runs-on: self-hosted
+    runs-on: [self-hosted, legacy_runner]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Summary:
This should be a no-op. We are trying to increase the size of the self hosted runner and move it to a new AWS account. The steps are:

1) i will configure a larger instance in the mpc-aem account, and ssh into it and make sure the workflow runs. [DONE, see test plan]
2) OSS team will add a label to the old runner, like "legacy_runner" [DONE, see below]
https://pxl.cl/20mC2
3) I will make a PR, saying our workflow should use "legacy_runner" [this diff]
4) I will configure the new instance with a new label, like "mpc_runner" [TODO]
5) I will make a PR, saying our workflow should use "mpc_runner" [TODO]
6) Create a diff to add cleanup steps between jobs (prune images, stop containers). [TODO]

Differential Revision: D34724686

