### PR TITLE
Remove std::cout from PCF 2.0

### DIFF
--- a/fbpcf/mpc_framework/engine/util/util.h
+++ b/fbpcf/mpc_framework/engine/util/util.h
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include "fbpcf/mpc_framework/engine/util/aes.h"
+#include "folly/logging/xlog.h"
 
 namespace fbpcf::engine::util {
 
@@ -78,7 +79,7 @@ class EngineWrap {
           "ENGINE_set_default failed. Error code: " +
           std::to_string(ERR_get_error()));
     }
-    std::cout << "Successfully initialized the hardware PRG.";
+    XLOG(INFO) << "Successfully initialized the hardware PRG.";
   }
   ~EngineWrap() {
     if (engine_) {

--- a/fbpcf/mpc_framework/frontend/test/BitTest.cpp
+++ b/fbpcf/mpc_framework/frontend/test/BitTest.cpp
@@ -498,7 +498,6 @@ TEST(BitTest, testReferenceCount) {
     // no change
     auto b3(std::move(b2));
 
-    std::cout << "here executed" << std::endl;
     // increase reference
     // decrease reference
     b1 = b3;
@@ -519,7 +518,6 @@ TEST(BitTest, testReferenceCount) {
     // no change
     auto b3(std::move(b2));
 
-    std::cout << "here executed" << std::endl;
     // increase reference
     // decrease reference
     b1 = b3;
@@ -556,7 +554,6 @@ TEST(BitTest, testReferenceCountBatch) {
     // no change
     auto b3(std::move(b2));
 
-    std::cout << "here executed" << std::endl;
     // increase reference
     // decrease reference
     b1 = b3;
@@ -577,7 +574,6 @@ TEST(BitTest, testReferenceCountBatch) {
     // no change
     auto b3(std::move(b2));
 
-    std::cout << "here executed" << std::endl;
     // increase reference
     // decrease reference
     b1 = b3;


### PR DESCRIPTION
Summary: Replacing this with `XLOG(INFO)`, which we're already using.

Differential Revision: D34792136

