### PR TITLE
Update all APIs to use std::shared_ptr<std::vector<char>> instead of a raw buffer

### DIFF
--- a/fbpcf/io/api/CloudFileReader.cpp
+++ b/fbpcf/io/api/CloudFileReader.cpp
@@ -8,6 +8,7 @@
 #include "fbpcf/io/api/CloudFileReader.h"
 #include <cstddef>
 #include <string>
+#include <vector>
 
 namespace fbpcf::io {
 
@@ -16,7 +17,7 @@ CloudFileReader::CloudFileReader(std::string /* filePath */) {}
 int CloudFileReader::close() {
   return 0;
 }
-int CloudFileReader::read(char buf[], size_t nBytes) {
+size_t CloudFileReader::read(std::vector<char>& /* buf */) {
   return 0;
 }
 

--- a/fbpcf/io/api/CloudFileReader.h
+++ b/fbpcf/io/api/CloudFileReader.h
@@ -8,6 +8,7 @@
 #pragma once
 #include <cstddef>
 #include <string>
+#include <vector>
 #include "fbpcf/io/api/IReaderCloser.h"
 
 namespace fbpcf::io {
@@ -22,7 +23,7 @@ class CloudFileReader : public IReaderCloser {
   explicit CloudFileReader(std::string filePath);
 
   int close() override;
-  int read(char buf[], size_t nBytes) override;
+  size_t read(std::vector<char>& buf) override;
   ~CloudFileReader() override;
 };
 

--- a/fbpcf/io/api/CloudFileWriter.cpp
+++ b/fbpcf/io/api/CloudFileWriter.cpp
@@ -7,7 +7,9 @@
 
 #include "fbpcf/io/api/CloudFileWriter.h"
 #include <cstddef>
+#include <memory>
 #include <string>
+#include <vector>
 
 namespace fbpcf::io {
 
@@ -16,7 +18,7 @@ CloudFileWriter::CloudFileWriter(std::string /* filePath */) {}
 int CloudFileWriter::close() {
   return 0;
 }
-int CloudFileWriter::write(char buf[], size_t nBytes) {
+size_t CloudFileWriter::write(std::vector<char>& /* buf */) {
   return 0;
 }
 

--- a/fbpcf/io/api/CloudFileWriter.h
+++ b/fbpcf/io/api/CloudFileWriter.h
@@ -8,6 +8,8 @@
 #pragma once
 #include <cstddef>
 #include <string>
+#include <vector>
+
 #include "fbpcf/io/api/IWriterCloser.h"
 
 namespace fbpcf::io {
@@ -22,7 +24,7 @@ class CloudFileWriter : public IWriterCloser {
   explicit CloudFileWriter(std::string filePath);
 
   int close() override;
-  int write(char buf[], size_t nBytes) override;
+  size_t write(std::vector<char>& buf) override;
   ~CloudFileWriter() override;
 };
 

--- a/fbpcf/io/api/FileReader.cpp
+++ b/fbpcf/io/api/FileReader.cpp
@@ -9,6 +9,7 @@
 #include <cstddef>
 #include <memory>
 #include <string>
+#include <vector>
 #include "fbpcf/io/api/CloudFileReader.h"
 #include "fbpcf/io/api/LocalFileReader.h"
 
@@ -27,8 +28,8 @@ FileReader::~FileReader() {
   close();
 }
 
-int FileReader::read(char buf[], size_t nBytes) {
-  return childReader_->read(buf, nBytes);
+size_t FileReader::read(std::vector<char>& buf) {
+  return childReader_->read(buf);
 }
 
 int FileReader::close() {

--- a/fbpcf/io/api/FileReader.h
+++ b/fbpcf/io/api/FileReader.h
@@ -9,6 +9,7 @@
 #include <cstddef>
 #include <memory>
 #include <string>
+#include <vector>
 #include "fbpcf/io/api/IReaderCloser.h"
 
 namespace fbpcf::io {
@@ -25,7 +26,7 @@ class FileReader : public IReaderCloser {
   explicit FileReader(std::string filePath);
 
   int close() override;
-  int read(char buf[], size_t nBytes) override;
+  size_t read(std::vector<char>& buf) override;
   ~FileReader() override;
 
  private:

--- a/fbpcf/io/api/FileWriter.cpp
+++ b/fbpcf/io/api/FileWriter.cpp
@@ -9,6 +9,7 @@
 #include <cstddef>
 #include <memory>
 #include <string>
+#include <vector>
 #include "fbpcf/io/api/CloudFileWriter.h"
 #include "fbpcf/io/api/IOUtils.h"
 #include "fbpcf/io/api/LocalFileWriter.h"
@@ -26,8 +27,8 @@ FileWriter::~FileWriter() {
   close();
 }
 
-int FileWriter::write(char buf[], size_t nBytes) {
-  return childWriter_->write(buf, nBytes);
+size_t FileWriter::write(std::vector<char>& buf) {
+  return childWriter_->write(buf);
 }
 
 int FileWriter::close() {

--- a/fbpcf/io/api/FileWriter.h
+++ b/fbpcf/io/api/FileWriter.h
@@ -9,6 +9,7 @@
 #include <cstddef>
 #include <memory>
 #include <string>
+#include <vector>
 #include "fbpcf/io/api/IWriterCloser.h"
 
 namespace fbpcf::io {
@@ -25,7 +26,7 @@ class FileWriter : public IWriterCloser {
   explicit FileWriter(std::string filePath);
 
   int close() override;
-  int write(char buf[], size_t nBytes) override;
+  size_t write(std::vector<char>& buf) override;
   ~FileWriter() override;
 
  private:

--- a/fbpcf/io/api/IReader.h
+++ b/fbpcf/io/api/IReader.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <cstddef>
+#include <vector>
 
 namespace fbpcf::io {
 
@@ -23,7 +24,7 @@ class IReader {
    * the provided buffer with the data that was
    * read
    */
-  virtual int read(char buf[], size_t nBytes) = 0;
+  virtual size_t read(std::vector<char>& buf) = 0;
   virtual ~IReader() = default;
 };
 

--- a/fbpcf/io/api/IWriter.h
+++ b/fbpcf/io/api/IWriter.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <cstddef>
+#include <vector>
 
 namespace fbpcf::io {
 
@@ -23,7 +24,7 @@ class IWriter {
    * an error. It attempts to write the first
    * n bytes of the entire provided buffer.
    */
-  virtual int write(char buf[], size_t nBytes) = 0;
+  virtual size_t write(std::vector<char>& buf) = 0;
   virtual ~IWriter() = default;
 };
 

--- a/fbpcf/io/api/LocalFileReader.cpp
+++ b/fbpcf/io/api/LocalFileReader.cpp
@@ -7,6 +7,7 @@
 
 #include "fbpcf/io/api/LocalFileReader.h"
 #include <cstddef>
+#include <vector>
 
 namespace fbpcf::io {
 
@@ -15,7 +16,7 @@ LocalFileReader::LocalFileReader(std::string /* filePath */) {}
 int LocalFileReader::close() {
   return 0;
 }
-int LocalFileReader::read(char buf[], size_t nBytes) {
+size_t LocalFileReader::read(std::vector<char>& /* buf */) {
   return 0;
 }
 

--- a/fbpcf/io/api/LocalFileReader.h
+++ b/fbpcf/io/api/LocalFileReader.h
@@ -8,6 +8,8 @@
 #pragma once
 #include <cstddef>
 #include <string>
+#include <vector>
+
 #include "fbpcf/io/api/IReaderCloser.h"
 
 namespace fbpcf::io {
@@ -22,7 +24,7 @@ class LocalFileReader : public IReaderCloser {
   explicit LocalFileReader(std::string filePath);
 
   int close() override;
-  int read(char buf[], size_t nBytes) override;
+  size_t read(std::vector<char>& buf) override;
   ~LocalFileReader() override;
 };
 

--- a/fbpcf/io/api/LocalFileWriter.cpp
+++ b/fbpcf/io/api/LocalFileWriter.cpp
@@ -8,6 +8,7 @@
 #include "fbpcf/io/api/LocalFileWriter.h"
 #include <cstddef>
 #include <string>
+#include <vector>
 
 namespace fbpcf::io {
 LocalFileWriter::LocalFileWriter(std::string /* filePath */) {}
@@ -15,7 +16,7 @@ LocalFileWriter::LocalFileWriter(std::string /* filePath */) {}
 int LocalFileWriter::close() {
   return 0;
 }
-int LocalFileWriter::write(char buf[], size_t nBytes) {
+size_t LocalFileWriter::write(std::vector<char>& /* buf */) {
   return 0;
 }
 

--- a/fbpcf/io/api/LocalFileWriter.h
+++ b/fbpcf/io/api/LocalFileWriter.h
@@ -8,6 +8,8 @@
 #pragma once
 #include <cstddef>
 #include <string>
+#include <vector>
+
 #include "fbpcf/io/api/IWriterCloser.h"
 
 namespace fbpcf::io {
@@ -22,7 +24,7 @@ class LocalFileWriter : public IWriterCloser {
   explicit LocalFileWriter(std::string filePath);
 
   int close() override;
-  int write(char buf[], size_t nBytes) override;
+  size_t write(std::vector<char>& buf) override;
   ~LocalFileWriter() override;
 };
 

--- a/fbpcf/io/api/SocketReader.h
+++ b/fbpcf/io/api/SocketReader.h
@@ -8,6 +8,7 @@
 #pragma once
 #include <openssl/ssl.h>
 #include <cstddef>
+#include <vector>
 
 #include "fbpcf/io/api/IReaderCloser.h"
 
@@ -32,7 +33,7 @@ class SocketReader : public IReaderCloser {
   SocketReader(SSL* ssl);
 
   int close() override;
-  int read(char buf[], size_t nBytes) override;
+  size_t read(std::vector<char>& buf) override;
   ~SocketReader() override;
 };
 

--- a/fbpcf/io/api/SocketWriter.h
+++ b/fbpcf/io/api/SocketWriter.h
@@ -9,6 +9,7 @@
 
 #include <openssl/ssl.h>
 #include <cstddef>
+#include <vector>
 
 #include "fbpcf/io/api/IWriterCloser.h"
 
@@ -33,7 +34,7 @@ class SocketWriter : public IWriterCloser {
   SocketWriter(SSL* ssl);
 
   int close() override;
-  int write(char buf[], size_t nBytes) override;
+  size_t write(std::vector<char>& buf) override;
   ~SocketWriter() override;
 };
 


### PR DESCRIPTION
Summary:
I'm still new to C++, so I did some research on the tradeoffs here
- raw arrays tend to be dangerous. there is a chance of reading unassigned memory, triggering stack overflows. You also don't have any metadata about things like size
- std::arrays are slightly better since they have a concept of size, but are just a fancy wrapper around raw arrays. furthermore, they have `size` as a template argument, which makes them pretty unwieldy to work with, because if you need to pass them into a function as an argument, the size needs to be a template.
- std::vector is the more modern approach. it is stored on the heap and has metadata around it. often, the biggest con to using vectors is performance. however, our use case is that we are simply filling up a pre-allocated vector, and not doing resizing, deleting etc. so, for us, using vector should have a negligible impact.

also, using a smart pointer makes sense for memory management reasons.

Differential Revision: D34839884

