### PR TITLE
Implement BufferedWriter that wraps a child writer

### DIFF
--- a/fbpcf/io/api/BufferedReader.cpp
+++ b/fbpcf/io/api/BufferedReader.cpp
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <cstddef>
+#include <exception>
+#include <stdexcept>
+#include <vector>
+
+#include "fbpcf/io/api/BufferedReader.h"
+
+namespace fbpcf::io {
+
+int BufferedReader::close() {
+  return baseReader_.close();
+}
+
+size_t BufferedReader::read(std::vector<char>& buf) {
+  if (eof()) {
+    throw std::runtime_error("There is no more data in this file.");
+  }
+
+  size_t filledUp = 0;
+  size_t remaining = buf.size();
+  while (filledUp < buf.size() && !eof()) {
+    if ((lastPosition_ - currentPosition_) >= remaining) {
+      // we already have enough data loaded
+      std::copy(
+          buffer_.begin() + currentPosition_,
+          buffer_.begin() + currentPosition_ + remaining,
+          buf.begin() + filledUp);
+      currentPosition_ += remaining;
+      filledUp += remaining;
+      break;
+    }
+
+    // need to load more data
+
+    // first, copy what we currently have
+    std::copy(
+        buffer_.begin() + currentPosition_,
+        buffer_.begin() + lastPosition_,
+        buf.begin() + filledUp);
+    filledUp += (lastPosition_ - currentPosition_);
+    remaining = buf.size() - filledUp;
+    currentPosition_ = lastPosition_;
+
+    if (baseReader_.eof()) {
+      // that's all the data that exists in the file
+      return filledUp;
+    }
+
+    // load next chunk and the repeat
+    // loadNextChunk appropriately sets
+    // currentPosition, lastPosition_, and eof_
+    loadNextChunk();
+  }
+
+  return filledUp;
+}
+
+bool BufferedReader::eof() {
+  // The base file is exhausted and the buffer is exhausted
+  return baseReader_.eof() && (currentPosition_ == lastPosition_);
+}
+
+BufferedReader::~BufferedReader() {
+  close();
+}
+
+std::string BufferedReader::readLine() {
+  if (eof()) {
+    throw std::runtime_error("There are no more lines in this file.");
+  }
+
+  if (currentPosition_ == lastPosition_) {
+    loadNextChunk();
+  }
+
+  auto c = buffer_.at(currentPosition_);
+  std::string output = "";
+  while (c != '\n') {
+    output += c;
+    currentPosition_++;
+
+    if (currentPosition_ == lastPosition_) {
+      // we've run out of data, try to get the next chunk
+      if (baseReader_.eof()) {
+        // no more data in the file, return what we have
+        break;
+      }
+
+      loadNextChunk();
+    }
+
+    c = buffer_.at(currentPosition_);
+  }
+  currentPosition_++;
+
+  return output;
+}
+
+void BufferedReader::loadNextChunk() {
+  auto bytesRead = baseReader_.read(buffer_);
+
+  lastPosition_ = bytesRead;
+  currentPosition_ = 0;
+}
+
+} // namespace fbpcf::io

--- a/fbpcf/io/api/BufferedReader.h
+++ b/fbpcf/io/api/BufferedReader.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+#include "fbpcf/io/api/IReaderCloser.h"
+
+namespace fbpcf::io {
+
+/*
+This class is the API for buffered reading, which
+provides a readLine function as well as the ability
+to specify a chunk size.
+*/
+
+constexpr size_t defaultChunkSize = 4096;
+
+class BufferedReader : public IReaderCloser {
+ public:
+  explicit BufferedReader(
+      IReaderCloser& baseReader,
+      const size_t chunkSize = defaultChunkSize)
+      : buffer_{std::vector<char>(chunkSize)},
+        currentPosition_{0},
+        baseReader_{baseReader},
+        lastPosition_{0} {}
+
+  int close() override;
+  size_t read(std::vector<char>& buf) override;
+  bool eof() override;
+  ~BufferedReader() override;
+
+  std::string readLine();
+
+ private:
+  void loadNextChunk();
+
+  std::vector<char> buffer_;
+  size_t currentPosition_;
+  IReaderCloser& baseReader_;
+  size_t lastPosition_;
+};
+
+} // namespace fbpcf::io

