### PR TITLE
Refactor gate keeper

### DIFF
--- a/fbpcf/scheduler/gate_keeper/GateKeeper.cpp
+++ b/fbpcf/scheduler/gate_keeper/GateKeeper.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "fbpcf/scheduler/gate_keeper/GateKeeper.h"
+#include <cstddef>
 #include "fbpcf/scheduler/IScheduler.h"
 #include "fbpcf/scheduler/gate_keeper/BatchCompositeGate.h"
 #include "fbpcf/scheduler/gate_keeper/BatchNormalGate.h"
@@ -19,63 +20,144 @@ GateKeeper::GateKeeper(std::shared_ptr<IWireKeeper> wireKeeper)
 
 IScheduler::WireId<IScheduler::Boolean> GateKeeper::inputGate(
     BoolType<false> initialValue) {
-  return addGate<false, false>(
-      INormalGate<IScheduler::Boolean>::GateType::Input,
-      IScheduler::WireId<IScheduler::Boolean>(),
-      IScheduler::WireId<IScheduler::Boolean>(),
-      initialValue);
+  auto level = getOutputLevel(
+      GateClass<false>::isFree(
+          INormalGate<IScheduler::Boolean>::GateType::Input),
+      firstUnexecutedLevel_);
+  auto outputWire = allocateNewWire(initialValue, level);
+  addGate(
+      std::make_unique<NormalGate<IScheduler::Boolean>>(
+          INormalGate<IScheduler::Boolean>::GateType::Input,
+          outputWire,
+          IScheduler::WireId<IScheduler::Boolean>(),
+          IScheduler::WireId<IScheduler::Boolean>(),
+          0,
+          *wireKeeper_),
+      level);
+  return outputWire;
 }
 
 IScheduler::WireId<IScheduler::Boolean> GateKeeper::inputGateBatch(
     BoolType<true> initialValue) {
-  return addGate<true, false>(
-      INormalGate<IScheduler::Boolean>::GateType::Input,
-      IScheduler::WireId<IScheduler::Boolean>(),
-      IScheduler::WireId<IScheduler::Boolean>(),
-      initialValue);
+  auto size = initialValue.size();
+  auto level = getOutputLevel(
+      GateClass<false>::isFree(
+          INormalGate<IScheduler::Boolean>::GateType::Input),
+      firstUnexecutedLevel_);
+
+  auto outputWire = allocateNewWire(initialValue, level);
+  addGate(
+      std::make_unique<BatchNormalGate<IScheduler::Boolean>>(
+          INormalGate<IScheduler::Boolean>::GateType::Input,
+          outputWire,
+          IScheduler::WireId<IScheduler::Boolean>(),
+          IScheduler::WireId<IScheduler::Boolean>(),
+          0,
+          size,
+          *wireKeeper_),
+      level);
+  return outputWire;
 }
 
 IScheduler::WireId<IScheduler::Boolean> GateKeeper::outputGate(
     IScheduler::WireId<IScheduler::Boolean> src,
     int partyID) {
-  return addGate<false, false>(
-      INormalGate<IScheduler::Boolean>::GateType::Output,
-      src,
-      IScheduler::WireId<IScheduler::Boolean>(),
-      false,
-      partyID);
+  auto level = getOutputLevel(
+      GateClass<false>::isFree(
+          INormalGate<IScheduler::Boolean>::GateType::Output),
+      getMaxLevel<false>(src));
+  auto outputWire = allocateNewWire(false, level);
+
+  addGate(
+      std::make_unique<NormalGate<IScheduler::Boolean>>(
+          INormalGate<IScheduler::Boolean>::GateType::Output,
+          outputWire,
+          src,
+          IScheduler::WireId<IScheduler::Boolean>(),
+          partyID,
+          *wireKeeper_),
+      level);
+
+  return outputWire;
 }
 
 IScheduler::WireId<IScheduler::Boolean> GateKeeper::outputGateBatch(
     IScheduler::WireId<IScheduler::Boolean> src,
     int partyID) {
-  return addGate<true, false>(
-      INormalGate<IScheduler::Boolean>::GateType::Output,
-      src,
-      IScheduler::WireId<IScheduler::Boolean>(),
-      {},
-      partyID);
+  auto level = getOutputLevel(
+      GateClass<false>::isFree(
+          INormalGate<IScheduler::Boolean>::GateType::Output),
+      getMaxLevel<true>(src));
+  auto outputWire = allocateNewWire(std::vector<bool>(), level);
+
+  addGate(
+      std::make_unique<BatchNormalGate<IScheduler::Boolean>>(
+          INormalGate<IScheduler::Boolean>::GateType::Output,
+          outputWire,
+          src,
+          IScheduler::WireId<IScheduler::Boolean>(),
+          partyID,
+          0,
+          *wireKeeper_),
+      level);
+
+  return outputWire;
 }
 
 IScheduler::WireId<IScheduler::Boolean> GateKeeper::normalGate(
     INormalGate<IScheduler::Boolean>::GateType gateType,
     IScheduler::WireId<IScheduler::Boolean> left,
     IScheduler::WireId<IScheduler::Boolean> right) {
-  return addGate<false, false>(gateType, left, right, false);
+  auto level = getOutputLevel(
+      GateClass<false>::isFree(gateType),
+      std::max(getMaxLevel<false>(left), getMaxLevel<false>(right)));
+  auto outputWire = allocateNewWire(false, level);
+
+  addGate(
+      std::make_unique<NormalGate<IScheduler::Boolean>>(
+          gateType, outputWire, left, right, 0, *wireKeeper_),
+      level);
+
+  return outputWire;
 }
 
 IScheduler::WireId<IScheduler::Boolean> GateKeeper::normalGateBatch(
     INormalGate<IScheduler::Boolean>::GateType gateType,
     IScheduler::WireId<IScheduler::Boolean> left,
     IScheduler::WireId<IScheduler::Boolean> right) {
-  return addGate<true, false>(gateType, left, right, {});
+  auto level = getOutputLevel(
+      GateClass<false>::isFree(gateType),
+      std::max(getMaxLevel<true>(left), getMaxLevel<true>(right)));
+  auto outputWire = allocateNewWire(std::vector<bool>(), level);
+
+  addGate(
+      std::make_unique<BatchNormalGate<IScheduler::Boolean>>(
+          gateType, outputWire, left, right, 0, 0, *wireKeeper_),
+      level);
+
+  return outputWire;
 }
 
 std::vector<IScheduler::WireId<IScheduler::Boolean>> GateKeeper::compositeGate(
     ICompositeGate::GateType gateType,
     IScheduler::WireId<IScheduler::Boolean> left,
     std::vector<IScheduler::WireId<IScheduler::Boolean>> rights) {
-  return addGate<false, true>(gateType, left, rights, 0);
+  auto compositeSize = rights.size();
+  std::vector<IScheduler::WireId<IScheduler::Boolean>> outputWires(
+      compositeSize);
+  auto level = getOutputLevel(
+      GateClass<true>::isFree(gateType),
+      std::max(getMaxLevel<false>(left), getMaxLevel<false>(rights)));
+  for (size_t i = 0; i < compositeSize; i++) {
+    outputWires[i] = allocateNewWire(false, level);
+  }
+
+  addGate(
+      std::make_unique<CompositeGate>(
+          gateType, outputWires, left, rights, *wireKeeper_),
+      level);
+
+  return outputWires;
 }
 
 std::vector<IScheduler::WireId<IScheduler::Boolean>>
