### PR TITLE
Change fetch-depth and add action to tag commit

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,6 +20,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Build fbpcf docker image
         run: |
@@ -38,6 +40,14 @@ jobs:
           major_pattern: "((MAJOR))"
           minor_pattern: "((MINOR))"
           format: "${major}.${minor}.${patch}-pre${increment}"
+
+      - name: Add tag to commit
+      id: tag_version
+      uses: mathieudutour/github-tag-action@v6.0
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        custom_tag: ${{ steps.create_version.outputs.version_tag }}
+        tag_prefix: ""
 
       - name: Log into registry ${{ env.REGISTRY }}
         uses: docker/login-action@v1


### PR DESCRIPTION
Summary:
After the workflow ran yesterday, I observed that the `semantic_version` action did **not** tag commits. This is actually confirmed by looking at the source code. Seems like the only thing it does is set the output: https://fburl.com/5rbgqi87

So, I added back the action for tags that was removed in V2 of D34826819 (https://github.com/facebookresearch/fbpcf/commit/6382b522c671417aa463f94f13e2a717d20f92d9).

In addition, the semantic versioning action says to use `fetch-depth: 0` to properly set the version string: https://fburl.com/jwsg8220. I do that as well.

Differential Revision: D34888631

