### PR TITLE
Add benchmarks for RCOT

### DIFF
--- a/fbpcf/engine/tuple_generator/oblivious_transfer/test/benchmarks/OtBenchmark.cpp
+++ b/fbpcf/engine/tuple_generator/oblivious_transfer/test/benchmarks/OtBenchmark.cpp
@@ -10,10 +10,20 @@
 
 #include "common/init/Init.h"
 
+#include "fbpcf/engine/tuple_generator/oblivious_transfer/EmpShRandomCorrelatedObliviousTransferFactory.h"
+#include "fbpcf/engine/tuple_generator/oblivious_transfer/ExtenderBasedRandomCorrelatedObliviousTransferFactory.h"
 #include "fbpcf/engine/tuple_generator/oblivious_transfer/IBaseObliviousTransfer.h"
+#include "fbpcf/engine/tuple_generator/oblivious_transfer/IRandomCorrelatedObliviousTransferFactory.h"
+#include "fbpcf/engine/tuple_generator/oblivious_transfer/IknpShRandomCorrelatedObliviousTransferFactory.h"
 #include "fbpcf/engine/tuple_generator/oblivious_transfer/NpBaseObliviousTransferFactory.h"
+#include "fbpcf/engine/tuple_generator/oblivious_transfer/ferret/RcotExtenderFactory.h"
+#include "fbpcf/engine/tuple_generator/oblivious_transfer/ferret/RegularErrorMultiPointCot.h"
+#include "fbpcf/engine/tuple_generator/oblivious_transfer/ferret/RegularErrorMultiPointCotFactory.h"
+#include "fbpcf/engine/tuple_generator/oblivious_transfer/ferret/SinglePointCotFactory.h"
+#include "fbpcf/engine/tuple_generator/oblivious_transfer/ferret/TenLocalLinearMatrixMultiplierFactory.h"
 #include "fbpcf/engine/util/test/benchmarks/BenchmarkHelper.h"
 #include "fbpcf/engine/util/test/benchmarks/NetworkedBenchmark.h"
