### PR TITLE
Add rebatching API for bitstring

### DIFF
--- a/fbpcf/frontend/Bit.h
+++ b/fbpcf/frontend/Bit.h
@@ -118,6 +118,12 @@ class Bit : public scheduler::SchedulerKeeper<schedulerId> {
    */
   typename Bit<true, schedulerId, usingBatch>::ExtractedBit extractBit() const;
 
+  Bit<isSecret, schedulerId, usingBatch> batchingWith(
+      const std::vector<Bit<isSecret, schedulerId, usingBatch>>& others) const;
+
+  std::vector<Bit<isSecret, schedulerId, usingBatch>> unbatching(
+      std::shared_ptr<std::vector<uint32_t>> unbatchingStrategy) const;
+
  private:
   void increaseReferenceCount(const WireType& v) const;
   void decreaseReferenceCount(const WireType& v) const;

--- a/fbpcf/frontend/BitString.h
+++ b/fbpcf/frontend/BitString.h
@@ -121,6 +121,13 @@ class BitString : public scheduler::SchedulerKeeper<schedulerId> {
   mux(const Bit<isSecretChoice, schedulerId, usingBatch>& choice,
       const BitString<isSecretOther, schedulerId, usingBatch>& other) const;
 
+  BitString<isSecret, schedulerId, usingBatch> batchingWith(
+      const std::vector<BitString<isSecret, schedulerId, usingBatch>>& others)
+      const;
+
+  std::vector<BitString<isSecret, schedulerId, usingBatch>> unbatching(
+      std::shared_ptr<std::vector<uint32_t>> unbatchingStrategy) const;
+
  private:
   std::vector<Bit<isSecret, schedulerId, usingBatch>> data_;
 

--- a/fbpcf/frontend/Int.h
+++ b/fbpcf/frontend/Int.h
@@ -204,6 +204,14 @@ class Int {
   typename Int<isSigned, width, true, schedulerId, usingBatch>::ExtractedInt
   extractIntShare() const;
 
+  Int<isSigned, width, isSecret, schedulerId, usingBatch> batchingWith(
+      const std::vector<
+          Int<isSigned, width, isSecret, schedulerId, usingBatch>>& others)
+      const;
+
+  std::vector<Int<isSigned, width, isSecret, schedulerId, usingBatch>>
+  unbatching(std::shared_ptr<std::vector<uint32_t>> unbatchingStrategy) const;
+
  private:
   template <typename T>
   std::vector<UnitIntType> convertTo64BitIntVector(

--- a/fbpcf/frontend/test/BitTest.cpp
+++ b/fbpcf/frontend/test/BitTest.cpp
@@ -31,25 +31,29 @@ TEST(BitTest, testInputAndOutput) {
 
   EXPECT_CALL(*mock, recoverBooleanWire(v)).Times(1);
 
-  EXPECT_CALL(*mock, openBooleanValueToParty(_, partyId)).Times(1);
+  EXPECT_CALL(*mock, openBooleanValueToParty(WireIdEq(1), partyId)).Times(1);
 
-  EXPECT_CALL(*mock, extractBooleanSecretShare(_)).Times(1);
+  EXPECT_CALL(*mock, extractBooleanSecretShare(WireIdEq(2))).Times(1);
 
-  EXPECT_CALL(*mock, getBooleanValue(_)).Times(1);
+  EXPECT_CALL(*mock, getBooleanValue(WireIdEq(3))).Times(1);
 
   scheduler::SchedulerKeeper<0>::setScheduler(std::move(mock));
 
   using SecBit = Bit<true, 0>;
   using PubBit = Bit<false, 0>;
   {
+    // id 1
     SecBit b1(v, partyId);
     SecBit b2;
+    // id 2
     b2.privateInput(v, partyId);
 
+    // id3
     PubBit b3(v);
 
     SecBit::ExtractedBit extractedBit(v);
 
+    // id 4
     SecBit b4(std::move(extractedBit));
 
     b1.openToParty(partyId);
@@ -73,21 +77,25 @@ TEST(BitTest, testInputAndOutputBatch) {
 
   EXPECT_CALL(*mock, recoverBooleanWireBatch(v)).Times(1);
 
-  EXPECT_CALL(*mock, openBooleanValueToPartyBatch(_, partyId)).Times(1);
+  EXPECT_CALL(*mock, openBooleanValueToPartyBatch(WireIdEq(1), partyId))
+      .Times(1);
 
-  EXPECT_CALL(*mock, extractBooleanSecretShareBatch(_)).Times(1);
+  EXPECT_CALL(*mock, extractBooleanSecretShareBatch(WireIdEq(2))).Times(1);
 
-  EXPECT_CALL(*mock, getBooleanValueBatch(_)).Times(1);
+  EXPECT_CALL(*mock, getBooleanValueBatch(WireIdEq(3))).Times(1);
 
   scheduler::SchedulerKeeper<0>::setScheduler(std::move(mock));
 
   using SecBitBatch = Bit<true, 0, true>;
   using PubBitBatch = Bit<false, 0, true>;
   {
+    // id 1
     SecBitBatch b1(v, partyId);
     SecBitBatch b2;
+    // id 2
     b2.privateInput(v, partyId);
 
+    // id 3
     PubBitBatch b3(v);
 
     SecBitBatch::ExtractedBit extractedBit(v);
@@ -109,11 +117,11 @@ TEST(BitTest, testAnd) {
   bool v = true;
   int partyId = 3;
 
-  EXPECT_CALL(*mock, privateAndPrivate(_, _)).Times(1);
+  EXPECT_CALL(*mock, privateAndPrivate(WireIdEq(1), WireIdEq(2))).Times(1);
 
-  EXPECT_CALL(*mock, privateAndPublic(_, _)).Times(1);
+  EXPECT_CALL(*mock, privateAndPublic(WireIdEq(1), WireIdEq(3))).Times(1);
 
-  EXPECT_CALL(*mock, publicAndPublic(_, _)).Times(1);
+  EXPECT_CALL(*mock, publicAndPublic(WireIdEq(4), WireIdEq(3))).Times(1);
 
   scheduler::SchedulerKeeper<0>::setScheduler(std::move(mock));
 
@@ -143,11 +151,11 @@ TEST(BitTest, testAndBatch) {
   std::vector<bool> v(5, true);
   int partyId = 3;
 
-  EXPECT_CALL(*mock, privateAndPrivateBatch(_, _)).Times(1);
+  EXPECT_CALL(*mock, privateAndPrivateBatch(WireIdEq(1), WireIdEq(2))).Times(1);
 
-  EXPECT_CALL(*mock, privateAndPublicBatch(_, _)).Times(1);
+  EXPECT_CALL(*mock, privateAndPublicBatch(WireIdEq(1), WireIdEq(3))).Times(1);
 
-  EXPECT_CALL(*mock, publicAndPublicBatch(_, _)).Times(1);
+  EXPECT_CALL(*mock, publicAndPublicBatch(WireIdEq(4), WireIdEq(3))).Times(1);
 
   scheduler::SchedulerKeeper<0>::setScheduler(std::move(mock));
 
@@ -209,11 +217,11 @@ TEST(BitTest, testXorBatch) {
   std::vector<bool> v(5, true);
   int partyId = 3;
 
-  EXPECT_CALL(*mock, privateXorPrivateBatch(_, _)).Times(1);
+  EXPECT_CALL(*mock, privateXorPrivateBatch(WireIdEq(1), WireIdEq(2))).Times(1);
 
-  EXPECT_CALL(*mock, privateXorPublicBatch(_, _)).Times(1);
+  EXPECT_CALL(*mock, privateXorPublicBatch(WireIdEq(1), WireIdEq(3))).Times(1);
 
-  EXPECT_CALL(*mock, publicXorPublicBatch(_, _)).Times(1);
+  EXPECT_CALL(*mock, publicXorPublicBatch(WireIdEq(4), WireIdEq(3))).Times(1);
 
   scheduler::SchedulerKeeper<0>::setScheduler(std::move(mock));
 
@@ -241,9 +249,9 @@ TEST(BitTest, testNot) {
   bool v = true;
   int partyId = 3;
 
-  EXPECT_CALL(*mock, notPrivate(_)).Times(1);
+  EXPECT_CALL(*mock, notPrivate(WireIdEq(1))).Times(1);
 
-  EXPECT_CALL(*mock, notPublic(_)).Times(1);
+  EXPECT_CALL(*mock, notPublic(WireIdEq(2))).Times(1);
 
   scheduler::SchedulerKeeper<0>::setScheduler(std::move(mock));
 
@@ -266,9 +274,9 @@ TEST(BitTest, testNotBatch) {
   std::vector<bool> v(5, true);
   int partyId = 3;
 
-  EXPECT_CALL(*mock, notPrivateBatch(_)).Times(1);
+  EXPECT_CALL(*mock, notPrivateBatch(WireIdEq(1))).Times(1);
 
-  EXPECT_CALL(*mock, notPublicBatch(_)).Times(1);
+  EXPECT_CALL(*mock, notPublicBatch(WireIdEq(2))).Times(1);
 
   scheduler::SchedulerKeeper<0>::setScheduler(std::move(mock));
 
@@ -291,33 +299,38 @@ TEST(BitTest, testOr) {
   bool v = true;
   int partyId = 3;
 
-  EXPECT_CALL(*mock, privateXorPrivate(_, _)).Times(3);
+  EXPECT_CALL(*mock, privateXorPrivate(WireIdEq(1), WireIdEq(2))).Times(1);
+  EXPECT_CALL(*mock, privateAndPrivate(WireIdEq(1), WireIdEq(2))).Times(1);
+  EXPECT_CALL(*mock, privateXorPrivate(WireIdEq(5), WireIdEq(6))).Times(1);
 
-  EXPECT_CALL(*mock, privateXorPublic(_, _)).Times(1);
+  EXPECT_CALL(*mock, privateXorPublic(WireIdEq(1), WireIdEq(3))).Times(1);
+  EXPECT_CALL(*mock, privateAndPublic(WireIdEq(1), WireIdEq(3))).Times(1);
+  EXPECT_CALL(*mock, privateXorPrivate(WireIdEq(8), WireIdEq(9))).Times(1);
 
-  EXPECT_CALL(*mock, publicXorPublic(_, _)).Times(2);
-
-  EXPECT_CALL(*mock, privateAndPrivate(_, _)).Times(1);
-
-  EXPECT_CALL(*mock, privateAndPublic(_, _)).Times(1);
-
-  EXPECT_CALL(*mock, publicAndPublic(_, _)).Times(1);
+  EXPECT_CALL(*mock, publicXorPublic(WireIdEq(4), WireIdEq(3))).Times(1);
+  EXPECT_CALL(*mock, publicAndPublic(WireIdEq(4), WireIdEq(3))).Times(1);
+  EXPECT_CALL(*mock, publicXorPublic(WireIdEq(12), WireIdEq(11))).Times(1);
 
   scheduler::SchedulerKeeper<0>::setScheduler(std::move(mock));
 
   using SecBit = Bit<true, 0>;
   using PubBit = Bit<false, 0>;
   {
+    // id 1
     SecBit b1(v, partyId);
     SecBit b2;
+    // id 2
     b2.privateInput(v, partyId);
-
+    // id 3
     PubBit b3(v);
-
+    // id 4
     PubBit b4(v);
 
+    // id 7
     auto b5 = b1 || b2;
+    // id 10
     auto b6 = b1 || b3;
+    // id 13
     auto b7 = b3 || b4;
   }
   scheduler::SchedulerKeeper<0>::freeScheduler();
@@ -329,17 +342,17 @@ TEST(BitTest, testOrBatch) {
   std::vector<bool> v(5, true);
   int partyId = 3;
 
-  EXPECT_CALL(*mock, privateXorPrivateBatch(_, _)).Times(3);
+  EXPECT_CALL(*mock, privateXorPrivateBatch(WireIdEq(1), WireIdEq(2))).Times(1);
+  EXPECT_CALL(*mock, privateAndPrivateBatch(WireIdEq(1), WireIdEq(2))).Times(1);
+  EXPECT_CALL(*mock, privateXorPrivateBatch(WireIdEq(5), WireIdEq(6))).Times(1);
 
-  EXPECT_CALL(*mock, privateXorPublicBatch(_, _)).Times(1);
+  EXPECT_CALL(*mock, privateXorPublicBatch(WireIdEq(1), WireIdEq(3))).Times(1);
+  EXPECT_CALL(*mock, privateAndPublicBatch(WireIdEq(1), WireIdEq(3))).Times(1);
+  EXPECT_CALL(*mock, privateXorPrivateBatch(WireIdEq(8), WireIdEq(9))).Times(1);
 
-  EXPECT_CALL(*mock, publicXorPublicBatch(_, _)).Times(2);
-
-  EXPECT_CALL(*mock, privateAndPrivateBatch(_, _)).Times(1);
-
-  EXPECT_CALL(*mock, privateAndPublicBatch(_, _)).Times(1);
-
-  EXPECT_CALL(*mock, publicAndPublicBatch(_, _)).Times(1);
+  EXPECT_CALL(*mock, publicXorPublicBatch(WireIdEq(4), WireIdEq(3))).Times(1);
+  EXPECT_CALL(*mock, publicAndPublicBatch(WireIdEq(4), WireIdEq(3))).Times(1);
+  EXPECT_CALL(*mock, publicXorPublicBatch(WireIdEq(12), WireIdEq(11))).Times(1);
 
   scheduler::SchedulerKeeper<0>::setScheduler(std::move(mock));
 
@@ -481,10 +494,11 @@ TEST(BitTest, testReferenceCount) {
   bool v = true;
   int partyId = 3;
 
-  EXPECT_CALL(*mock, increaseReferenceCount(_)).Times(4);
+  EXPECT_CALL(*mock, increaseReferenceCount(WireIdEq(1))).Times(2);
+  EXPECT_CALL(*mock, increaseReferenceCount(WireIdEq(2))).Times(2);
 
-  EXPECT_CALL(*mock, decreaseReferenceCount(_)).Times(6);
-
+  EXPECT_CALL(*mock, decreaseReferenceCount(WireIdEq(1))).Times(3);
+  EXPECT_CALL(*mock, decreaseReferenceCount(WireIdEq(2))).Times(3);
   scheduler::SchedulerKeeper<0>::setScheduler(std::move(mock));
 
   using SecBit = Bit<true, 0>;
@@ -537,9 +551,10 @@ TEST(BitTest, testReferenceCountBatch) {
   std::vector<bool> v(5, true);
   int partyId = 3;
 
-  EXPECT_CALL(*mock, increaseReferenceCountBatch(_)).Times(4);
-
-  EXPECT_CALL(*mock, decreaseReferenceCountBatch(_)).Times(6);
+  EXPECT_CALL(*mock, increaseReferenceCountBatch(WireIdEq(1))).Times(2);
+  EXPECT_CALL(*mock, increaseReferenceCountBatch(WireIdEq(2))).Times(2);
+  EXPECT_CALL(*mock, decreaseReferenceCountBatch(WireIdEq(1))).Times(3);
+  EXPECT_CALL(*mock, decreaseReferenceCountBatch(WireIdEq(2))).Times(3);
 
   scheduler::SchedulerKeeper<0>::setScheduler(std::move(mock));
 

--- a/fbpcf/frontend/test/schedulerMock.h
+++ b/fbpcf/frontend/test/schedulerMock.h
@@ -19,6 +19,33 @@ MATCHER_P(WireIdEq, expectedId, "Check if it is the expected WireId") {
   return expectedId == arg.getId();
 }
 
+MATCHER_P(
+    WireIdVectorEq,
+    expectedIdVector,
+    "Check if it is the expected WireId vector") {
+  if (arg.size() != expectedIdVector.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < arg.size(); i++) {
+    if (arg.at(i).getId() != expectedIdVector.at(i)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+MATCHER_P(VectorPtrEq, expectedVector, "Check if it is the expected Vector") {
+  if (arg->size() != expectedVector.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < arg->size(); i++) {
+    if (arg->at(i) != expectedVector.at(i)) {
+      return false;
+    }
+  }
+  return true;
+}
+
 class schedulerMock final : public scheduler::IScheduler {
  public:
   schedulerMock() {
@@ -101,6 +128,19 @@ class schedulerMock final : public scheduler::IScheduler {
     ON_CALL(*this, publicXorPublicBatch(_, _))
         .WillByDefault(Invoke([this](auto, auto) {
           return WireId<IScheduler::Boolean>(wireId++);
+        }));
+
+    ON_CALL(*this, batchingUp(_)).WillByDefault(Invoke([this](auto) {
+      return WireId<IScheduler::Boolean>(wireId++);
+    }));
+
+    ON_CALL(*this, unbatching(_, _))
+        .WillByDefault(Invoke([this](auto, auto strategy) {
+          std::vector<WireId<IScheduler::Boolean>> rst(strategy->size());
+          for (auto& item : rst) {
+            item = WireId<IScheduler::Boolean>(wireId++);
+          }
+          return rst;
         }));
   }
 

--- a/fbpcf/frontend/test/schedulerMock.h
+++ b/fbpcf/frontend/test/schedulerMock.h
@@ -289,6 +289,14 @@ class schedulerMock final : public scheduler::IScheduler {
 
   MOCK_METHOD1(decreaseReferenceCountBatch, void(WireId<IScheduler::Boolean>));
 
+  MOCK_METHOD1(batchingUp, WireId<Boolean>(std::vector<WireId<Boolean>>));
+
+  MOCK_METHOD2(
+      unbatching,
+      std::vector<WireId<Boolean>>(
+          WireId<Boolean>,
+          std::shared_ptr<std::vector<uint32_t>>));
+
   std::pair<uint64_t, uint64_t> getTrafficStatistics() const override {
     return {0, 0};
   }

--- a/fbpcf/frontend/test/schedulerMock.h
+++ b/fbpcf/frontend/test/schedulerMock.h
@@ -15,24 +15,92 @@ namespace fbpcf::frontend {
 
 using namespace ::testing;
 
+MATCHER_P(WireIdEq, expectedId, "Check if it is the expected WireId") {
+  return expectedId == arg.getId();
+}
+
 class schedulerMock final : public scheduler::IScheduler {
  public:
   schedulerMock() {
     ON_CALL(*this, privateBooleanInput(_, _))
-        .WillByDefault(Return(WireId<IScheduler::Boolean>(1)));
+        .WillByDefault(Invoke([this](bool /*input*/, int /*party*/) {
+          return WireId<IScheduler::Boolean>(wireId++);
+        }));
 
     ON_CALL(*this, publicBooleanInput(_))
-        .WillByDefault(Return(WireId<IScheduler::Boolean>(1)));
+        .WillByDefault(Invoke([this](bool /*input*/) {
+          return WireId<IScheduler::Boolean>(wireId++);
+        }));
 
     ON_CALL(*this, privateBooleanInputBatch(_, _))
         .WillByDefault(
-            Invoke([](const std::vector<bool>& /*input*/, int /*party*/) {
-              return WireId<IScheduler::Boolean>(1);
+            Invoke([this](const std::vector<bool>& /*input*/, int /*party*/) {
+              return WireId<IScheduler::Boolean>(wireId++);
             }));
 
     ON_CALL(*this, publicBooleanInputBatch(_))
-        .WillByDefault(Invoke([](const std::vector<bool>& /*input*/) {
-          return WireId<IScheduler::Boolean>(1);
+        .WillByDefault(Invoke([this](const std::vector<bool>& /*input*/) {
+          return WireId<IScheduler::Boolean>(wireId++);
+        }));
+
+    ON_CALL(*this, privateAndPrivate(_, _))
+        .WillByDefault(Invoke([this](auto, auto) {
+          return WireId<IScheduler::Boolean>(wireId++);
+        }));
+
+    ON_CALL(*this, privateXorPrivate(_, _))
+        .WillByDefault(Invoke([this](auto, auto) {
+          return WireId<IScheduler::Boolean>(wireId++);
+        }));
+
+    ON_CALL(*this, privateAndPublic(_, _))
+        .WillByDefault(Invoke([this](auto, auto) {
+          return WireId<IScheduler::Boolean>(wireId++);
+        }));
+
+    ON_CALL(*this, privateXorPublic(_, _))
+        .WillByDefault(Invoke([this](auto, auto) {
+          return WireId<IScheduler::Boolean>(wireId++);
+        }));
+
+    ON_CALL(*this, publicAndPublic(_, _))
+        .WillByDefault(Invoke([this](auto, auto) {
+          return WireId<IScheduler::Boolean>(wireId++);
+        }));
+
+    ON_CALL(*this, publicXorPublic(_, _))
+        .WillByDefault(Invoke([this](auto, auto) {
+          return WireId<IScheduler::Boolean>(wireId++);
+        }));
+
+    ON_CALL(*this, privateAndPrivateBatch(_, _))
+        .WillByDefault(Invoke([this](auto, auto) {
+          return WireId<IScheduler::Boolean>(wireId++);
+        }));
+
+    ON_CALL(*this, privateXorPrivateBatch(_, _))
+        .WillByDefault(Invoke([this](auto, auto) {
+          return WireId<IScheduler::Boolean>(wireId++);
+        }));
+
+    ON_CALL(*this, privateAndPublicBatch(_, _))
+        .WillByDefault(Invoke([this](auto, auto) {
+          return WireId<IScheduler::Boolean>(wireId++);
+        }));
+
+    ON_CALL(*this, privateXorPublicBatch(_, _))
+        .WillByDefault(Invoke([this](auto, auto) {
+          return WireId<IScheduler::Boolean>(wireId++);
+        }));
+
+    ON_CALL(*this, publicAndPublicBatch(_, _))
+        .WillByDefault(Invoke([this](auto, auto) {
+          return WireId<IScheduler::Boolean>(wireId++);
+        }));
+
+    ON_CALL(*this, publicXorPublicBatch(_, _))
+        .WillByDefault(Invoke([this](auto, auto) {
+          return WireId<IScheduler::Boolean>(wireId++);
         }));
   }
 
@@ -228,6 +296,9 @@ class schedulerMock final : public scheduler::IScheduler {
   std::pair<uint64_t, uint64_t> getWireStatistics() const override {
     return {0, 0};
   }
+
+ private:
+  int wireId = 1;
 };
 
 } // namespace fbpcf::frontend

--- a/fbpcf/scheduler/EagerScheduler.h
+++ b/fbpcf/scheduler/EagerScheduler.h
@@ -279,6 +279,20 @@ class EagerScheduler final : public IScheduler {
    */
   void decreaseReferenceCountBatch(WireId<IScheduler::Boolean> id) override;
 
+  //======== Below are rebatching APIs: ========
+
+  // band a number of batches into one batch.
+  WireId<Boolean> batchingUp(std::vector<WireId<Boolean>> src) override {
+    throw std::runtime_error("Not implemented!");
+  }
+
+  // decompose a batch of values into several smaller batches.
+  std::vector<WireId<Boolean>> unbatching(
+      WireId<Boolean> src,
+      std::shared_ptr<std::vector<uint32_t>> unbatchingStrategy) override {
+    throw std::runtime_error("Not implemented!");
+  }
+
   //======== Below are miscellaneous APIs: ========
 
   /**

--- a/fbpcf/scheduler/EagerScheduler.h
+++ b/fbpcf/scheduler/EagerScheduler.h
@@ -282,16 +282,12 @@ class EagerScheduler final : public IScheduler {
   //======== Below are rebatching APIs: ========
 
   // band a number of batches into one batch.
-  WireId<Boolean> batchingUp(std::vector<WireId<Boolean>> src) override {
-    throw std::runtime_error("Not implemented!");
-  }
+  WireId<Boolean> batchingUp(std::vector<WireId<Boolean>> src) override;
 
   // decompose a batch of values into several smaller batches.
   std::vector<WireId<Boolean>> unbatching(
       WireId<Boolean> src,
-      std::shared_ptr<std::vector<uint32_t>> unbatchingStrategy) override {
-    throw std::runtime_error("Not implemented!");
-  }
+      std::shared_ptr<std::vector<uint32_t>> unbatchingStrategy) override;
 
   //======== Below are miscellaneous APIs: ========
 

--- a/fbpcf/scheduler/IScheduler.h
+++ b/fbpcf/scheduler/IScheduler.h
@@ -338,6 +338,16 @@ class IScheduler {
    */
   virtual void decreaseReferenceCountBatch(WireId<Boolean> id) = 0;
 
+  //======== Below are rebatching APIs: ========
+
+  // band a number of batches into one batch.
+  virtual WireId<Boolean> batchingUp(std::vector<WireId<Boolean>> src) = 0;
+
+  // decompose a batch of values into several smaller batches.
+  virtual std::vector<WireId<Boolean>> unbatching(
+      WireId<Boolean> src,
+      std::shared_ptr<std::vector<uint32_t>> unbatchingStrategy) = 0;
+
   //======== Below are miscellaneous APIs: ========
   /**
    * Get the total amount of traffic transmitted.

--- a/fbpcf/scheduler/IWireKeeper.h
+++ b/fbpcf/scheduler/IWireKeeper.h
@@ -103,6 +103,14 @@ class IWireKeeper {
   virtual const std::vector<uint64_t>& getBatchIntegerValue(
       IScheduler::WireId<IScheduler::Arithmetic> id) const = 0;
 
+  // get the writable batch of value associated with boolean wire with given id.
+  virtual std::vector<bool>& getWritableBatchBooleanValue(
+      IScheduler::WireId<IScheduler::Boolean> id) const = 0;
+
+  // get the writable batch of value associated with integer wire with given id.
+  virtual std::vector<uint64_t>& getWritableBatchIntegerValue(
+      IScheduler::WireId<IScheduler::Arithmetic> id) const = 0;
+
   // set the value associated with boolean wire with given id.
   virtual void setBatchBooleanValue(
       IScheduler::WireId<IScheduler::Boolean> id,

--- a/fbpcf/scheduler/LazyScheduler.h
+++ b/fbpcf/scheduler/LazyScheduler.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <stdexcept>
 #include "fbpcf/engine/ISecretShareEngine.h"
 #include "fbpcf/scheduler/IScheduler.h"
 #include "fbpcf/scheduler/IWireKeeper.h"
@@ -281,6 +282,20 @@ class LazyScheduler final : public IScheduler {
    * @inherit doc
    */
   void decreaseReferenceCountBatch(WireId<IScheduler::Boolean> id) override;
+
+  //======== Below are rebatching APIs: ========
+
+  // band a number of batches into one batch.
+  WireId<Boolean> batchingUp(std::vector<WireId<Boolean>> src) override {
+    throw std::runtime_error("Not implemented!");
+  }
+
+  // decompose a batch of values into several smaller batches.
+  std::vector<WireId<Boolean>> unbatching(
+      WireId<Boolean> src,
+      std::shared_ptr<std::vector<uint32_t>> unbatchingStrategy) override {
+    throw std::runtime_error("Not implemented!");
+  }
 
   //======== Below are miscellaneous APIs: ========
 

--- a/fbpcf/scheduler/LazyScheduler.h
+++ b/fbpcf/scheduler/LazyScheduler.h
@@ -286,16 +286,12 @@ class LazyScheduler final : public IScheduler {
   //======== Below are rebatching APIs: ========
 
   // band a number of batches into one batch.
-  WireId<Boolean> batchingUp(std::vector<WireId<Boolean>> src) override {
-    throw std::runtime_error("Not implemented!");
-  }
+  WireId<Boolean> batchingUp(std::vector<WireId<Boolean>> src) override;
 
   // decompose a batch of values into several smaller batches.
   std::vector<WireId<Boolean>> unbatching(
       WireId<Boolean> src,
-      std::shared_ptr<std::vector<uint32_t>> unbatchingStrategy) override {
-    throw std::runtime_error("Not implemented!");
-  }
+      std::shared_ptr<std::vector<uint32_t>> unbatchingStrategy) override;
 
   //======== Below are miscellaneous APIs: ========
 

--- a/fbpcf/scheduler/PlaintextScheduler.h
+++ b/fbpcf/scheduler/PlaintextScheduler.h
@@ -286,16 +286,12 @@ class PlaintextScheduler : public IScheduler {
   //======== Below are rebatching APIs: ========
 
   // band a number of batches into one batch.
-  WireId<Boolean> batchingUp(std::vector<WireId<Boolean>> src) override {
-    throw std::runtime_error("Not implemented!");
-  }
+  WireId<Boolean> batchingUp(std::vector<WireId<Boolean>> src) override;
 
   // decompose a batch of values into several smaller batches.
   std::vector<WireId<Boolean>> unbatching(
       WireId<Boolean> src,
-      std::shared_ptr<std::vector<uint32_t>> unbatchingStrategy) override {
-    throw std::runtime_error("Not implemented!");
-  }
+      std::shared_ptr<std::vector<uint32_t>> unbatchingStrategy) override;
 
   //======== Below are miscellaneous APIs: ========
 

--- a/fbpcf/scheduler/PlaintextScheduler.h
+++ b/fbpcf/scheduler/PlaintextScheduler.h
@@ -283,6 +283,20 @@ class PlaintextScheduler : public IScheduler {
    */
   void decreaseReferenceCountBatch(WireId<IScheduler::Boolean> id) override;
 
+  //======== Below are rebatching APIs: ========
+
+  // band a number of batches into one batch.
+  WireId<Boolean> batchingUp(std::vector<WireId<Boolean>> src) override {
+    throw std::runtime_error("Not implemented!");
+  }
+
+  // decompose a batch of values into several smaller batches.
+  std::vector<WireId<Boolean>> unbatching(
+      WireId<Boolean> src,
+      std::shared_ptr<std::vector<uint32_t>> unbatchingStrategy) override {
+    throw std::runtime_error("Not implemented!");
+  }
+
   //======== Below are miscellaneous APIs: ========
 
   /**

--- a/fbpcf/scheduler/WireKeeper.cpp
+++ b/fbpcf/scheduler/WireKeeper.cpp
@@ -143,6 +143,16 @@ const std::vector<uint64_t>& WireKeeper::getBatchIntegerValue(
   return intBatchAllocator_->get(id.getId()).v;
 }
 
+std::vector<bool>& WireKeeper::getWritableBatchBooleanValue(
+    IScheduler::WireId<IScheduler::Boolean> id) const {
+  return boolBatchAllocator_->getWritableReference(id.getId()).v;
+}
+
+std::vector<uint64_t>& WireKeeper::getWritableBatchIntegerValue(
+    IScheduler::WireId<IScheduler::Arithmetic> id) const {
+  return intBatchAllocator_->getWritableReference(id.getId()).v;
+}
+
 void WireKeeper::setBatchBooleanValue(
     IScheduler::WireId<IScheduler::Boolean> id,
     const std::vector<bool>& v) {

--- a/fbpcf/scheduler/WireKeeper.h
+++ b/fbpcf/scheduler/WireKeeper.h
@@ -172,6 +172,14 @@ class WireKeeper final : public IWireKeeper {
   const std::vector<uint64_t>& getBatchIntegerValue(
       IScheduler::WireId<IScheduler::Arithmetic> id) const override;
 
+  // get the writable batch of value associated with boolean wire with given id.
+  std::vector<bool>& getWritableBatchBooleanValue(
+      IScheduler::WireId<IScheduler::Boolean> id) const override;
+
+  // get the writable batch of value associated with integer wire with given id.
+  std::vector<uint64_t>& getWritableBatchIntegerValue(
+      IScheduler::WireId<IScheduler::Arithmetic> id) const override;
+
   /**
    * @inherit doc
    */

--- a/fbpcf/scheduler/gate_keeper/GateKeeper.cpp
+++ b/fbpcf/scheduler/gate_keeper/GateKeeper.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "fbpcf/scheduler/gate_keeper/GateKeeper.h"
+#include <cstddef>
 #include "fbpcf/scheduler/IScheduler.h"
 #include "fbpcf/scheduler/gate_keeper/BatchCompositeGate.h"
 #include "fbpcf/scheduler/gate_keeper/BatchNormalGate.h"
@@ -19,63 +20,144 @@ GateKeeper::GateKeeper(std::shared_ptr<IWireKeeper> wireKeeper)
 
 IScheduler::WireId<IScheduler::Boolean> GateKeeper::inputGate(
     BoolType<false> initialValue) {
-  return addGate<false, false>(
-      INormalGate<IScheduler::Boolean>::GateType::Input,
-      IScheduler::WireId<IScheduler::Boolean>(),
-      IScheduler::WireId<IScheduler::Boolean>(),
-      initialValue);
+  auto level = getOutputLevel(
+      GateClass<false>::isFree(
+          INormalGate<IScheduler::Boolean>::GateType::Input),
+      firstUnexecutedLevel_);
+  auto outputWire = allocateNewWire(initialValue, level);
+  addGate(
+      std::make_unique<NormalGate<IScheduler::Boolean>>(
+          INormalGate<IScheduler::Boolean>::GateType::Input,
+          outputWire,
+          IScheduler::WireId<IScheduler::Boolean>(),
+          IScheduler::WireId<IScheduler::Boolean>(),
+          0,
+          *wireKeeper_),
+      level);
+  return outputWire;
 }
 
 IScheduler::WireId<IScheduler::Boolean> GateKeeper::inputGateBatch(
     BoolType<true> initialValue) {
-  return addGate<true, false>(
-      INormalGate<IScheduler::Boolean>::GateType::Input,
-      IScheduler::WireId<IScheduler::Boolean>(),
-      IScheduler::WireId<IScheduler::Boolean>(),
-      initialValue);
+  auto size = initialValue.size();
+  auto level = getOutputLevel(
+      GateClass<false>::isFree(
+          INormalGate<IScheduler::Boolean>::GateType::Input),
+      firstUnexecutedLevel_);
+
+  auto outputWire = allocateNewWire(initialValue, level);
+  addGate(
+      std::make_unique<BatchNormalGate<IScheduler::Boolean>>(
+          INormalGate<IScheduler::Boolean>::GateType::Input,
+          outputWire,
+          IScheduler::WireId<IScheduler::Boolean>(),
+          IScheduler::WireId<IScheduler::Boolean>(),
+          0,
+          size,
+          *wireKeeper_),
+      level);
+  return outputWire;
 }
 
 IScheduler::WireId<IScheduler::Boolean> GateKeeper::outputGate(
     IScheduler::WireId<IScheduler::Boolean> src,
     int partyID) {
-  return addGate<false, false>(
-      INormalGate<IScheduler::Boolean>::GateType::Output,
-      src,
-      IScheduler::WireId<IScheduler::Boolean>(),
-      false,
-      partyID);
+  auto level = getOutputLevel(
+      GateClass<false>::isFree(
+          INormalGate<IScheduler::Boolean>::GateType::Output),
+      getMaxLevel<false>(src));
+  auto outputWire = allocateNewWire(false, level);
+
+  addGate(
+      std::make_unique<NormalGate<IScheduler::Boolean>>(
+          INormalGate<IScheduler::Boolean>::GateType::Output,
+          outputWire,
+          src,
+          IScheduler::WireId<IScheduler::Boolean>(),
+          partyID,
+          *wireKeeper_),
+      level);
+
+  return outputWire;
 }
 
 IScheduler::WireId<IScheduler::Boolean> GateKeeper::outputGateBatch(
     IScheduler::WireId<IScheduler::Boolean> src,
     int partyID) {
-  return addGate<true, false>(
-      INormalGate<IScheduler::Boolean>::GateType::Output,
-      src,
-      IScheduler::WireId<IScheduler::Boolean>(),
-      {},
-      partyID);
+  auto level = getOutputLevel(
+      GateClass<false>::isFree(
+          INormalGate<IScheduler::Boolean>::GateType::Output),
+      getMaxLevel<true>(src));
+  auto outputWire = allocateNewWire(std::vector<bool>(), level);
+
+  addGate(
+      std::make_unique<BatchNormalGate<IScheduler::Boolean>>(
+          INormalGate<IScheduler::Boolean>::GateType::Output,
+          outputWire,
+          src,
+          IScheduler::WireId<IScheduler::Boolean>(),
+          partyID,
+          0,
+          *wireKeeper_),
+      level);
+
+  return outputWire;
 }
 
 IScheduler::WireId<IScheduler::Boolean> GateKeeper::normalGate(
     INormalGate<IScheduler::Boolean>::GateType gateType,
     IScheduler::WireId<IScheduler::Boolean> left,
     IScheduler::WireId<IScheduler::Boolean> right) {
-  return addGate<false, false>(gateType, left, right, false);
+  auto level = getOutputLevel(
+      GateClass<false>::isFree(gateType),
+      std::max(getMaxLevel<false>(left), getMaxLevel<false>(right)));
+  auto outputWire = allocateNewWire(false, level);
+
+  addGate(
+      std::make_unique<NormalGate<IScheduler::Boolean>>(
+          gateType, outputWire, left, right, 0, *wireKeeper_),
+      level);
+
+  return outputWire;
 }
 
 IScheduler::WireId<IScheduler::Boolean> GateKeeper::normalGateBatch(
     INormalGate<IScheduler::Boolean>::GateType gateType,
     IScheduler::WireId<IScheduler::Boolean> left,
     IScheduler::WireId<IScheduler::Boolean> right) {
-  return addGate<true, false>(gateType, left, right, {});
+  auto level = getOutputLevel(
+      GateClass<false>::isFree(gateType),
+      std::max(getMaxLevel<true>(left), getMaxLevel<true>(right)));
+  auto outputWire = allocateNewWire(std::vector<bool>(), level);
+
+  addGate(
+      std::make_unique<BatchNormalGate<IScheduler::Boolean>>(
+          gateType, outputWire, left, right, 0, 0, *wireKeeper_),
+      level);
+
+  return outputWire;
 }
 
 std::vector<IScheduler::WireId<IScheduler::Boolean>> GateKeeper::compositeGate(
     ICompositeGate::GateType gateType,
     IScheduler::WireId<IScheduler::Boolean> left,
     std::vector<IScheduler::WireId<IScheduler::Boolean>> rights) {
-  return addGate<false, true>(gateType, left, rights, 0);
+  auto compositeSize = rights.size();
+  std::vector<IScheduler::WireId<IScheduler::Boolean>> outputWires(
+      compositeSize);
+  auto level = getOutputLevel(
+      GateClass<true>::isFree(gateType),
+      std::max(getMaxLevel<false>(left), getMaxLevel<false>(rights)));
+  for (size_t i = 0; i < compositeSize; i++) {
+    outputWires[i] = allocateNewWire(false, level);
+  }
+
+  addGate(
+      std::make_unique<CompositeGate>(
+          gateType, outputWires, left, rights, *wireKeeper_),
+      level);
+
+  return outputWires;
 }
 
 std::vector<IScheduler::WireId<IScheduler::Boolean>>
@@ -83,7 +165,22 @@ GateKeeper::compositeGateBatch(
     ICompositeGate::GateType gateType,
     IScheduler::WireId<IScheduler::Boolean> left,
     std::vector<IScheduler::WireId<IScheduler::Boolean>> rights) {
-  return addGate<true, true>(gateType, left, rights, {});
+  auto compositeSize = rights.size();
+  std::vector<IScheduler::WireId<IScheduler::Boolean>> outputWires(
+      compositeSize);
+  auto level = getOutputLevel(
+      GateClass<true>::isFree(gateType),
+      std::max(getMaxLevel<true>(left), getMaxLevel<true>(rights)));
+  for (size_t i = 0; i < compositeSize; i++) {
+    outputWires[i] = allocateNewWire(std::vector<bool>(), level);
+  }
+
+  addGate(
+      std::make_unique<BatchCompositeGate>(
+          gateType, outputWires, left, rights, *wireKeeper_),
+      level);
+
+  return outputWires;
 }
 
 uint32_t GateKeeper::getFirstUnexecutedLevel() const {
@@ -102,118 +199,4 @@ bool GateKeeper::hasReachedBatchingLimit() const {
   return numUnexecutedGates_ > kMaxUnexecutedGates;
 }
 
-template <bool usingBatch, bool isCompositeWire>
-GateKeeper::RightWireType<isCompositeWire> GateKeeper::addGate(
-    GateType<isCompositeWire> gateType,
-    IScheduler::WireId<IScheduler::Boolean> left,
-    RightWireType<isCompositeWire> right,
-    BoolType<usingBatch> initialValue,
-    int partyID) {
-  numUnexecutedGates_++;
-
-  auto level = getFirstAvailableLevelForNewWire<usingBatch, isCompositeWire>(
-      gateType, left, right);
-
-  while (gatesByLevelOffset_.size() <= level - firstUnexecutedLevel_) {
-    gatesByLevelOffset_.emplace_back(std::vector<std::unique_ptr<IGate>>());
-  }
-
-  auto& gatesForLevel = gatesByLevelOffset_.at(level - firstUnexecutedLevel_);
-
-  RightWireType<isCompositeWire> outputWire;
-  if constexpr (isCompositeWire) {
-    if constexpr (usingBatch) {
-      for (size_t i = 0; i < right.size(); i++) {
-        outputWire.push_back(wireKeeper_->allocateBatchBooleanValue({}, level));
-      }
-      gatesForLevel.push_back(std::make_unique<BatchCompositeGate>(
-          gateType, outputWire, left, right, *wireKeeper_));
-    } else {
-      for (size_t i = 0; i < right.size(); i++) {
-        outputWire.push_back(wireKeeper_->allocateBooleanValue(0, level));
-      }
-      gatesForLevel.push_back(std::make_unique<CompositeGate>(
-          gateType, outputWire, left, right, *wireKeeper_));
-    }
-  } else {
-    if constexpr (usingBatch) {
-      outputWire = wireKeeper_->allocateBatchBooleanValue(initialValue, level);
-      auto numberOfResults = initialValue.size();
-      gatesForLevel.push_back(
-          std::make_unique<BatchNormalGate<IScheduler::Boolean>>(
-              gateType,
-              outputWire,
-              left,
-              right,
-              partyID,
-              numberOfResults,
-              *wireKeeper_));
-
-    } else {
-      outputWire = wireKeeper_->allocateBooleanValue(initialValue, level);
-      gatesForLevel.push_back(std::make_unique<NormalGate<IScheduler::Boolean>>(
-          gateType, outputWire, left, right, partyID, *wireKeeper_));
-    }
-  }
-
-  return outputWire;
-}
-
-// Free gates are added to even levels, and non-free gates are added to odd
-// levels. A gate can depend on a free gate at the same level, but cannot
-// depend on a non-free gate at the same level.
-template <bool usingBatch, bool isCompositeWire>
-uint32_t GateKeeper::getFirstAvailableLevelForNewWire(
-    GateType<isCompositeWire> gateType,
-    IScheduler::WireId<IScheduler::Boolean> left,
-    RightWireType<isCompositeWire> right) const {
-  uint32_t leftMaxLevel = 0;
-  if (left.isEmpty()) {
-    leftMaxLevel = 0;
-  } else if constexpr (usingBatch) {
-    leftMaxLevel = wireKeeper_->getBatchFirstAvailableLevel(left);
-  } else {
-    leftMaxLevel = wireKeeper_->getFirstAvailableLevel(left);
-  }
-
-  uint32_t rightMaxLevel = 0;
-  if constexpr (isCompositeWire) {
-    for (auto rightWire : right) {
-      if (!rightWire.isEmpty()) {
-        if constexpr (usingBatch) {
-          rightMaxLevel = std::max(
-              rightMaxLevel,
-              wireKeeper_->getBatchFirstAvailableLevel(rightWire));
-        } else {
-          rightMaxLevel = std::max(
-              rightMaxLevel, wireKeeper_->getFirstAvailableLevel(rightWire));
-        }
-      }
-    }
-  } else {
-    if (right.isEmpty()) {
-      rightMaxLevel = 0;
-    } else if constexpr (usingBatch) {
-      rightMaxLevel = wireKeeper_->getBatchFirstAvailableLevel(right);
-    } else {
-      rightMaxLevel = wireKeeper_->getFirstAvailableLevel(right);
-    }
-  }
-
-  auto isFreeGate = GateClass<isCompositeWire>::isFree(gateType);
-
-  auto minAvailableLeft = leftMaxLevel +
-      (IGateKeeper::isLevelFree(leftMaxLevel) ? (isFreeGate ? 0 : 1)
-                                              : (isFreeGate ? 1 : 2));
-  auto minAvailableRight = rightMaxLevel +
-      (IGateKeeper::isLevelFree(rightMaxLevel) ? (isFreeGate ? 0 : 1)
-                                               : (isFreeGate ? 1 : 2));
-  auto minAvailableFirstUnexecuted = firstUnexecutedLevel_ +
-      (IGateKeeper::isLevelFree(firstUnexecutedLevel_) ? (isFreeGate ? 0 : 1)
-                                                       : (isFreeGate ? 1 : 0));
-
-  return std::max(
-      std::max(minAvailableLeft, minAvailableRight),
-      minAvailableFirstUnexecuted);
-}
 } // namespace fbpcf::scheduler

--- a/fbpcf/scheduler/gate_keeper/GateKeeper.h
+++ b/fbpcf/scheduler/gate_keeper/GateKeeper.h
@@ -79,6 +79,15 @@ class GateKeeper : public IGateKeeper {
       IScheduler::WireId<IScheduler::Boolean> left,
       std::vector<IScheduler::WireId<IScheduler::Boolean>> rights) override;
 
+  // band a number of batches into one batch.
+  IScheduler::WireId<IScheduler::Boolean> batchingUp(
+      std::vector<IScheduler::WireId<IScheduler::Boolean>> src) override;
+
+  // decompose a batch of values into several smaller batches.
+  std::vector<IScheduler::WireId<IScheduler::Boolean>> unbatching(
+      IScheduler::WireId<IScheduler::Boolean> src,
+      std::shared_ptr<std::vector<uint32_t>> unbatchingStrategy) override;
+
   /**
    * @inherit doc
    */

--- a/fbpcf/scheduler/gate_keeper/IGateKeeper.h
+++ b/fbpcf/scheduler/gate_keeper/IGateKeeper.h
@@ -11,6 +11,7 @@
 #include "fbpcf/scheduler/gate_keeper/ICompositeGate.h"
 #include "fbpcf/scheduler/gate_keeper/IGate.h"
 #include "fbpcf/scheduler/gate_keeper/INormalGate.h"
+#include "fbpcf/scheduler/gate_keeper/RebatchingGate.h"
 
 namespace fbpcf::scheduler {
 
@@ -73,6 +74,15 @@ class IGateKeeper {
       ICompositeGate::GateType gateType,
       IScheduler::WireId<IScheduler::Boolean> left,
       std::vector<IScheduler::WireId<IScheduler::Boolean>> rights) = 0;
+
+  // band a number of batches into one batch.
+  virtual IScheduler::WireId<IScheduler::Boolean> batchingUp(
+      std::vector<IScheduler::WireId<IScheduler::Boolean>> src) = 0;
+
+  // decompose a batch of values into several smaller batches.
+  virtual std::vector<IScheduler::WireId<IScheduler::Boolean>> unbatching(
+      IScheduler::WireId<IScheduler::Boolean> src,
+      std::shared_ptr<std::vector<uint32_t>> unbatchingStrategy) = 0;
 
   // Return the first level of gates that has not been executed yet.
   // NOTE: Free gates are added to even levels, and non-free gates are added

--- a/fbpcf/scheduler/gate_keeper/RebatchingGate.h
+++ b/fbpcf/scheduler/gate_keeper/RebatchingGate.h
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <functional>
+#include <stdexcept>
+#include <string>
+#include "fbpcf/scheduler/gate_keeper/INormalGate.h"
+
+namespace fbpcf::scheduler {
+/**
+ * Rebatching gate doesn't really do any computation. Instead, its only goal is
+ *to rebatch some batched values to ease future computation. Note that because
+ *all other computation happens in an async manner, this kind of rebatching will
+ *also need to be async as well.
+ **/
+
+class RebatchingBooleanGate : public IGate {
+ public:
+  enum class GateType {
+    Batching, // Batch a number of batches of values into one batch of
+              // values.
+    Unbatching, // decompose a batch into several batches.
+  };
+
+  // this contructor will create a "Batching" gate. The caller is responsible
+  // to make sure the batching is doable - e.g. you can't batch 3 vectors of 2
+  // elements to a vector of 3 elements.
+  RebatchingBooleanGate(
+      const std::vector<IScheduler::WireId<IScheduler::Boolean>>&
+          individualWireIDs,
+      const IScheduler::WireId<IScheduler::Boolean>& batchWireID,
+      IWireKeeper& wireKeeper)
+      : gateType_(GateType::Batching),
+        individualWireIDs_(individualWireIDs),
+        batchWireID_(batchWireID),
+        wireKeeper_(wireKeeper) {}
+
+  // this contructor will create a "unbatching" gate. The caller is responsible
+  // to make sure the unbatching is doable - e.g. you can't unbatch a vector of
+  // 3 elements to 3 vectors of 2 elements.
+  RebatchingBooleanGate(
+      const IScheduler::WireId<IScheduler::Boolean>& batchWireID,
+      const std::vector<IScheduler::WireId<IScheduler::Boolean>>&
+          individualWireIDs,
+      IWireKeeper& wireKeeper,
+      std::shared_ptr<std::vector<uint32_t>> unbatchingStrategy)
+      : gateType_(GateType::Unbatching),
+        individualWireIDs_(individualWireIDs),
+        batchWireID_(batchWireID),
+        wireKeeper_(wireKeeper),
+        unbatchingStrategy_(unbatchingStrategy) {}
+
+  void compute(
+      engine::ISecretShareEngine&,
+      std::map<int64_t, std::vector<bool>>&) override {
+    switch (gateType_) {
+      case GateType::Batching:
+        executeBatchingGate();
+        break;
+      case GateType::Unbatching:
+        executeUnbatchingGate();
+        break;
+    }
+  }
+
+  void collectScheduledResult(
+      engine::ISecretShareEngine&,
+      std::map<int64_t, std::vector<bool>>&) override {}
+
+  uint32_t getNumberOfResults() const override {
+    return 0;
+  }
+
+  std::vector<IScheduler::WireId<IScheduler::Boolean>> getIndividualWireIDs()
+      const {
+    return individualWireIDs_;
+  }
+
+  IScheduler::WireId<IScheduler::Boolean> getBatchWireID() const {
+    return batchWireID_;
+  }
+
+  bool isBatching() const {
+    return gateType_ == GateType::Batching;
+  }
+
+ private:
+  void executeBatchingGate() const {
+    size_t batchIndex = 0;
+    size_t totalSize = 0;
+    std::vector<std::reference_wrapper<const std::vector<bool>>> batchValues(
+        individualWireIDs_.size(),
+        wireKeeper_.getBatchBooleanValue(individualWireIDs_.at(0)));
+
+    for (size_t i = 0; i < individualWireIDs_.size(); i++) {
+      batchValues[i] =
+          wireKeeper_.getBatchBooleanValue(individualWireIDs_.at(i));
+      totalSize += batchValues.at(i).get().size();
+    }
+
+    std::vector<bool> dst(totalSize);
+
+    for (size_t i = 0; i < individualWireIDs_.size(); i++) {
+      for (size_t j = 0; j < batchValues.at(i).get().size(); j++) {
+        dst[batchIndex++] = batchValues.at(i).get().at(j);
+      }
+    }
+    wireKeeper_.setBatchBooleanValue(batchWireID_, dst);
+  }
+
+  void executeUnbatchingGate() const {
+    size_t batchIndex = 0;
+    auto& src = wireKeeper_.getBatchBooleanValue(batchWireID_);
+    for (size_t i = 0; i < unbatchingStrategy_->size(); i++) {
+      std::vector<bool> dst(unbatchingStrategy_->at(i));
+      for (size_t j = 0; j < dst.size(); j++) {
+        dst[j] = src.at(batchIndex++);
+      }
+      wireKeeper_.setBatchBooleanValue(individualWireIDs_.at(i), dst);
+    }
+  }
+
+  GateType gateType_;
+  std::vector<IScheduler::WireId<IScheduler::Boolean>> individualWireIDs_;
+  IScheduler::WireId<IScheduler::Boolean> batchWireID_;
+  IWireKeeper& wireKeeper_;
+  std::shared_ptr<std::vector<uint32_t>> unbatchingStrategy_;
+};
+
+} // namespace fbpcf::scheduler

--- a/fbpcf/scheduler/gate_keeper/test/GateKeeperTest.cpp
+++ b/fbpcf/scheduler/gate_keeper/test/GateKeeperTest.cpp
@@ -213,4 +213,5 @@ TEST(GateKeeperTest, TestCompositeGates) {
   // check level 131
   testLevel(gateKeeper->popFirstUnexecutedLevel(), {}, {wires4});
 }
+
 } // namespace fbpcf::scheduler

--- a/fbpcf/scheduler/test/WireKeeperTest.cpp
+++ b/fbpcf/scheduler/test/WireKeeperTest.cpp
@@ -40,11 +40,14 @@ void wireKeeperTestAllocateSetAndGet(std::unique_ptr<IWireKeeper> wireKeeper) {
   EXPECT_EQ(wireKeeper->getIntegerValue(wire6), 0);
 
   // Batch API: Bool
-  std::vector<bool> testValue1(true, 3);
+  std::vector<bool> testValue1(3, true);
   auto wire7 = wireKeeper->allocateBatchBooleanValue(testValue1);
   testVectorEq(wireKeeper->getBatchBooleanValue(wire7), testValue1);
-  std::vector<bool> testValue2(false, 4);
+  std::vector<bool> testValue2(4, false);
   wireKeeper->setBatchBooleanValue(wire7, testValue2);
+  testVectorEq(wireKeeper->getBatchBooleanValue(wire7), testValue2);
+  testValue2[0] = true;
+  wireKeeper->getWritableBatchBooleanValue(wire7)[0] = true;
   testVectorEq(wireKeeper->getBatchBooleanValue(wire7), testValue2);
 
   // Batch API: Int
@@ -55,6 +58,9 @@ void wireKeeperTestAllocateSetAndGet(std::unique_ptr<IWireKeeper> wireKeeper) {
 
   std::vector<uint64_t> testValue4({10, 11, 12});
   wireKeeper->setBatchIntegerValue(wire8, testValue4);
+  testVectorEq(wireKeeper->getBatchIntegerValue(wire8), testValue4);
+  testValue4[0] = 33;
+  wireKeeper->getWritableBatchIntegerValue(wire8)[0] = 33;
   testVectorEq(wireKeeper->getBatchIntegerValue(wire8), testValue4);
 }
 


### PR DESCRIPTION
Summary:
For UDP protocol, we need to add a new type of gate. Rebatching gate. This type of gate allows to break a batch of values into smaller batches or combine several batches into a larger one.

This diff adds the APIs for bit string type to batching/unbatching

Reviewed By: elliottlawrence

Differential Revision: D34914178

