### PR TITLE
Merge ferret benchmarks into one

### DIFF
--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/test/benchmarks/BenchmarkMain.cpp
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/test/benchmarks/BenchmarkMain.cpp
@@ -14,38 +14,39 @@
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/TenLocalLinearMatrixMultiplierFactory.h"
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/test/benchmarks/MatrixMultiplierBenchmark.h"
 
-using namespace folly;
-using namespace fbpcf::mpc_framework::engine::tuple_generator::
-    oblivious_transfer;
+namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
+    ferret {
 
 inline void benchmarkMatrixMultiplier(
-    std::unique_ptr<ferret::IMatrixMultiplierFactory> factory,
+    std::unique_ptr<IMatrixMultiplierFactory> factory,
     uint64_t n) {
-  ferret::MatrixMultiplierBenchmark matrixMultiplierBenchmark;
+  MatrixMultiplierBenchmark matrixMultiplierBenchmark;
   BENCHMARK_SUSPEND {
     matrixMultiplierBenchmark.setup(
-        std::move(factory), ferret::kExtendedSize, ferret::kBaseSize);
+        std::move(factory), kExtendedSize, kBaseSize);
   }
 
   std::vector<__m128i> rst;
   while (n--) {
     rst = matrixMultiplierBenchmark.benchmark();
   }
-  doNotOptimizeAway(rst);
+  folly::doNotOptimizeAway(rst);
 }
 
 BENCHMARK(DummyMatrixMultiplier, n) {
   benchmarkMatrixMultiplier(
-      std::make_unique<ferret::insecure::DummyMatrixMultiplierFactory>(), n);
+      std::make_unique<insecure::DummyMatrixMultiplierFactory>(), n);
 }
 
 BENCHMARK(TenLocalLinearMatrixMultiplier, n) {
   benchmarkMatrixMultiplier(
-      std::make_unique<ferret::TenLocalLinearMatrixMultiplierFactory>(), n);
+      std::make_unique<TenLocalLinearMatrixMultiplierFactory>(), n);
 }
