### PR TITLE
Combine builds into one job

### DIFF
--- a/.github/workflows/continuous-tests-nonblocking.yml
+++ b/.github/workflows/continuous-tests-nonblocking.yml
@@ -17,7 +17,7 @@ env:
   VERSION_TAG: latest-build
 
 jobs:
-  build_docker_fbpcf:
+  build_docker:
     runs-on: [self-hosted, e2e_test_runner]
 
     steps:
@@ -31,21 +31,11 @@ jobs:
       run: |
         ./build-docker.sh -u
 
-  sanity_check_pcf_v1:
-    runs-on: [self-hosted, e2e_test_runner]
-    needs: build_docker_fbpcf
-    steps:
-    - uses: actions/checkout@v2
     - name: Sanity check fbpcf library
       timeout-minutes: 3
       run: |
         ./run-millionaire-sample.sh -u
 
-  build_docker_fbpcs:
-    runs-on: [self-hosted, e2e_test_runner]
-    needs: build_docker_fbpcf
-    steps:
-    - uses: actions/checkout@v2
     - name: Log into registry ${{ env.REGISTRY }}
       uses: docker/login-action@v1
       with:
@@ -79,7 +69,7 @@ jobs:
 
   private_attribution_e2e_test:
     runs-on: [self-hosted, e2e_test_runner]
-    needs: build_docker_fbpcs
+    needs: build_docker
     steps:
     - uses: actions/checkout@v2
     - name: Log into registry ${{ env.REGISTRY }}
@@ -193,7 +183,7 @@ jobs:
 
   private_lift_e2e_test:
     runs-on: [self-hosted, e2e_test_runner]
-    needs: build_docker_fbpcs
+    needs: build_docker
     steps:
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
Summary:
I think the way the self hosted runner works is that it doesn't seem to preserve state between two jobs (since jobs from different workflows can be run in any order). So, we were seeing instances where the `sanity_check` job didn't find the fbpcf image.

This will fix it. The other option was to upload to the docker registry with a pre-release tag, but that would upload an image for every pre-release, which will use a lot of storage.

Differential Revision: D34888385

