### PR TITLE
Add benchmark for WireKeeper

### DIFF
--- a/fbpcf/scheduler/test/benchmarks/AllocatorBenchmark.h
+++ b/fbpcf/scheduler/test/benchmarks/AllocatorBenchmark.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/Benchmark.h>
+
+#include "fbpcf/scheduler/UnorderedMapAllocator.h"
+#include "fbpcf/scheduler/VectorArenaAllocator.h"
+
+namespace fbpcf::scheduler {
+
+const bool unsafe = true;
+
+template <typename T>
+inline void benchmarkAllocate(std::unique_ptr<IAllocator<T>> allocator, int n) {
+  while (n--) {
+    allocator->allocate(n);
+  }
+}
+
+template <typename T>
+inline void benchmarkFree(std::unique_ptr<IAllocator<T>> allocator, int n) {
+  uint64_t ref;
+  BENCHMARK_SUSPEND {
+    auto count = n;
+    while (count--) {
+      ref = allocator->allocate(count);
+    }
+  }
+
+  while (n--) {
+    allocator->free(ref--);
+  }
+}
+
+template <typename T>
+inline void benchmarkGet(std::unique_ptr<IAllocator<T>> allocator, int n) {
+  uint64_t ref;
+  BENCHMARK_SUSPEND {
+    auto count = n;
+    while (count--) {
+      ref = allocator->allocate(count);
+    }
+  }
+
+  while (n--) {
+    allocator->get(ref--);
+  }
+}
+
+BENCHMARK(VectorArenaAllocator_allocate, n) {
+  benchmarkAllocate<int64_t>(
+      std::make_unique<VectorArenaAllocator<int64_t, unsafe>>(), n);
+}
+
+BENCHMARK(VectorArenaAllocator_free, n) {
+  benchmarkFree<int64_t>(
+      std::make_unique<VectorArenaAllocator<int64_t, unsafe>>(), n);
+}
+
+BENCHMARK(VectorArenaAllocator_get, n) {
+  benchmarkGet<int64_t>(
+      std::make_unique<VectorArenaAllocator<int64_t, unsafe>>(), n);
+}
+
+BENCHMARK(UnorderedMapAllocator_allocate, n) {
+  benchmarkAllocate<int64_t>(
+      std::make_unique<UnorderedMapAllocator<int64_t>>(), n);
+}
+
+BENCHMARK(UnorderedMapAllocator_free, n) {
+  benchmarkFree<int64_t>(std::make_unique<UnorderedMapAllocator<int64_t>>(), n);
+}
+
+BENCHMARK(UnorderedMapAllocator_get, n) {
+  benchmarkGet<int64_t>(std::make_unique<UnorderedMapAllocator<int64_t>>(), n);
+}
+} // namespace fbpcf::scheduler

--- a/fbpcf/scheduler/test/benchmarks/SchedulerBenchmark.cpp
+++ b/fbpcf/scheduler/test/benchmarks/SchedulerBenchmark.cpp
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <folly/Benchmark.h>
+
+#include "common/init/Init.h"
+
+#include "fbpcf/scheduler/test/benchmarks/AllocatorBenchmark.h"
+
+int main(int argc, char* argv[]) {
+  facebook::initFacebook(&argc, &argv);
+  folly::runBenchmarks();
+  return 0;
+}

--- a/fbpcf/scheduler/test/benchmarks/SchedulerBenchmark.cpp
+++ b/fbpcf/scheduler/test/benchmarks/SchedulerBenchmark.cpp
@@ -10,6 +10,7 @@
 #include "common/init/Init.h"
 
 #include "fbpcf/scheduler/test/benchmarks/AllocatorBenchmark.h"
+#include "fbpcf/scheduler/test/benchmarks/WireKeeperBenchmark.h"
 
 int main(int argc, char* argv[]) {
   facebook::initFacebook(&argc, &argv);

--- a/fbpcf/scheduler/test/benchmarks/WireKeeperBenchmark.h
+++ b/fbpcf/scheduler/test/benchmarks/WireKeeperBenchmark.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/Benchmark.h>
+
+#include "fbpcf/scheduler/WireKeeper.h"
+
+const bool unsafe = true;
+
+namespace fbpcf::scheduler {
+
+#define BENCHMARK_WIREKEEPER                                     \
+  folly::BenchmarkSuspender braces;                              \
+  auto wireKeeper = WireKeeper::createWithVectorArena<unsafe>(); \
+  std::vector<IScheduler::WireId<IScheduler::Boolean>> wireIds;  \
+  for (auto i = 0; i < n; i++) {                                 \
+    wireIds.push_back(wireKeeper->allocateBooleanValue());       \
+  }                                                              \
+  braces.dismiss();                                              \
+  while (n--)
+
+BENCHMARK(WireKeeperBenchmark_allocateBooleanValue, n) {
+  folly::BenchmarkSuspender braces;
+  auto wireKeeper = WireKeeper::createWithVectorArena<unsafe>();
+  braces.dismiss();
+
+  while (n--) {
+    wireKeeper->allocateBooleanValue();
+  }
+}
+
+BENCHMARK(WireKeeperBenchmark_getBooleanValue, n) {
+  BENCHMARK_WIREKEEPER {
+    wireKeeper->getBooleanValue(wireIds.at(n));
+  }
+}
+
+BENCHMARK(WireKeeperBenchmark_setBooleanValue, n) {
+  BENCHMARK_WIREKEEPER {
+    wireKeeper->setBooleanValue(wireIds.at(n), n & 1);
+  }
+}
+
+BENCHMARK(WireKeeperBenchmark_getFirstAvailableLevel, n) {
+  BENCHMARK_WIREKEEPER {
+    wireKeeper->getFirstAvailableLevel(wireIds.at(n));
+  }
+}
+
+BENCHMARK(WireKeeperBenchmark_setFirstAvailableLevel, n) {
+  BENCHMARK_WIREKEEPER {
+    wireKeeper->setFirstAvailableLevel(wireIds.at(n), n);
+  }
+}
+
+BENCHMARK(WireKeeperBenchmark_increaseReferenceCount, n) {
+  BENCHMARK_WIREKEEPER {
+    wireKeeper->increaseReferenceCount(wireIds.at(n));
+  }
+}
+
+BENCHMARK(WireKeeperBenchmark_decreaseReferenceCount, n) {
+  BENCHMARK_WIREKEEPER {
+    wireKeeper->decreaseReferenceCount(wireIds.at(n));
+  }
+}
+} // namespace fbpcf::scheduler


### PR DESCRIPTION
Summary: This diff adds benchmarks for the WireKeeper. I opted to not include the batch or arithmetic API (for now at least), since they are implemented the exact same way as the boolean, non-batch API.

Differential Revision: D35035761

