### PR TITLE
Track initialization metrics separately

### DIFF
--- a/fbpcf/engine/tuple_generator/test/benchmarks/TupleGeneratorBenchmark.cpp
+++ b/fbpcf/engine/tuple_generator/test/benchmarks/TupleGeneratorBenchmark.cpp
@@ -47,13 +47,20 @@ class ProductShareGeneratorBenchmark : public util::NetworkedBenchmark {
     receiverRight_ = util::getRandomBoolVector(size_);
   }
 
-  void runSender() override {
+ protected:
+  void initSender() override {
     sender_ = senderFactory_->create(1);
+  }
+
+  void runSender() override {
     sender_->generateBooleanProductShares(senderLeft_, senderRight_);
   }
 
-  void runReceiver() override {
+  void initReceiver() override {
     receiver_ = receiverFactory_->create(0);
+  }
+
+  void runReceiver() override {
     receiver_->generateBooleanProductShares(receiverLeft_, receiverRight_);
   }
 
@@ -98,13 +105,20 @@ class BaseTupleGeneratorBenchmark : public util::NetworkedBenchmark {
     receiverFactory_ = getTupleGeneratorFactory(1, *agentFactory1_);
   }
 
-  void runSender() override {
+ protected:
+  void initSender() override {
     sender_ = senderFactory_->create();
+  }
+
+  void runSender() override {
     sender_->getBooleanTuple(size_);
   }
 
-  void runReceiver() override {
+  void initReceiver() override {
     receiver_ = receiverFactory_->create();
+  }
+
+  void runReceiver() override {
     receiver_->getBooleanTuple(size_);
   }
 
@@ -112,7 +126,6 @@ class BaseTupleGeneratorBenchmark : public util::NetworkedBenchmark {
     return sender_->getTrafficStatistics();
   }
 
- protected:
   virtual std::unique_ptr<ITupleGeneratorFactory> getTupleGeneratorFactory(
       int myId,
       communication::IPartyCommunicationAgentFactory& agentFactory) = 0;


### PR DESCRIPTION
Summary: Many components in the MPC engine have a one-time initialization. Depending on how large of a sample size we use in our benchmarks, this can take up a significant amount of the overall runtime or network traffic. For this reason, I'm thinking it'd be useful to separate out the portion that's just for the initialization.

Reviewed By: adshastri

Differential Revision: D34906916

