### PR TITLE
Fix bug in container name for PL test

### DIFF
--- a/.github/workflows/continuous-tests-nonblocking.yml
+++ b/.github/workflows/continuous-tests-nonblocking.yml
@@ -210,7 +210,7 @@ jobs:
 
     - name: Start container
       run: |
-        ./start_container.sh ${{ env.PA_CONTAINER_NAME }} ${{ env.COORDINATOR_IMAGE }}:${{ env.VERSION_TAG }}
+        ./start_container.sh ${{ env.PL_CONTAINER_NAME }} ${{ env.COORDINATOR_IMAGE }}:${{ env.VERSION_TAG }}
       working-directory: fbpcf/tests/github/
 
     - name: Lift - Create Instance


### PR DESCRIPTION
Summary: See title. We were incorrectly passing PA_CONTAINER_NAME for the PL test

Differential Revision: D34882976