@@ -83,7 +165,22 @@ GateKeeper::compositeGateBatch(
     ICompositeGate::GateType gateType,
     IScheduler::WireId<IScheduler::Boolean> left,
     std::vector<IScheduler::WireId<IScheduler::Boolean>> rights) {
-  return addGate<true, true>(gateType, left, rights, {});
+  auto compositeSize = rights.size();
+  std::vector<IScheduler::WireId<IScheduler::Boolean>> outputWires(
+      compositeSize);
+  auto level = getOutputLevel(
+      GateClass<true>::isFree(gateType),
+      std::max(getMaxLevel<true>(left), getMaxLevel<true>(rights)));
+  for (size_t i = 0; i < compositeSize; i++) {
+    outputWires[i] = allocateNewWire(std::vector<bool>(), level);
+  }
+
+  addGate(
+      std::make_unique<BatchCompositeGate>(
+          gateType, outputWires, left, rights, *wireKeeper_),
+      level);
+
+  return outputWires;
 }
 
 uint32_t GateKeeper::getFirstUnexecutedLevel() const {
@@ -102,118 +199,4 @@ bool GateKeeper::hasReachedBatchingLimit() const {
   return numUnexecutedGates_ > kMaxUnexecutedGates;
 }
 
-template <bool usingBatch, bool isCompositeWire>
-GateKeeper::RightWireType<isCompositeWire> GateKeeper::addGate(
-    GateType<isCompositeWire> gateType,
-    IScheduler::WireId<IScheduler::Boolean> left,
-    RightWireType<isCompositeWire> right,
-    BoolType<usingBatch> initialValue,
-    int partyID) {
-  numUnexecutedGates_++;
-
-  auto level = getFirstAvailableLevelForNewWire<usingBatch, isCompositeWire>(
-      gateType, left, right);
-
-  while (gatesByLevelOffset_.size() <= level - firstUnexecutedLevel_) {
-    gatesByLevelOffset_.emplace_back(std::vector<std::unique_ptr<IGate>>());
-  }
-
-  auto& gatesForLevel = gatesByLevelOffset_.at(level - firstUnexecutedLevel_);
-
-  RightWireType<isCompositeWire> outputWire;
-  if constexpr (isCompositeWire) {
-    if constexpr (usingBatch) {
-      for (size_t i = 0; i < right.size(); i++) {
-        outputWire.push_back(wireKeeper_->allocateBatchBooleanValue({}, level));
-      }
-      gatesForLevel.push_back(std::make_unique<BatchCompositeGate>(
-          gateType, outputWire, left, right, *wireKeeper_));
-    } else {
-      for (size_t i = 0; i < right.size(); i++) {
-        outputWire.push_back(wireKeeper_->allocateBooleanValue(0, level));
-      }
-      gatesForLevel.push_back(std::make_unique<CompositeGate>(
-          gateType, outputWire, left, right, *wireKeeper_));
-    }
-  } else {
-    if constexpr (usingBatch) {
-      outputWire = wireKeeper_->allocateBatchBooleanValue(initialValue, level);
-      auto numberOfResults = initialValue.size();
-      gatesForLevel.push_back(
-          std::make_unique<BatchNormalGate<IScheduler::Boolean>>(
-              gateType,
-              outputWire,
-              left,
-              right,
-              partyID,
-              numberOfResults,
-              *wireKeeper_));
-
-    } else {
-      outputWire = wireKeeper_->allocateBooleanValue(initialValue, level);
-      gatesForLevel.push_back(std::make_unique<NormalGate<IScheduler::Boolean>>(
-          gateType, outputWire, left, right, partyID, *wireKeeper_));
-    }
-  }
-
-  return outputWire;
-}
-
-// Free gates are added to even levels, and non-free gates are added to odd
-// levels. A gate can depend on a free gate at the same level, but cannot
-// depend on a non-free gate at the same level.
-template <bool usingBatch, bool isCompositeWire>
-uint32_t GateKeeper::getFirstAvailableLevelForNewWire(
-    GateType<isCompositeWire> gateType,
-    IScheduler::WireId<IScheduler::Boolean> left,
-    RightWireType<isCompositeWire> right) const {
-  uint32_t leftMaxLevel = 0;
-  if (left.isEmpty()) {
-    leftMaxLevel = 0;
-  } else if constexpr (usingBatch) {
-    leftMaxLevel = wireKeeper_->getBatchFirstAvailableLevel(left);
-  } else {
-    leftMaxLevel = wireKeeper_->getFirstAvailableLevel(left);
-  }
-
-  uint32_t rightMaxLevel = 0;
-  if constexpr (isCompositeWire) {
-    for (auto rightWire : right) {
-      if (!rightWire.isEmpty()) {
-        if constexpr (usingBatch) {
-          rightMaxLevel = std::max(
-              rightMaxLevel,
-              wireKeeper_->getBatchFirstAvailableLevel(rightWire));
-        } else {
-          rightMaxLevel = std::max(
-              rightMaxLevel, wireKeeper_->getFirstAvailableLevel(rightWire));
-        }
-      }
-    }
-  } else {
-    if (right.isEmpty()) {
-      rightMaxLevel = 0;
-    } else if constexpr (usingBatch) {
-      rightMaxLevel = wireKeeper_->getBatchFirstAvailableLevel(right);
-    } else {
-      rightMaxLevel = wireKeeper_->getFirstAvailableLevel(right);
-    }
-  }
-
-  auto isFreeGate = GateClass<isCompositeWire>::isFree(gateType);
-
-  auto minAvailableLeft = leftMaxLevel +
-      (IGateKeeper::isLevelFree(leftMaxLevel) ? (isFreeGate ? 0 : 1)
-                                              : (isFreeGate ? 1 : 2));
-  auto minAvailableRight = rightMaxLevel +
-      (IGateKeeper::isLevelFree(rightMaxLevel) ? (isFreeGate ? 0 : 1)
-                                               : (isFreeGate ? 1 : 2));
-  auto minAvailableFirstUnexecuted = firstUnexecutedLevel_ +
-      (IGateKeeper::isLevelFree(firstUnexecutedLevel_) ? (isFreeGate ? 0 : 1)
-                                                       : (isFreeGate ? 1 : 0));
-
-  return std::max(
-      std::max(minAvailableLeft, minAvailableRight),
-      minAvailableFirstUnexecuted);
-}
 } // namespace fbpcf::scheduler

--- a/fbpcf/scheduler/gate_keeper/test/GateKeeperTest.cpp
+++ b/fbpcf/scheduler/gate_keeper/test/GateKeeperTest.cpp
@@ -213,4 +213,5 @@ TEST(GateKeeperTest, TestCompositeGates) {
   // check level 131
   testLevel(gateKeeper->popFirstUnexecutedLevel(), {}, {wires4});
 }
+
 } // namespace fbpcf::scheduler


### PR DESCRIPTION
Summary: This diff refactor the gate keeper object to avoid a huge addGate function and a complicated gate-level-inference function. Now they are broken down to smaller helpers.

Reviewed By: elliottlawrence

Differential Revision: D34903403

