### PR TITLE
Split up secret share AND computation method

### DIFF
--- a/fbpcf/engine/SecretShareEngine.h
+++ b/fbpcf/engine/SecretShareEngine.h
@@ -291,6 +291,21 @@ class SecretShareEngine final : public ISecretShareEngine {
       std::vector<ScheduledCompositeAND>& compositeAnds,
       std::vector<ScheduledBatchCompositeAND>& batchCompositeAnds);
 
+  std::vector<bool> computeSecretSharesToOpen(
+      std::vector<ScheduledAND>& ands,
+      std::vector<ScheduledBatchAND>& batchAnds,
+      std::vector<ScheduledCompositeAND>& compositeAnds,
+      std::vector<ScheduledBatchCompositeAND>& batchCompositeAnds,
+      std::vector<tuple_generator::ITupleGenerator::BooleanTuple>& tuples);
+
+  ExecutionResults computeExecutionResultsFromOpenedShares(
+      std::vector<ScheduledAND>& ands,
+      std::vector<ScheduledBatchAND>& batchAnds,
+      std::vector<ScheduledCompositeAND>& compositeAnds,
+      std::vector<ScheduledBatchCompositeAND>& batchCompositeAnds,
+      std::vector<bool> openedSecrets,
+      std::vector<tuple_generator::ITupleGenerator::BooleanTuple> tuples);
+
   std::unique_ptr<tuple_generator::ITupleGenerator> tupleGenerator_;
   std::unique_ptr<communication::ISecretShareEngineCommunicationAgent>
       communicationAgent_;

--- a/fbpcf/engine/tuple_generator/ITupleGenerator.h
+++ b/fbpcf/engine/tuple_generator/ITupleGenerator.h
@@ -36,17 +36,17 @@ class ITupleGenerator {
     }
 
     // get the first share
-    bool getA() {
+    bool getA() const {
       return (value_ >> 2) & 1;
     }
 
     // get the second share
-    bool getB() {
+    bool getB() const {
       return (value_ >> 1) & 1;
     }
 
     // get the third share
-    bool getC() {
+    bool getC() const {
       return value_ & 1;
     }
 


### PR DESCRIPTION
Summary:
Follow up on the comment in D34461061 (https://github.com/facebookresearch/fbpcf/commit/34bdf51925aae32a3e73efef8fa9dc7b0ab701ed). This will split up the method `computeAllANDsFromScheduledANDs` into 3 steps

1. Count the total number of tuples and generate them
2. Pass to helper function to generate shares
3. Reveal the secrets to each other
4. Pass to helper function to compute final result of AND's

Reviewed By: RuiyuZhu

Differential Revision: D34801200

