### PR TITLE
Update workflows to use "e2e_test_runner" label

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   # Push image to GitHub Packages.
   push:
-    runs-on: [self-hosted, legacy_runner]
+    runs-on: [self-hosted, e2e_test_runner]
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   ubuntu:
-    runs-on: [self-hosted, legacy_runner]
+    runs-on: [self-hosted, e2e_test_runner]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Summary:
We are trying to increase the size of the self hosted runner and move it to a new AWS account. The steps are:
1) i will configure a larger instance in the mpc-aem account, and ssh into it and make sure the workflow runs. [DONE, see test plan]
2) OSS team will add a label to the old runner, like "legacy_runner" [DONE, see below]
Preview image from Summary
https://pxl.cl/20mC2
3) I will make a PR, saying our workflow should use "legacy_runner" [DONE D34724686 (https://github.com/facebookresearch/fbpcf/commit/707ba7c218304c6ca975f4124e518f43fce09803)]
4) I will configure the new instance with a new label, like "e2e_test_runner" [DONE https://pxl.cl/20mM4
]
5) I will make a PR, saying our workflow should use "mpc_runner" [this diff]
6) Create a diff to add cleanup steps between jobs (prune images, stop containers). [TODO]

Differential Revision: D34726066

