### PR TITLE
Add interface/class for composite tuple generation

### DIFF
--- a/fbpcf/engine/tuple_generator/DummyTupleGenerator.h
+++ b/fbpcf/engine/tuple_generator/DummyTupleGenerator.h
@@ -23,6 +23,43 @@ class DummyTupleGenerator final : public ITupleGenerator {
     return result;
   }
 
+  /**
+   * @inherit doc
+   */
+  std::unordered_map<size_t, std::vector<CompositeBooleanTuple>>
+  getCompositeTuple(std::unordered_map<size_t, uint32_t>& tupleSizes) override {
+    std::unordered_map<size_t, std::vector<CompositeBooleanTuple>> result;
+    for (auto& countOfTuples : tupleSizes) {
+      size_t tupleSize = countOfTuples.first;
+      uint32_t tupleCount = countOfTuples.second;
+
+      result.emplace(tupleSize, std::vector<CompositeBooleanTuple>(tupleCount));
+      for (int i = 0; i < tupleCount; i++) {
+        result.at(tupleSize).at(i) = CompositeBooleanTuple(
+            std::vector<bool>(tupleSize, 0),
+            0,
+            std::vector<bool>(tupleSize, 0));
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * @inherit doc
+   */
+  std::pair<
+      std::vector<BooleanTuple>,
+      std::unordered_map<size_t, std::vector<CompositeBooleanTuple>>>
+  getNormalAndCompositeBooleanTuples(
+      uint32_t tupleSizes,
+      std::unordered_map<size_t, uint32_t>& compositeTupleSizes) override {
+    auto boolResult = getBooleanTuple(tupleSizes);
+    auto compositeBoolResult = getCompositeTuple(compositeTupleSizes);
+    return std::make_pair(
+        std::move(boolResult), std::move(compositeBoolResult));
+  }
+
   std::pair<uint64_t, uint64_t> getTrafficStatistics() const override {
     return {0, 0};
   }

--- a/fbpcf/engine/tuple_generator/ITupleGenerator.h
+++ b/fbpcf/engine/tuple_generator/ITupleGenerator.h
@@ -8,6 +8,8 @@
 #pragma once
 
 #include <stdint.h>
+#include <stdexcept>
+#include <unordered_map>
 #include <vector>
 
 namespace fbpcf::engine::tuple_generator {
@@ -56,10 +58,68 @@ class ITupleGenerator {
   };
 
   /**
+   * Boolean version of composite multiplicative triple. Rather than being a
+   * single a and c however, there are n 'a' values and n 'c' values.
+   * For each 0 <= i < n, ai & b = ci. I.e. it holds n regular boolean tuples
+   * with the b bit shared.
+   *
+   */
+  class CompositeBooleanTuple {
+   public:
+    CompositeBooleanTuple() {}
+
+    CompositeBooleanTuple(std::vector<bool> a, bool b, std::vector<bool> c)
+        : a_{a}, c_{c}, b_{b} {
+      if (a.size() != c.size()) {
+        throw std::invalid_argument("Sizes of a and c must be equal");
+      }
+    }
+
+    // get the vector of A bit shares
+    std::vector<bool> getA() {
+      return a_;
+    }
+
+    // get the secret-share of shared bit B
+    bool getB() {
+      return b_;
+    }
+
+    // get the vector of C bit shares
+    std::vector<bool> getC() {
+      return c_;
+    }
+
+   private:
+    std::vector<bool> a_, c_;
+    bool b_;
+  };
+
+  /**
    * Generate a number of boolean tuples.
    * @param size number of tuples to generate.
    */
   virtual std::vector<BooleanTuple> getBooleanTuple(uint32_t size) = 0;
+
+  /**
+   * Generate a number of composite boolean tuples.
+   * @param tupleSize A map of tuple sizes requested to the number of those
+   * tuples to generate.
+   * @return A map of tuple sizes to vector of those tuples
+   */
+  virtual std::unordered_map<size_t, std::vector<CompositeBooleanTuple>>
+  getCompositeTuple(std::unordered_map<size_t, uint32_t>& tupleSizes) = 0;
+
+  /**
+   * Wrapper method for getBooleanTuple() and getCompositeTuple() which performs
+   * only one round of communication.
+   */
+  virtual std::pair<
+      std::vector<BooleanTuple>,
+      std::unordered_map<size_t, std::vector<CompositeBooleanTuple>>>
+  getNormalAndCompositeBooleanTuples(
+      uint32_t tupleSize,
+      std::unordered_map<size_t, uint32_t>& compositeTupleSizes) = 0;
 
   /**
    * Get the total amount of traffic transmitted.

--- a/fbpcf/engine/tuple_generator/TupleGenerator.cpp
+++ b/fbpcf/engine/tuple_generator/TupleGenerator.cpp
@@ -56,6 +56,23 @@ std::vector<TupleGenerator::BooleanTuple> TupleGenerator::generateTuples(
   return booleanTuples;
 }
 
+std::unordered_map<size_t, std::vector<ITupleGenerator::CompositeBooleanTuple>>
+TupleGenerator::getCompositeTuple(
+    std::unordered_map<size_t, uint32_t>& tupleSizes) {
+  throw std::runtime_error("Not implemented");
+}
+
+std::pair<
+    std::vector<ITupleGenerator::BooleanTuple>,
+    std::unordered_map<
+        size_t,
+        std::vector<ITupleGenerator::CompositeBooleanTuple>>>
+TupleGenerator::getNormalAndCompositeBooleanTuples(
+    uint32_t tupleSize,
+    std::unordered_map<size_t, uint32_t>& tupleSizes) {
+  throw std::runtime_error("Not implemented");
+}
+
 std::pair<uint64_t, uint64_t> TupleGenerator::getTrafficStatistics() const {
   std::pair<uint64_t, uint64_t> rst = {0, 0};
   for (auto& item : productShareGeneratorMap_) {

--- a/fbpcf/engine/tuple_generator/TupleGenerator.h
+++ b/fbpcf/engine/tuple_generator/TupleGenerator.h
@@ -39,6 +39,22 @@ class TupleGenerator final : public ITupleGenerator {
    */
   std::vector<BooleanTuple> getBooleanTuple(uint32_t size) override;
 
+  /**
+   * @inherit doc
+   */
+  std::unordered_map<size_t, std::vector<CompositeBooleanTuple>>
+  getCompositeTuple(std::unordered_map<size_t, uint32_t>& tupleSizes) override;
+
+  /**
+   * @inherit doc
+   */
+  std::pair<
+      std::vector<BooleanTuple>,
+      std::unordered_map<size_t, std::vector<CompositeBooleanTuple>>>
+  getNormalAndCompositeBooleanTuples(
+      uint32_t tupleSize,
+      std::unordered_map<size_t, uint32_t>& compositeTupleSizes) override;
+
   std::pair<uint64_t, uint64_t> getTrafficStatistics() const override;
 
  private:

--- a/fbpcf/engine/tuple_generator/TwoPartyTupleGenerator.cpp
+++ b/fbpcf/engine/tuple_generator/TwoPartyTupleGenerator.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "fbpcf/engine/tuple_generator/TwoPartyTupleGenerator.h"
+#include <stdexcept>
 #include "fbpcf/engine/util/util.h"
 
 namespace fbpcf::engine::tuple_generator {
@@ -91,6 +92,23 @@ TwoPartyTupleGenerator::generateTuples(uint64_t size) {
     booleanTuples[i] = BooleanTuple(a, b, c);
   }
   return booleanTuples;
+}
+
+std::unordered_map<size_t, std::vector<ITupleGenerator::CompositeBooleanTuple>>
+TwoPartyTupleGenerator::getCompositeTuple(
+    std::unordered_map<size_t, uint32_t>& tupleSizes) {
+  throw std::runtime_error("Not implemented");
+}
+
+std::pair<
+    std::vector<ITupleGenerator::BooleanTuple>,
+    std::unordered_map<
+        size_t,
+        std::vector<ITupleGenerator::CompositeBooleanTuple>>>
+TwoPartyTupleGenerator::getNormalAndCompositeBooleanTuples(
+    uint32_t tupleSize,
+    std::unordered_map<size_t, uint32_t>& tupleSizes) {
+  throw std::runtime_error("Not implemented");
 }
 
 std::pair<uint64_t, uint64_t> TwoPartyTupleGenerator::getTrafficStatistics()

--- a/fbpcf/engine/tuple_generator/TwoPartyTupleGenerator.h
+++ b/fbpcf/engine/tuple_generator/TwoPartyTupleGenerator.h
@@ -34,6 +34,22 @@ class TwoPartyTupleGenerator final : public ITupleGenerator {
   /**
    * @inherit doc
    */
+  std::unordered_map<size_t, std::vector<CompositeBooleanTuple>>
+  getCompositeTuple(std::unordered_map<size_t, uint32_t>& tupleSizes) override;
+
+  /**
+   * @inherit doc
+   */
+  std::pair<
+      std::vector<BooleanTuple>,
+      std::unordered_map<size_t, std::vector<CompositeBooleanTuple>>>
+  getNormalAndCompositeBooleanTuples(
+      uint32_t tupleSize,
+      std::unordered_map<size_t, uint32_t>& compositeTupleSizes) override;
+
+  /**
+   * @inherit doc
+   */
   std::pair<uint64_t, uint64_t> getTrafficStatistics() const override;
 
  private:


### PR DESCRIPTION
Summary:
This diff adds the external interface for the tuple generator to support composite tuples. The caller will pass in an unordered map of composite tuple sizes to the number of those tuples requested.

I've also added a second method to perform both the composite and non-composite tuple generation together to reduce the number of round trips. I'm not actually sure how useful this will be though given the use of async buffers in the implementations so might end up removing it.

Reviewed By: RuiyuZhu

Differential Revision: D34807935