--- a/fbpcf/io/api/BufferedWriter.cpp
+++ b/fbpcf/io/api/BufferedWriter.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <algorithm>
+#include <cstddef>
+#include <vector>
+
+#include "fbpcf/io/api/BufferedWriter.h"
+
+namespace fbpcf::io {
+
+int BufferedWriter::close() {
+  flush();
+  return baseWriter_.close();
+}
+
+size_t BufferedWriter::write(std::vector<char>& buf) {
+  size_t written = 0;
+  size_t remaining = buf.size();
+
+  while (written < buf.size()) {
+    // write what we can in the current chunk
+    size_t bytesThatWillFit = buffer_.size() - currentPosition_;
+    size_t bytesToWrite = std::min(bytesThatWillFit, remaining);
+    std::copy(
+        buf.begin() + written,
+        buf.begin() + written + bytesToWrite,
+        buffer_.begin() + currentPosition_);
+    currentPosition_ += bytesToWrite;
+    written += bytesToWrite;
+    remaining -= bytesToWrite;
+    if (remaining == 0) {
+      // if we were able to fit everything, break and return right here
+      break;
+    }
+
+    // flush appropriately sets the currentPosition_
+    flush();
+  }
+
+  return written;
+}
+
+BufferedWriter::~BufferedWriter() {
+  close();
+}
+
+void BufferedWriter::flush() {
+  if (currentPosition_ == 0) {
+    return;
+  }
+
+  std::vector<char> toWrite;
+  if (currentPosition_ < buffer_.size()) {
+    toWrite = std::vector<char>(currentPosition_);
+    std::copy(
+        buffer_.begin(), buffer_.begin() + currentPosition_, toWrite.begin());
+  } else {
+    toWrite = buffer_;
+  }
+  currentPosition_ = 0;
+  if (baseWriter_.write(toWrite) != toWrite.size()) {
+    throw std::runtime_error(
+        "Failed to flush contents of buffer. Terminating.");
+  }
+}
+
+} // namespace fbpcf::io

--- a/fbpcf/io/api/BufferedWriter.h
+++ b/fbpcf/io/api/BufferedWriter.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+#include "fbpcf/io/api/IWriterCloser.h"
+
+namespace fbpcf::io {
+
+/*
+This class is the API for buffered writer, which
+provides the ability to specify a chunk size.
+*/
+
+constexpr size_t defaultChunkSize = 4096;
+
+class BufferedWriter : public IWriterCloser {
+ public:
+  explicit BufferedWriter(
+      IWriterCloser& baseWriter,
+      const size_t chunkSize = defaultChunkSize)
+      : buffer_{std::vector<char>(chunkSize)},
+        currentPosition_{0},
+        baseWriter_{baseWriter} {}
+
+  int close() override;
+  size_t write(std::vector<char>& buf) override;
+  ~BufferedWriter() override;
+
+  void flush();
+
+ private:
+  std::vector<char> buffer_;
+  size_t currentPosition_;
+  IWriterCloser& baseWriter_;
+};
+
+} // namespace fbpcf::io

