### PR TITLE
Use different action for creating releases

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -72,12 +72,12 @@ jobs:
           docker push --all-tags ${{ env.REGISTRY_IMAGE_NAME }}
 
       - name: Create release
-        uses: "marvinpinto/action-automatic-releases@latest"
+        uses: "actions/create-release@v1"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          prerelease: false
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "latest"
-          title: ${{ steps.create_version.outputs.version_tag }}
+          release_name: ${{ steps.create_version.outputs.version_tag }}
+          tag_name: ${{ steps.create_version.outputs.version_tag }}
 
       - name: Cleanup
         run: |


### PR DESCRIPTION
Summary:
Notice that the releases are getting overridden - https://github.com/facebookresearch/fbpcf/releases

even though the tags are being properly set - https://github.com/facebookresearch/fbpcf/tags

Seems like this library is buggy. I am now using the library that folly uses - https://github.com/facebook/folly/blob/main/.github/workflows/TagIt.yml

Even though this action is not actively developed, v1 is stable and is good enough for folly...and folly is pretty trustworthy

Differential Revision: D34931681

