### PR TITLE
Use correct ECS task definition in the PC config file

### DIFF
--- a/fbpcf/tests/github/fbpcf_e2e_aws.yml
+++ b/fbpcf/tests/github/fbpcf_e2e_aws.yml
@@ -28,7 +28,7 @@ private_computation:
           binary_version: latest
     OneDockerServiceConfig:
       constructor:
-        task_definition: onedocker-task-fbpcf-e2e-workflow:6#onedocker-container-fbpcf-e2e-workflow
+        task_definition: onedocker-task-fbpcf-e2e-workflow:7#onedocker-container-fbpcf-e2e-workflow
 pid:
   dependency:
     PIDInstanceRepository:


### PR DESCRIPTION
Summary: This was using the old container definition. I had tested locally using version 7, but for some reason version 6 got committed to prod.

Differential Revision: D34885427

