### PR TITLE
Add eof() function to reader APIs

### DIFF
--- a/fbpcf/io/api/CloudFileReader.cpp
+++ b/fbpcf/io/api/CloudFileReader.cpp
@@ -20,6 +20,9 @@ int CloudFileReader::close() {
 size_t CloudFileReader::read(std::vector<char>& /* buf */) {
   return 0;
 }
+bool CloudFileReader::eof() {
+  return false;
+}
 
 CloudFileReader::~CloudFileReader() {
   close();

--- a/fbpcf/io/api/CloudFileReader.h
+++ b/fbpcf/io/api/CloudFileReader.h
@@ -24,6 +24,7 @@ class CloudFileReader : public IReaderCloser {
 
   int close() override;
   size_t read(std::vector<char>& buf) override;
+  bool eof() override;
   ~CloudFileReader() override;
 };
 

--- a/fbpcf/io/api/FileReader.cpp
+++ b/fbpcf/io/api/FileReader.cpp
@@ -32,6 +32,10 @@ size_t FileReader::read(std::vector<char>& buf) {
   return childReader_->read(buf);
 }
 
+bool FileReader::eof() {
+  return childReader_->eof();
+}
+
 int FileReader::close() {
   return childReader_->close();
 }

--- a/fbpcf/io/api/FileReader.h
+++ b/fbpcf/io/api/FileReader.h
@@ -27,6 +27,7 @@ class FileReader : public IReaderCloser {
 
   int close() override;
   size_t read(std::vector<char>& buf) override;
+  bool eof() override;
   ~FileReader() override;
 
  private:

--- a/fbpcf/io/api/IReader.h
+++ b/fbpcf/io/api/IReader.h
@@ -25,6 +25,11 @@ class IReader {
    * read
    */
   virtual size_t read(std::vector<char>& buf) = 0;
+  /*
+   * eof() returns whether there is any more
+   * data left in the file
+   */
+  virtual bool eof() = 0;
   virtual ~IReader() = default;
 };
 

--- a/fbpcf/io/api/LocalFileReader.cpp
+++ b/fbpcf/io/api/LocalFileReader.cpp
@@ -7,17 +7,34 @@
 
 #include "fbpcf/io/api/LocalFileReader.h"
 #include <cstddef>
+#include <fstream>
 #include <vector>
 
 namespace fbpcf::io {
 
-LocalFileReader::LocalFileReader(std::string /* filePath */) {}
+LocalFileReader::LocalFileReader(std::string filePath) {
+  inputStream_ = std::make_unique<std::ifstream>(filePath);
+}
 
 int LocalFileReader::close() {
-  return 0;
+  inputStream_->close();
+
+  return inputStream_->fail() ? -1 : 0;
 }
-size_t LocalFileReader::read(std::vector<char>& /* buf */) {
-  return 0;
+
+size_t LocalFileReader::read(std::vector<char>& buf) {
+  if (inputStream_->fail()) {
+    throw std::runtime_error("Input stream is in a failed state.");
+  }
+
+  inputStream_->read(buf.data(), buf.size());
+
+  if (inputStream_->fail() && !inputStream_->eof()) {
+    throw std::runtime_error(
+        "Internal error when reading from local file. Stream integrity may have been affected.");
+  }
+
+  return inputStream_->gcount();
 }
 
 LocalFileReader::~LocalFileReader() {

--- a/fbpcf/io/api/LocalFileReader.cpp
+++ b/fbpcf/io/api/LocalFileReader.cpp
@@ -37,6 +37,10 @@ size_t LocalFileReader::read(std::vector<char>& buf) {
   return inputStream_->gcount();
 }
 
+bool LocalFileReader::eof() {
+  return inputStream_->eof();
+}
+
 LocalFileReader::~LocalFileReader() {
   close();
 }

--- a/fbpcf/io/api/LocalFileReader.h
+++ b/fbpcf/io/api/LocalFileReader.h
@@ -7,6 +7,8 @@
 
 #pragma once
 #include <cstddef>
+#include <fstream>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -26,6 +28,9 @@ class LocalFileReader : public IReaderCloser {
   int close() override;
   size_t read(std::vector<char>& buf) override;
   ~LocalFileReader() override;
+
+ private:
+  std::unique_ptr<std::ifstream> inputStream_;
 };
 
 } // namespace fbpcf::io

--- a/fbpcf/io/api/LocalFileReader.h
+++ b/fbpcf/io/api/LocalFileReader.h
@@ -27,6 +27,7 @@ class LocalFileReader : public IReaderCloser {
 
   int close() override;
   size_t read(std::vector<char>& buf) override;
+  bool eof() override;
   ~LocalFileReader() override;
 
  private:

--- a/fbpcf/io/api/LocalFileWriter.cpp
+++ b/fbpcf/io/api/LocalFileWriter.cpp
@@ -7,17 +7,30 @@
 
 #include "fbpcf/io/api/LocalFileWriter.h"
 #include <cstddef>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
 namespace fbpcf::io {
-LocalFileWriter::LocalFileWriter(std::string /* filePath */) {}
+LocalFileWriter::LocalFileWriter(std::string filePath) {
+  outputStream_ = std::make_unique<std::ofstream>(filePath);
+}
 
 int LocalFileWriter::close() {
-  return 0;
+  outputStream_->close();
+
+  return outputStream_->fail() ? -1 : 0;
 }
-size_t LocalFileWriter::write(std::vector<char>& /* buf */) {
-  return 0;
+
+size_t LocalFileWriter::write(std::vector<char>& buf) {
+  outputStream_->write(buf.data(), buf.size());
+
+  if (outputStream_->fail()) {
+    throw std::runtime_error(
+        "Internal error when writing to local file. Stream integrity may have been affected.");
+  }
+
+  return buf.size();
 }
 
 LocalFileWriter::~LocalFileWriter() {

--- a/fbpcf/io/api/LocalFileWriter.h
+++ b/fbpcf/io/api/LocalFileWriter.h
@@ -7,6 +7,8 @@
 
 #pragma once
 #include <cstddef>
+#include <fstream>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -26,6 +28,9 @@ class LocalFileWriter : public IWriterCloser {
   int close() override;
   size_t write(std::vector<char>& buf) override;
   ~LocalFileWriter() override;
+
+ private:
+  std::unique_ptr<std::ofstream> outputStream_;
 };
 
 } // namespace fbpcf::io

--- a/fbpcf/io/api/SocketReader.h
+++ b/fbpcf/io/api/SocketReader.h
@@ -34,6 +34,7 @@ class SocketReader : public IReaderCloser {
 
   int close() override;
   size_t read(std::vector<char>& buf) override;
+  bool eof() override;
   ~SocketReader() override;
 };
 

--- a/fbpcf/io/api/test/LocalFileReaderTest.cpp
+++ b/fbpcf/io/api/test/LocalFileReaderTest.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include "folly/logging/xlog.h"
+
+#include "fbpcf/io/api/LocalFileReader.h"
+#include "fbpcf/io/api/test/utils/IOTestHelper.h"
+
+namespace fbpcf::io {
+
+TEST(LocalFileReaderTest, testReadingFromFile) {
+  auto reader = std::make_unique<fbpcf::io::LocalFileReader>(
+      IOTestHelper::getBaseDirFromPath(__FILE__) +
+      "data/local_file_reader_test_file.txt");
+
+  /*
+    CASE 1A
+    Buffer of size 20, read 20 bytes
+  */
+  auto buf = std::vector<char>(20);
+  auto nBytes = reader->read(buf);
+
+  EXPECT_EQ(nBytes, 20);
+  IOTestHelper::expectBufferToEqualString(buf, "this is a test file\n", 20);
+
+  /*
+      CASE 1B
+      Buffer of size 25, read 25 bytes
+  */
+  auto buf2 = std::vector<char>(25);
+  nBytes = reader->read(buf2);
+  EXPECT_EQ(nBytes, 25);
+  IOTestHelper::expectBufferToEqualString(
+      buf2, "it has many lines in it\n\n", 25);
+
+  /*
+      CASE 2
+      Buffer of size 500, but file only has 45 bytes
+      Expect to read 45 bytes
+  */
+  auto buf3 = std::vector<char>(500);
+
+  nBytes = reader->read(buf3);
+
+  EXPECT_EQ(nBytes, 45);
+  IOTestHelper::expectBufferToEqualString(
+      buf3, "the quick brown fox jumped over the lazy dog\n", 45);
+
+  EXPECT_THROW(reader->read(buf3), std::runtime_error);
+}
+
+} // namespace fbpcf::io

--- a/fbpcf/io/api/test/LocalFileReaderTest.cpp
+++ b/fbpcf/io/api/test/LocalFileReaderTest.cpp
@@ -18,6 +18,8 @@ TEST(LocalFileReaderTest, testReadingFromFile) {
       IOTestHelper::getBaseDirFromPath(__FILE__) +
       "data/local_file_reader_test_file.txt");
 
+  EXPECT_FALSE(reader->eof());
+
   /*
     CASE 1A
     Buffer of size 20, read 20 bytes
@@ -27,6 +29,7 @@ TEST(LocalFileReaderTest, testReadingFromFile) {
 
   EXPECT_EQ(nBytes, 20);
   IOTestHelper::expectBufferToEqualString(buf, "this is a test file\n", 20);
+  EXPECT_FALSE(reader->eof());
 
   /*
       CASE 1B
@@ -37,6 +40,7 @@ TEST(LocalFileReaderTest, testReadingFromFile) {
   EXPECT_EQ(nBytes, 25);
   IOTestHelper::expectBufferToEqualString(
       buf2, "it has many lines in it\n\n", 25);
+  EXPECT_FALSE(reader->eof());
 
   /*
       CASE 2
@@ -50,6 +54,8 @@ TEST(LocalFileReaderTest, testReadingFromFile) {
   EXPECT_EQ(nBytes, 45);
   IOTestHelper::expectBufferToEqualString(
       buf3, "the quick brown fox jumped over the lazy dog\n", 45);
+
+  EXPECT_TRUE(reader->eof());
 
   EXPECT_THROW(reader->read(buf3), std::runtime_error);
 }

--- a/fbpcf/io/api/test/data/expected_local_file_writer_test_file.txt
+++ b/fbpcf/io/api/test/data/expected_local_file_writer_test_file.txt
@@ -1,0 +1,4 @@
+this file contains the expected text in local_file_writer_test_file.text
+
+LocalFileWriterTest writes to the above file
+We assert that it's contents match this file

--- a/fbpcf/io/api/test/data/local_file_reader_test_file.txt
+++ b/fbpcf/io/api/test/data/local_file_reader_test_file.txt
@@ -1,0 +1,4 @@
+this is a test file
+it has many lines in it
+
+the quick brown fox jumped over the lazy dog

--- a/fbpcf/io/api/test/utils/IOTestHelper.h
+++ b/fbpcf/io/api/test/utils/IOTestHelper.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <gtest/gtest.h>
+#include <string>
+
+namespace fbpcf::io {
+
+class IOTestHelper {
+ public:
+  static void expectBufferToEqualString(
+      std::vector<char>& buf,
+      std::string contents,
+      size_t nBytes) {
+    for (int i = 0; i < nBytes; i++) {
+      EXPECT_EQ(buf.at(i), contents.at(i));
+    }
+  }
+
+  static std::string getBaseDirFromPath(const std::string& filePath) {
+    return filePath.substr(0, filePath.rfind("/") + 1);
+  }
+};
+
+} // namespace fbpcf::io

--- a/fbpcf/io/api/test/utils/IOTestHelper.h
+++ b/fbpcf/io/api/test/utils/IOTestHelper.h
@@ -8,6 +8,9 @@
 #pragma once
 
 #include <gtest/gtest.h>
+#include <fstream>
+#include <memory>
+
 #include <string>
 
 namespace fbpcf::io {
@@ -25,6 +28,23 @@ class IOTestHelper {
 
   static std::string getBaseDirFromPath(const std::string& filePath) {
     return filePath.substr(0, filePath.rfind("/") + 1);
+  }
+
+  static void expectFileContentsMatch(
+      std::string testFilePath,
+      std::string expectedFilePath) {
+    auto testFile = std::make_unique<std::ifstream>(testFilePath);
+    auto expectedFile = std::make_unique<std::ifstream>(expectedFilePath);
+
+    while (!expectedFile->eof()) {
+      if (testFile->eof()) {
+        FAIL();
+      }
+
+      auto expected = expectedFile->get();
+      auto test = testFile->get();
+      EXPECT_EQ(test, expected);
+    }
   }
 };
 


### PR DESCRIPTION
Summary: We need to know whether the underlying source has any more data, otherwise we won't know whether to stop reading

Differential Revision: D34967134

