### PR TITLE
Address flaky test issue for LocalFileWriterTest

### DIFF
--- a/fbpcf/io/api/test/LocalFileWriterTest.cpp
+++ b/fbpcf/io/api/test/LocalFileWriterTest.cpp
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 #include <stdio.h>
 #include <filesystem>
+#include <random>
 #include <string>
 #include "folly/logging/xlog.h"
 
@@ -22,7 +23,12 @@ inline void cleanup(std::string fileToDelete) {
 
 TEST(LocalFileWriterTest, testWritingToFile) {
   std::string baseDir = IOTestHelper::getBaseDirFromPath(__FILE__);
-  std::string fileToWriteTo = baseDir + "data/local_file_writer_test_file.txt";
+  std::random_device rd;
+  std::default_random_engine defEngine(rd());
+  std::uniform_int_distribution<int> intDistro(1, 25000);
+  auto randint = intDistro(defEngine);
+  std::string fileToWriteTo = baseDir + "data/local_file_writer_test_file" +
+      std::to_string(randint) + ".txt";
   auto writer = std::make_unique<fbpcf::io::LocalFileWriter>(fileToWriteTo);
 
   /*

--- a/fbpcf/io/api/test/utils/IOTestHelper.h
+++ b/fbpcf/io/api/test/utils/IOTestHelper.h
@@ -45,6 +45,9 @@ class IOTestHelper {
       auto test = testFile->get();
       EXPECT_EQ(test, expected);
     }
+
+    expectedFile->close();
+    testFile->close();
   }
 };
 


### PR DESCRIPTION
Summary:
See T115000570. This test is flaky on `stress-runs` because it uses the same file name for every run.

In this diff, we just add a random number

Differential Revision: D35053135

