### PR TITLE
Add benchmark for allocators

### DIFF
--- a/fbpcf/scheduler/test/benchmarks/AllocatorBenchmark.h
+++ b/fbpcf/scheduler/test/benchmarks/AllocatorBenchmark.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/Benchmark.h>
+
+#include "fbpcf/scheduler/UnorderedMapAllocator.h"
+#include "fbpcf/scheduler/VectorArenaAllocator.h"
+
+namespace fbpcf::scheduler {
+
+const bool unsafe = true;
+
+template <typename T>
+inline void benchmarkAllocate(std::unique_ptr<IAllocator<T>> allocator, int n) {
+  while (n--) {
+    allocator->allocate(n);
+  }
+}
+
+template <typename T>
+inline void benchmarkFree(std::unique_ptr<IAllocator<T>> allocator, int n) {
+  uint64_t ref;
+  BENCHMARK_SUSPEND {
+    auto count = n;
+    while (count--) {
+      ref = allocator->allocate(count);
+    }
+  }
+
+  while (n--) {
+    allocator->free(ref--);
+  }
+}
+
+template <typename T>
+inline void benchmarkGet(std::unique_ptr<IAllocator<T>> allocator, int n) {
+  uint64_t ref;
+  BENCHMARK_SUSPEND {
+    auto count = n;
+    while (count--) {
+      ref = allocator->allocate(count);
+    }
+  }
+
+  while (n--) {
+    allocator->get(ref--);
+  }
+}
+
+BENCHMARK(VectorArenaAllocator_allocate, n) {
+  benchmarkAllocate<int64_t>(
+      std::make_unique<VectorArenaAllocator<int64_t, unsafe>>(), n);
+}
+
+BENCHMARK(VectorArenaAllocator_free, n) {
+  benchmarkFree<int64_t>(
+      std::make_unique<VectorArenaAllocator<int64_t, unsafe>>(), n);
+}
+
+BENCHMARK(VectorArenaAllocator_get, n) {
+  benchmarkGet<int64_t>(
+      std::make_unique<VectorArenaAllocator<int64_t, unsafe>>(), n);
+}
+
+BENCHMARK(UnorderedMapAllocator_allocate, n) {
+  benchmarkAllocate<int64_t>(
+      std::make_unique<UnorderedMapAllocator<int64_t>>(), n);
+}
+
+BENCHMARK(UnorderedMapAllocator_free, n) {
+  benchmarkFree<int64_t>(std::make_unique<UnorderedMapAllocator<int64_t>>(), n);
+}
+
+BENCHMARK(UnorderedMapAllocator_get, n) {
+  benchmarkGet<int64_t>(std::make_unique<UnorderedMapAllocator<int64_t>>(), n);
+}
+} // namespace fbpcf::scheduler

--- a/fbpcf/scheduler/test/benchmarks/SchedulerBenchmark.cpp
+++ b/fbpcf/scheduler/test/benchmarks/SchedulerBenchmark.cpp
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <folly/Benchmark.h>
+
+#include "common/init/Init.h"
+
+#include "fbpcf/scheduler/test/benchmarks/AllocatorBenchmark.h"
+
+int main(int argc, char* argv[]) {
+  facebook::initFacebook(&argc, &argv);
+  folly::runBenchmarks();
+  return 0;
+}


### PR DESCRIPTION
Summary: This diff adds benchmarks for the vector arena and unordered map allocators. Only the vector arena is used in production, but having both benchmarks lets us check that the vector arena is faster than the unordered map implementation.

Differential Revision: D35028432