--- a/fbpcf/io/api/test/BufferedReaderTest.cpp
+++ b/fbpcf/io/api/test/BufferedReaderTest.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include <memory>
+
+#include "fbpcf/io/api/BufferedReader.h"
+#include "fbpcf/io/api/FileReader.h"
+#include "fbpcf/io/api/test/utils/IOTestHelper.h"
+
+namespace fbpcf::io {
+
+TEST(BufferedReaderTest, testBufferedReaderWithBothReadAndReadLine) {
+  auto fileReader = fbpcf::io::FileReader(
+      IOTestHelper::getBaseDirFromPath(__FILE__) +
+      "data/buffered_reader_test_file.txt");
+  auto bufferedReader =
+      std::make_unique<fbpcf::io::BufferedReader>(fileReader, 40);
+
+  auto firstLine = bufferedReader->readLine();
+
+  EXPECT_EQ(firstLine, "this is a simple first line");
+  EXPECT_FALSE(bufferedReader->eof());
+
+  auto secondLine = bufferedReader->readLine();
+
+  EXPECT_EQ(
+      secondLine,
+      "this is a second line that is intended to be longer than a line that can fit in a single buffer");
+  EXPECT_FALSE(bufferedReader->eof());
+
+  auto thirdLine = bufferedReader->readLine();
+  std::string expectedLongString =
+      "this is a third line that should take at least three iterations of the buffer so that we can properly check the iterative functionality";
+  EXPECT_EQ(thirdLine, expectedLongString);
+  EXPECT_FALSE(bufferedReader->eof());
+
+  auto fourthLine = bufferedReader->readLine();
+  EXPECT_EQ(fourthLine, "");
+  EXPECT_FALSE(bufferedReader->eof());
+
+  auto blurb = std::vector<char>(65);
+  auto nBytes = bufferedReader->read(blurb);
+  EXPECT_EQ(nBytes, 65);
+  IOTestHelper::expectBufferToEqualString(
+      blurb,
+      "we also test a blank line and\na line that will include a newline\n",
+      65);
+  EXPECT_FALSE(bufferedReader->eof());
+
+  auto blankLine = bufferedReader->readLine();
+  EXPECT_EQ(blankLine, "");
+  EXPECT_FALSE(bufferedReader->eof());
+
+  auto remainingBytes = std::vector<char>(300);
+  nBytes = bufferedReader->read(remainingBytes);
+  EXPECT_EQ(nBytes, 242);
+  std::string expectedLongParagraph =
+      "finally, we want to test a really long block of\ntext, that will take 3 or 4 chunks, but this time\nusing the read API instead of the readLine API to\nmake sure that we have adequate test coverage. the\ntotal size of this paragraph is 242 bytes.\n";
+  IOTestHelper::expectBufferToEqualString(
+      remainingBytes, expectedLongParagraph, nBytes);
+  EXPECT_TRUE(bufferedReader->eof());
+
+  bufferedReader->close();
+}
+
+TEST(BufferedReaderTest, testBufferedReaderWithReadLineOnly) {
+  // this more accurately resembles a production style usage
+  auto fileReader = fbpcf::io::FileReader(
+      IOTestHelper::getBaseDirFromPath(__FILE__) +
+      "data/buffered_reader_test_file.txt");
+  auto bufferedReader =
+      std::make_unique<fbpcf::io::BufferedReader>(fileReader, 40);
+
+  auto expectedLines = std::vector<std::string>{
+      "this is a simple first line",
+      "this is a second line that is intended to be longer than a line that can fit in a single buffer",
+      "this is a third line that should take at least three iterations of the buffer so that we can properly check the iterative functionality",
+      "",
+      "we also test a blank line and",
+      "a line that will include a newline",
+      "",
+      "finally, we want to test a really long block of",
+      "text, that will take 3 or 4 chunks, but this time",
+      "using the read API instead of the readLine API to",
+      "make sure that we have adequate test coverage. the",
+      "total size of this paragraph is 242 bytes."};
+
+  auto i = 0;
+  while (!bufferedReader->eof()) {
+    auto line = bufferedReader->readLine();
+    EXPECT_EQ(line, expectedLines.at(i));
+    i++;
+
+    if (i == expectedLines.size()) {
+      EXPECT_TRUE(bufferedReader->eof());
+    } else {
+      EXPECT_FALSE(bufferedReader->eof());
+    }
+  }
+}
+
+} // namespace fbpcf::io

--- a/fbpcf/io/api/test/BufferedWriterTest.cpp
+++ b/fbpcf/io/api/test/BufferedWriterTest.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include <stdio.h>
+#include <filesystem>
+#include <string>
+#include "folly/logging/xlog.h"
+
+#include "fbpcf/io/api/BufferedWriter.h"
+#include "fbpcf/io/api/LocalFileWriter.h"
+#include "fbpcf/io/api/test/utils/IOTestHelper.h"
+
+namespace fbpcf::io {
+
+TEST(BufferedWriterTest, testWritingToFile) {
+  std::string base_dir = IOTestHelper::getBaseDirFromPath(__FILE__);
+  std::string file_to_write_to =
+      base_dir + "data/buffered_writer_writer_test_file.txt";
+  auto writer = fbpcf::io::LocalFileWriter(file_to_write_to);
+  auto bufferedWriter = std::make_unique<BufferedWriter>(writer, 40);
+
+  std::string to_write = "this file tests the buffered writer\n";
+  auto buf =
+      std::vector<char>(to_write.c_str(), to_write.c_str() + to_write.size());
+  auto nBytes = bufferedWriter->write(buf);
+  EXPECT_EQ(nBytes, to_write.size());
+
+  std::vector<char> arbitraryBytes{
+      't', 'h', 'e', 's', 'e', ' ', 't', 'w', 'o', ' '};
+  nBytes = bufferedWriter->write(arbitraryBytes);
+  EXPECT_EQ(nBytes, arbitraryBytes.size());
+
+  to_write = "lines fit in one chunk\n";
+  auto buf2 =
+      std::vector<char>(to_write.c_str(), to_write.c_str() + to_write.size());
+  nBytes = bufferedWriter->write(buf2);
+  EXPECT_EQ(nBytes, to_write.size());
+
+  std::string longLine =
+      "but this next line is going to be much longer and will require multiple iterations of the loop to fit everything in the file\n";
+  auto buf3 =
+      std::vector<char>(longLine.c_str(), longLine.c_str() + longLine.size());
+  nBytes = bufferedWriter->write(buf3);
+  EXPECT_EQ(nBytes, longLine.size());
+  bufferedWriter->flush();
+
+  to_write = "this is tiny\n";
+  auto buf4 =
+      std::vector<char>(to_write.c_str(), to_write.c_str() + to_write.size());
+  nBytes = bufferedWriter->write(buf4);
+  EXPECT_EQ(nBytes, to_write.size());
+
+  bufferedWriter->close();
+
+  /*
+    Verify that file contents match the expected
+  */
+  IOTestHelper::expectFileContentsMatch(
+      file_to_write_to,
+      base_dir + "data/expected_buffered_writer_test_file.txt");
+
+  IOTestHelper::cleanup(file_to_write_to);
+}
+
+} // namespace fbpcf::io

