### PR TITLE
Use `dev` tag for coordinator image

### DIFF
--- a/.github/workflows/continuous-tests-nonblocking.yml
+++ b/.github/workflows/continuous-tests-nonblocking.yml
@@ -9,7 +9,7 @@ env:
   REGISTRY: ghcr.io
   FBPCF_LOCAL_IMAGE_NAME: ${{ github.event.repository.name }}/ubuntu
   REGISTRY_IMAGE_NAME: ghcr.io/${{ github.repository }}/ubuntu
-  COORDINATOR_IMAGE: ghcr.io/facebookresearch/fbpcs/coordinator
+  COORDINATOR_IMAGE_DEV: ghcr.io/facebookresearch/fbpcs/coordinator:dev
   LOCAL_IMAGE_NAME: fbpcs/onedocker
   TEST_REGISTRY_IMAGE_NAME: ghcr.io/${{ github.repository }}/test/ubuntu
   PL_CONTAINER_NAME: e2e_pl_container
@@ -81,11 +81,11 @@ jobs:
 
     - name: Pull coordinator image
       run: |
-        docker pull ${{ env.COORDINATOR_IMAGE }}:${{ env.VERSION_TAG }}
+        docker pull ${{ env.COORDINATOR_IMAGE_DEV }}
 
     - name: Start container
       run: |
-        ./start_container.sh ${{ env.PA_CONTAINER_NAME }} ${{ env.COORDINATOR_IMAGE }}:${{ env.VERSION_TAG }}
+        ./start_container.sh ${{ env.PA_CONTAINER_NAME }} ${{ env.COORDINATOR_IMAGE_DEV }}
       working-directory: fbpcf/tests/github/
 
     - name: Attribution - Create Instance
@@ -196,11 +196,11 @@ jobs:
 
     - name: Pull coordinator image
       run: |
-        docker pull ${{ env.COORDINATOR_IMAGE }}:${{ env.VERSION_TAG }}
+        docker pull ${{ env.COORDINATOR_IMAGE_DEV }}
 
     - name: Start container
       run: |
-        ./start_container.sh ${{ env.PL_CONTAINER_NAME }} ${{ env.COORDINATOR_IMAGE }}:${{ env.VERSION_TAG }}
+        ./start_container.sh ${{ env.PL_CONTAINER_NAME }} ${{ env.COORDINATOR_IMAGE_DEV }}
       working-directory: fbpcf/tests/github/
 
     - name: Lift - Create Instance


### PR DESCRIPTION
Summary:
We need the coordinator to have Ajinkya's latest changes that introduce a PCF 2 stage flow

The `latest` tag is 9 days old. It does not have the changes.

In order to unblock our workflow, we can use the `dev` tag. It is stable because it's only pushed when the e2e tests for lift and attribution pass.

Reviewed By: jrodal98

Differential Revision: D34939006