+#include "fbpcf/engine/util/util.h"
 
 namespace fbpcf::engine::tuple_generator::oblivious_transfer {
 
@@ -61,6 +71,132 @@ BENCHMARK_COUNTERS(NpBaseObliviousTransfer, counters) {
   NpBaseObliviousTransferBenchmark benchmark;
   benchmark.runBenchmark(counters);
 }
+
+class RandomCorrelatedObliviousTransferBenchmark
+    : public util::NetworkedBenchmark {
+ public:
+  void setup() override {
+    auto [agent0, agent1] = util::getSocketAgents();
+    agent0_ = std::move(agent0);
+    agent1_ = std::move(agent1);
+
+    std::random_device rd;
+    std::mt19937_64 e(rd());
+    std::uniform_int_distribution<uint64_t> dist(0, 0xFFFFFFFFFFFFFFFF);
+    delta_ = _mm_set_epi64x(dist(e), dist(e));
+    util::setLsbTo1(delta_);
+  }
+
+  void runSender() override {
+    sender_ = factory_->create(delta_, std::move(agent0_));
+    sender_->rcot(size_);
+  }
+
+  void runReceiver() override {
+    receiver_ = factory_->create(std::move(agent1_));
+    receiver_->rcot(size_);
+  }
+
+  std::pair<uint64_t, uint64_t> getTrafficStatistics() override {
+    return sender_->getTrafficStatistics();
+  }
+
+ protected:
+  std::unique_ptr<IRandomCorrelatedObliviousTransferFactory> factory_;
+
+ private:
+  size_t size_ = 1000000;
+  __m128i delta_;
+
+  std::unique_ptr<communication::IPartyCommunicationAgent> agent0_;
+  std::unique_ptr<communication::IPartyCommunicationAgent> agent1_;
+
+  std::unique_ptr<IRandomCorrelatedObliviousTransfer> sender_;
+  std::unique_ptr<IRandomCorrelatedObliviousTransfer> receiver_;
+};
+
+class EmpShRandomCorrelatedObliviousTransferBenchmark final
+    : public RandomCorrelatedObliviousTransferBenchmark {
+ public:
+  void setup() override {
+    RandomCorrelatedObliviousTransferBenchmark::setup();
+    factory_ = std::make_unique<EmpShRandomCorrelatedObliviousTransferFactory>(
+        std::make_unique<util::AesPrgFactory>());
+  }
+};
+
+BENCHMARK_COUNTERS(EmpShRandomCorrelatedObliviousTransfer, counters) {
+  EmpShRandomCorrelatedObliviousTransferBenchmark benchmark;
+  benchmark.runBenchmark(counters);
+}
+
+class IknpShRandomCorrelatedObliviousTransferBenchmark final
+    : public RandomCorrelatedObliviousTransferBenchmark {
+ public:
+  void setup() override {
+    RandomCorrelatedObliviousTransferBenchmark::setup();
+    factory_ = std::make_unique<IknpShRandomCorrelatedObliviousTransferFactory>(
+        std::make_unique<NpBaseObliviousTransferFactory>());
+  }
+};
+
+BENCHMARK_COUNTERS(IknpShRandomCorrelatedObliviousTransfer, counters) {
+  IknpShRandomCorrelatedObliviousTransferBenchmark benchmark;
+  benchmark.runBenchmark(counters);
+}
+
+class ExtenderBasedRandomCorrelatedObliviousTransferWithIknpBenchmark final
+    : public RandomCorrelatedObliviousTransferBenchmark {
+ public:
+  void setup() override {
+    RandomCorrelatedObliviousTransferBenchmark::setup();
+    factory_ = std::make_unique<
+        ExtenderBasedRandomCorrelatedObliviousTransferFactory>(
+        std::make_unique<IknpShRandomCorrelatedObliviousTransferFactory>(
+            std::make_unique<NpBaseObliviousTransferFactory>()),
+        std::make_unique<ferret::RcotExtenderFactory>(
+            std::make_unique<ferret::TenLocalLinearMatrixMultiplierFactory>(),
+            std::make_unique<ferret::RegularErrorMultiPointCotFactory>(
+                std::make_unique<ferret::SinglePointCotFactory>())),
+        ferret::kExtendedSize,
+        ferret::kBaseSize,
+        ferret::kWeight);
+  }
+};
+
+BENCHMARK_COUNTERS(
+    ExtenderBasedRandomCorrelatedObliviousTransferWithIknp,
+    counters) {
+  ExtenderBasedRandomCorrelatedObliviousTransferWithIknpBenchmark benchmark;
+  benchmark.runBenchmark(counters);
+}
+
+class ExtenderBasedRandomCorrelatedObliviousTransferWithEmpBenchmark final
+    : public RandomCorrelatedObliviousTransferBenchmark {
+ public:
+  void setup() override {
+    RandomCorrelatedObliviousTransferBenchmark::setup();
+    factory_ = std::make_unique<
+        ExtenderBasedRandomCorrelatedObliviousTransferFactory>(
+        std::make_unique<EmpShRandomCorrelatedObliviousTransferFactory>(
+            std::make_unique<util::AesPrgFactory>()),
+        std::make_unique<ferret::RcotExtenderFactory>(
+            std::make_unique<ferret::TenLocalLinearMatrixMultiplierFactory>(),
+            std::make_unique<ferret::RegularErrorMultiPointCotFactory>(
+                std::make_unique<ferret::SinglePointCotFactory>())),
+        ferret::kExtendedSize,
+        ferret::kBaseSize,
+        ferret::kWeight);
+  }
+};
+
+BENCHMARK_COUNTERS(
+    ExtenderBasedRandomCorrelatedObliviousTransferWithEmp,
+    counters) {
+  ExtenderBasedRandomCorrelatedObliviousTransferWithEmpBenchmark benchmark;
+  benchmark.runBenchmark(counters);
+}
+
 } // namespace fbpcf::engine::tuple_generator::oblivious_transfer
 
 int main(int argc, char* argv[]) {


### PR DESCRIPTION
Summary:
This diff adds a base class for testing RCOT instances, and 4 sub-classes for each instance:
- EMP-based RCOT
- IKNP-based RCOT
- An extender-based RCOT with EMP
- An extender-based RCOT with IKNP

Differential Revision: D34724319