--- a/fbpcf/io/api/test/LocalFileWriterTest.cpp
+++ b/fbpcf/io/api/test/LocalFileWriterTest.cpp
@@ -17,10 +17,6 @@
 
 namespace fbpcf::io {
 
-inline void cleanup(std::string fileToDelete) {
-  remove(fileToDelete.c_str());
-}
-
 TEST(LocalFileWriterTest, testWritingToFile) {
   std::string baseDir = IOTestHelper::getBaseDirFromPath(__FILE__);
   std::random_device rd;
@@ -71,7 +67,7 @@ TEST(LocalFileWriterTest, testWritingToFile) {
   IOTestHelper::expectFileContentsMatch(
       fileToWriteTo, baseDir + "data/expected_local_file_writer_test_file.txt");
 
-  cleanup(fileToWriteTo);
+  IOTestHelper::cleanup(fileToWriteTo);
 }
 
 } // namespace fbpcf::io

--- a/fbpcf/io/api/test/data/buffered_reader_test_file.txt
+++ b/fbpcf/io/api/test/data/buffered_reader_test_file.txt
@@ -1,0 +1,12 @@
+this is a simple first line
+this is a second line that is intended to be longer than a line that can fit in a single buffer
+this is a third line that should take at least three iterations of the buffer so that we can properly check the iterative functionality
+
+we also test a blank line and
+a line that will include a newline
+
+finally, we want to test a really long block of
+text, that will take 3 or 4 chunks, but this time
+using the read API instead of the readLine API to
+make sure that we have adequate test coverage. the
+total size of this paragraph is 242 bytes.

--- a/fbpcf/io/api/test/data/expected_buffered_writer_test_file.txt
+++ b/fbpcf/io/api/test/data/expected_buffered_writer_test_file.txt
@@ -1,0 +1,4 @@
+this file tests the buffered writer
+these two lines fit in one chunk
+but this next line is going to be much longer and will require multiple iterations of the loop to fit everything in the file
+this is tiny

--- a/fbpcf/io/api/test/utils/IOTestHelper.h
+++ b/fbpcf/io/api/test/utils/IOTestHelper.h
@@ -51,6 +51,10 @@ class IOTestHelper {
     expectedFile->close();
     testFile->close();
   }
+
+  static void cleanup(std::string file_to_delete) {
+    remove(file_to_delete.c_str());
+  }
 };
 
 } // namespace fbpcf::io

--- a/fbpcf/io/api/test/utils/IOTestHelper.h
+++ b/fbpcf/io/api/test/utils/IOTestHelper.h
@@ -10,6 +10,7 @@
 #include <gtest/gtest.h>
 #include <fstream>
 #include <memory>
+#include <vector>
 
 #include <string>
 
@@ -22,7 +23,8 @@ class IOTestHelper {
       std::string contents,
       size_t nBytes) {
     for (int i = 0; i < nBytes; i++) {
-      EXPECT_EQ(buf.at(i), contents.at(i));
+      EXPECT_EQ(buf.at(i), contents.at(i))
+          << "Failure at position " << i << " of buffer.";
     }
   }
 


### PR DESCRIPTION
Summary:
This diff adds a very simple buffered writer. Although this wasn't a requirement for supporting large PA/PL runs, it is good to have parity for buffered reader and buffered writer.

This class has a flush() function that writes the current buffer to the underlying file. When write is called, it first writes into the buffer and then flushes if there is no space

Differential Revision: D34904877