+} // namespace
+  // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::ferret
 
 int main(int argc, char* argv[]) {
   facebook::initFacebook(&argc, &argv);
-  runBenchmarks();
+  folly::runBenchmarks();
   return 0;
 }

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/test/benchmarks/BenchmarkMain.cpp
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/test/benchmarks/BenchmarkMain.cpp
@@ -10,28 +10,12 @@
 #include "common/init/Init.h"
 
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/DummyMatrixMultiplierFactory.h"
-#include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/RegularErrorMultiPointCot.h"
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/TenLocalLinearMatrixMultiplierFactory.h"
+#include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/test/benchmarks/CotBenchmark.h"
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/test/benchmarks/MatrixMultiplierBenchmark.h"
 
 namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
     ferret {
-
-inline void benchmarkMatrixMultiplier(
-    std::unique_ptr<IMatrixMultiplierFactory> factory,
-    uint64_t n) {
-  MatrixMultiplierBenchmark matrixMultiplierBenchmark;
-  BENCHMARK_SUSPEND {
-    matrixMultiplierBenchmark.setup(
-        std::move(factory), kExtendedSize, kBaseSize);
-  }
-
-  std::vector<__m128i> rst;
-  while (n--) {
-    rst = matrixMultiplierBenchmark.benchmark();
-  }
-  folly::doNotOptimizeAway(rst);
-}
 
 BENCHMARK(DummyMatrixMultiplier, n) {
   benchmarkMatrixMultiplier(
@@ -41,6 +25,21 @@ BENCHMARK(DummyMatrixMultiplier, n) {
 BENCHMARK(TenLocalLinearMatrixMultiplier, n) {
   benchmarkMatrixMultiplier(
       std::make_unique<TenLocalLinearMatrixMultiplierFactory>(), n);
+}
+
+BENCHMARK_COUNTERS(SinglePointCot, counters) {
+  SinglePointCotBenchmark benchmark;
+  benchmark.runBenchmark(counters);
+}
+
+BENCHMARK_COUNTERS(RegularErrorMultiPointCot, counters) {
+  RegularErrorMultiPointCotBenchmark benchmark;
+  benchmark.runBenchmark(counters);
+}
+
+BENCHMARK_COUNTERS(RcotExtender, counters) {
+  RcotExtenderBenchmark benchmark;
+  benchmark.runBenchmark(counters);
 }
 } // namespace
   // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::ferret

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/test/benchmarks/CotBenchmark.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/test/benchmarks/CotBenchmark.h
@@ -9,8 +9,6 @@
 #include <future>
 #include <random>
 
-#include "common/init/Init.h"
-
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/IMultiPointCot.h"
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/ISinglePointCot.h"
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/RcotExtenderFactory.h"
@@ -25,8 +23,8 @@
 namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
     ferret {
 
-std::tuple<std::vector<__m128i>, std::vector<__m128i>, __m128i> getBaseOT(
-    size_t baseOtSize) {
+inline std::tuple<std::vector<__m128i>, std::vector<__m128i>, __m128i>
+getBaseOT(size_t baseOtSize) {
   std::vector<__m128i> baseOTSend(baseOtSize);
   std::vector<__m128i> baseOTReceive(baseOtSize);
 
@@ -95,12 +93,8 @@ class SinglePointCotBenchmark final : public util::NetworkedBenchmark {
   std::vector<__m128i> baseOTReceive_;
 };
 
-BENCHMARK_COUNTERS(SinglePointCot, counters) {
-  SinglePointCotBenchmark benchmark;
-  benchmark.runBenchmark(counters);
-}
-
-class MultiPointCotBenchmark final : public util::NetworkedBenchmark {
+class RegularErrorMultiPointCotBenchmark final
+    : public util::NetworkedBenchmark {
  public:
   void setup() override {
     auto [agent0, agent1] = util::getSocketAgents();
@@ -145,11 +139,6 @@ class MultiPointCotBenchmark final : public util::NetworkedBenchmark {
   std::vector<__m128i> baseOTSend_;
   std::vector<__m128i> baseOTReceive_;
 };
-
-BENCHMARK_COUNTERS(MultiPointCot, counters) {
-  MultiPointCotBenchmark benchmark;
-  benchmark.runBenchmark(counters);
-}
 
 class RcotExtenderBenchmark final : public util::NetworkedBenchmark {
  public:
@@ -197,16 +186,5 @@ class RcotExtenderBenchmark final : public util::NetworkedBenchmark {
   std::vector<__m128i> baseOTReceive_;
 };
 
-BENCHMARK_COUNTERS(RcotExtender, counters) {
-  RcotExtenderBenchmark benchmark;
-  benchmark.runBenchmark(counters);
-}
-
 } // namespace
   // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::ferret
-
-int main(int argc, char* argv[]) {
-  facebook::initFacebook(&argc, &argv);
-  folly::runBenchmarks();
-  return 0;
-}

--- a/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/test/benchmarks/MatrixMultiplierBenchmark.h
+++ b/fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/test/benchmarks/MatrixMultiplierBenchmark.h
@@ -7,11 +7,13 @@
 
 #pragma once
 
+#include <folly/Benchmark.h>
 #include <folly/stop_watch.h>
 #include <memory>
 
 #include "fbpcf/mpc_framework/engine/communication/IPartyCommunicationAgent.h"
 #include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/IMatrixMultiplierFactory.h"
+#include "fbpcf/mpc_framework/engine/tuple_generator/oblivious_transfer/ferret/RegularErrorMultiPointCot.h"
 #include "fbpcf/mpc_framework/engine/util/AesPrgFactory.h"
 
 namespace fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::
@@ -40,5 +42,20 @@ class MatrixMultiplierBenchmark {
   std::vector<__m128i> src_;
 };
 
+inline void benchmarkMatrixMultiplier(
+    std::unique_ptr<IMatrixMultiplierFactory> factory,
+    uint64_t n) {
+  MatrixMultiplierBenchmark matrixMultiplierBenchmark;
+  BENCHMARK_SUSPEND {
+    matrixMultiplierBenchmark.setup(
+        std::move(factory), kExtendedSize, kBaseSize);
+  }
+
+  std::vector<__m128i> rst;
+  while (n--) {
+    rst = matrixMultiplierBenchmark.benchmark();
+  }
+  folly::doNotOptimizeAway(rst);
+}
 } // namespace
   // fbpcf::mpc_framework::engine::tuple_generator::oblivious_transfer::ferret

--- a/fbpcf/mpc_framework/engine/util/test/benchmarks/BenchmarkMain.cpp
+++ b/fbpcf/mpc_framework/engine/util/test/benchmarks/BenchmarkMain.cpp
@@ -15,8 +15,7 @@
 #include "fbpcf/mpc_framework/engine/util/aes.h"
 #include "folly/BenchmarkUtil.h"
 
-using namespace folly;
-using namespace fbpcf::mpc_framework::engine::util;
+namespace fbpcf::mpc_framework::engine::util {
 
 DEFINE_int64(
     AES_Benchmark_Size,
@@ -47,7 +46,7 @@ std::vector<__m128i> generateData() {
 }
 
 BENCHMARK(Aes_encryptInPlace, n) {
-  BenchmarkSuspender braces;
+  folly::BenchmarkSuspender braces;
   auto seed = getRandomSeed();
   auto data = generateData();
   braces.dismiss();
@@ -57,11 +56,11 @@ BENCHMARK(Aes_encryptInPlace, n) {
   while (n--) {
     cipher.encryptInPlace(data);
   }
-  doNotOptimizeAway(data);
+  folly::doNotOptimizeAway(data);
 }
 
 BENCHMARK(Aes_inPlaceHash, n) {
-  BenchmarkSuspender braces;
+  folly::BenchmarkSuspender braces;
   auto seed = getRandomSeed();
   auto data = generateData();
   braces.dismiss();
@@ -71,11 +70,11 @@ BENCHMARK(Aes_inPlaceHash, n) {
   while (n--) {
     cipher.inPlaceHash(data);
   }
-  doNotOptimizeAway(data);
+  folly::doNotOptimizeAway(data);
 }
 
 BENCHMARK(AesPrg_getRandomBits, n) {
-  BenchmarkSuspender braces;
+  folly::BenchmarkSuspender braces;
   auto seed = getRandomSeed();
   braces.dismiss();
 
@@ -88,7 +87,7 @@ BENCHMARK(AesPrg_getRandomBits, n) {
 }
 
 BENCHMARK(AesPrg_getRandomBytes, n) {
-  BenchmarkSuspender braces;
+  folly::BenchmarkSuspender braces;
   auto seed = getRandomSeed();
   braces.dismiss();
 
@@ -101,7 +100,7 @@ BENCHMARK(AesPrg_getRandomBytes, n) {
 }
 
 BENCHMARK(AesPrg_getRandomDataInPlace, n) {
-  BenchmarkSuspender braces;
+  folly::BenchmarkSuspender braces;
   auto seed = getRandomSeed();
   auto data = generateData();
   braces.dismiss();
@@ -110,12 +109,13 @@ BENCHMARK(AesPrg_getRandomDataInPlace, n) {
   while (n--) {
     prg.getRandomDataInPlace(data);
   }
-  doNotOptimizeAway(data);
+  folly::doNotOptimizeAway(data);
 }
+} // namespace fbpcf::mpc_framework::engine::util
 
 int main(int argc, char* argv[]) {
   facebook::initFacebook(&argc, &argv);
   gflags::ParseCommandLineFlags(&argc, &argv, true);
-  runBenchmarks();
+  folly::runBenchmarks();
   return 0;
 }


### PR DESCRIPTION
Summary:
I'm thinking of just having one set of benchmarks for each folder, just to keep the organization a bit simpler.

This diff merges the matrix multiplier and the correlated oblivious transfer benchmarks into one file. There's now just one set of benchmarks for everything in the `ferret` folder.

Differential Revision: D34720817

