### PR TITLE
Add semantic versioning, tags, and releases to docker publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,8 +3,6 @@ name: Publish Docker image
 on:
   push:
     branches: [ main ]
-  release:
-    types: [ published ]
 
 env:
   DISTRO: ubuntu
@@ -27,10 +25,19 @@ jobs:
         run: |
           ./build-docker.sh -u
 
-      - name: Sanity check fbpcf library
+      - name: Sanity check fbpcf library (only tests v1 functionality)
         timeout-minutes: 3
         run: |
           ./run-millionaire-sample.sh -u
+
+      - name: Create version string
+        id: create_version
+        uses: paulhatch/semantic-version@v4.0.2
+        with:
+          tag_prefix: "v"
+          major_pattern: "((MAJOR))"
+          minor_pattern: "((MINOR))"
+          format: "${major}.${minor}.${patch}-pre${increment}"
 
       - name: Log into registry ${{ env.REGISTRY }}
         uses: docker/login-action@v1
@@ -47,16 +54,20 @@ jobs:
         run: |
           docker tag ${{ env.LOCAL_IMAGE_NAME }} ${{ env.REGISTRY_IMAGE_NAME }}:${{ github.sha }}
           docker tag ${{ env.LOCAL_IMAGE_NAME }} ${{ env.REGISTRY_IMAGE_NAME }}:${{ steps.vars.outputs.ref }}
-
-      - name: Tag as latest
-        # Tag as latest only for main branch
-        if: github.event_name == 'push'
-        run: |
+          docker tag ${{ env.LOCAL_IMAGE_NAME }} ${{ env.REGISTRY_IMAGE_NAME }}:${{ steps.create_version.outputs.version_tag }}
           docker tag ${{ env.LOCAL_IMAGE_NAME }} ${{ env.REGISTRY_IMAGE_NAME }}:latest
 
       - name: Push Docker image
         run: |
           docker push --all-tags ${{ env.REGISTRY_IMAGE_NAME }}
+
+      - name: Create release
+        uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          prerelease: false
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "latest"
+          title: ${{ steps.create_version.outputs.version_tag }}
 
       - name: Cleanup
         run: |


### PR DESCRIPTION
Summary:
This diff does 4 things
1) We use `paulhatch/semantic-version` to generate a version string.
2) We do a `mathieudutour/github-tag-action` to assign the version to the commit
3) We add a new tag to the docker image that corresponds to the version string
4) We use `marvinpinto/action-automatic-releases` to create a tagged release of fbpcf

Differential Revision: D34826819

