### PR TITLE
Add write permission to docker-publish workflow so that it can create a release

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,7 +15,7 @@ jobs:
   push:
     runs-on: [self-hosted, e2e_test_runner]
     permissions:
-      contents: read
+      contents: write
       packages: write
 
     steps:


### PR DESCRIPTION
Summary: See title. This is required because D34826819 (https://github.com/facebookresearch/fbpcf/commit/6382b522c671417aa463f94f13e2a717d20f92d9) caused the workflow to start failing on master https://github.com/facebookresearch/fbpcf/actions/runs/1983395588

Differential Revision: D34882464

