### PR TITLE
Set up boilerplate for WriteOnlyOram benchmarks

### DIFF
--- a/fbpcf/mpc_std_lib/oram/test/DifferenceCalculatorTest.cpp
+++ b/fbpcf/mpc_std_lib/oram/test/DifferenceCalculatorTest.cpp
@@ -25,66 +25,9 @@
 namespace fbpcf::mpc_std_lib::oram {
 
 template <typename T>
-struct InputType {
-  std::vector<uint32_t> indicatorShares;
-  std::vector<std::vector<bool>> minuendShares;
-  std::vector<T> subtrahendShares;
-};
-
-template <typename T, int indicatorWidth>
-std::tuple<InputType<T>, InputType<T>, std::vector<T>> generateRandomInputs(
-    size_t batchSize) {
-  InputType<T> rst0{
-      .indicatorShares = std::vector<uint32_t>(batchSize),
-      .minuendShares = std::vector<std::vector<bool>>(),
-      .subtrahendShares = std::vector<T>(batchSize),
-  };
-  InputType<T> rst1{
-      .indicatorShares = std::vector<uint32_t>(batchSize),
-      .minuendShares = std::vector<std::vector<bool>>(),
-      .subtrahendShares = std::vector<T>(batchSize),
-  };
-  std::vector<T> expectedValue(batchSize);
-
-  std::random_device rd;
-  std::mt19937_64 e(rd());
-  std::uniform_int_distribution<uint32_t> randomIndicator(0, 0xFFFF);
-  std::uniform_int_distribution<int32_t> randomBit(0, 1);
-
-  for (size_t i = 0; i < batchSize; i++) {
-    auto [minuend, minuendShare0, minuendShare1] = util::getRandomData<T>(e);
-    auto subtrahend = std::get<0>(util::getRandomData<T>(e));
-    // indicator is 1 or -1;
-    int32_t indicator = static_cast<int32_t>(-1) + 2 * randomBit(e);
-    expectedValue[i] =
-        indicator == 1 ? (minuend - subtrahend) : (subtrahend - minuend);
-
-    rst0.indicatorShares[i] = randomIndicator(e);
-    rst1.indicatorShares[i] =
-        (rst0.indicatorShares.at(i) - indicator) % (1 << indicatorWidth);
-
-    rst0.subtrahendShares[i] = std::get<0>(util::getRandomData<T>(e));
-    rst1.subtrahendShares[i] = rst0.subtrahendShares.at(i) - subtrahend;
-
-    auto tmp0 = util::Adapters<T>::convertToBits(minuendShare0);
-    auto tmp1 = util::Adapters<T>::convertToBits(minuendShare1);
-    for (size_t j = 0; j < tmp0.size(); j++) {
-      if (j >= rst0.minuendShares.size()) {
-        rst0.minuendShares.push_back(std::vector<bool>(batchSize));
-        rst1.minuendShares.push_back(std::vector<bool>(batchSize));
-      }
-      rst0.minuendShares[j][i] = tmp0[j];
-      rst1.minuendShares[j][i] = tmp1[j];
-    }
-  }
-
-  return {rst0, rst1, expectedValue};
-}
-
-template <typename T>
 std::vector<T> differenceCalculatorHelper(
     std::unique_ptr<IDifferenceCalculatorFactory<T>> factory,
-    const InputType<T>& input) {
+    const util::InputType<T>& input) {
   auto calculator = factory->create();
   return calculator->calculateDifferenceBatch(
       input.indicatorShares, input.minuendShares, input.subtrahendShares);
@@ -97,16 +40,16 @@ void testDifferenceCalculator(
   size_t batchSize = 16384;
 
   auto [input0, input1, expectedValue] =
-      generateRandomInputs<T, indicatorWidth>(batchSize);
+      util::generateRandomInputs<T, indicatorWidth>(batchSize);
 
   auto future0 = std::async(
       differenceCalculatorHelper<T>,
       std::move(factory0),
-      std::reference_wrapper<InputType<T>>(input0));
+      std::reference_wrapper<util::InputType<T>>(input0));
   auto future1 = std::async(
       differenceCalculatorHelper<T>,
       std::move(factory1),
-      std::reference_wrapper<InputType<T>>(input1));
+      std::reference_wrapper<util::InputType<T>>(input1));
 
   auto result0 = future0.get();
   auto result1 = future1.get();

--- a/fbpcf/mpc_std_lib/oram/test/SinglePointArrayGeneratorTest.cpp
+++ b/fbpcf/mpc_std_lib/oram/test/SinglePointArrayGeneratorTest.cpp
@@ -29,26 +29,6 @@
 
 namespace fbpcf::mpc_std_lib::oram {
 
-std::tuple<std::vector<bool>, std::vector<bool>, uint32_t>
-generateSharedRandomBoolVector(size_t length) {
-  uint32_t width = std::ceil(std::log2(length));
-  std::random_device rd;
-  std::mt19937_64 e(rd());
-  std::uniform_int_distribution<uint32_t> dist(0, length - 1);
-  std::uniform_int_distribution<uint32_t> randomMask(
-      0, (uint64_t(1) << width) - 1);
-
-  auto value = dist(e);
-  auto mask0 = randomMask(e);
-  auto mask1 = mask0 ^ value;
-  auto rst0 = util::Adapters<uint32_t>::convertToBits(mask0);
-  auto rst1 = util::Adapters<uint32_t>::convertToBits(mask1);
-  rst0.erase(rst0.begin() + width, rst0.end());
-  rst1.erase(rst1.begin() + width, rst1.end());
-
-  return {rst0, rst1, value};
-}
-
 std::vector<std::pair<std::vector<bool>, std::vector<__m128i>>>
 generateSinglePointArrayHelper(
     std::unique_ptr<ISinglePointArrayGeneratorFactory> factory,
@@ -75,7 +55,9 @@ void testSinglePointArrayGenerator(
       width, std::vector<bool>(batchSize));
   std::vector<uint32_t> expectedIndex;
   for (size_t i = 0; i < batchSize; i++) {
-    auto [share0, share1, trueValue] = generateSharedRandomBoolVector(length);
+    auto [share0, share1, trueValue] =
+        util::generateSharedRandomBoolVectorForSinglePointArrayGenerator(
+            length);
     for (size_t j = 0; j < width; j++) {
       party0Input[j][i] = share0.at(j);
       party1Input[j][i] = share1.at(j);

--- a/fbpcf/mpc_std_lib/oram/test/WriteOnlyORAMTest.cpp
+++ b/fbpcf/mpc_std_lib/oram/test/WriteOnlyORAMTest.cpp
@@ -36,66 +36,11 @@
 
 namespace fbpcf::mpc_std_lib::oram {
 
-struct WritingType {
-  std::vector<std::vector<bool>> indexShares;
-  std::vector<std::vector<bool>> valueShares;
-};
-
-template <typename T>
-std::tuple<WritingType, WritingType, std::vector<T>> generateRandomValuesToAdd(
-    size_t oramSize,
-    size_t batchSize) {
-  size_t indexWidth = std::ceil(std::log2(oramSize));
-
-  WritingType input0{
-      .indexShares = std::vector<std::vector<bool>>(
-          indexWidth, std::vector<bool>(batchSize)),
-      .valueShares = std::vector<std::vector<bool>>()};
-
-  WritingType input1{
-      .indexShares = std::vector<std::vector<bool>>(
-          indexWidth, std::vector<bool>(batchSize)),
-      .valueShares = std::vector<std::vector<bool>>()};
-
-  std::vector<T> expectedValue(oramSize, T(0));
-
-  std::random_device rd;
-  std::mt19937_64 e(rd());
-  std::uniform_int_distribution<uint32_t> randomIndex(0, oramSize - 1);
-  std::uniform_int_distribution<uint32_t> randomMask(0, 0xFFFFFFFF);
-
-  for (size_t i = 0; i < batchSize; i++) {
-    auto index = randomIndex(e);
-    auto [value, share0, share1] = util::getRandomData<T>(e);
-    expectedValue[index] += value;
-
-    auto indexShare = randomMask(e);
-    auto tmp0 = util::Adapters<uint32_t>::convertToBits(indexShare);
-    auto tmp1 = util::Adapters<uint32_t>::convertToBits(index ^ indexShare);
-    for (size_t j = 0; j < indexWidth; j++) {
-      input0.indexShares[j][i] = tmp0.at(j);
-      input1.indexShares[j][i] = tmp1.at(j);
-    }
-
-    tmp0 = util::Adapters<T>::convertToBits(share0);
-    tmp1 = util::Adapters<T>::convertToBits(share1);
-    for (size_t j = 0; j < tmp0.size(); j++) {
-      if (j >= input0.valueShares.size()) {
-        input0.valueShares.push_back(std::vector<bool>(batchSize));
-        input1.valueShares.push_back(std::vector<bool>(batchSize));
-      }
-      input0.valueShares[j][i] = tmp0[j];
-      input1.valueShares[j][i] = tmp1[j];
-    }
-  }
-  return {input0, input1, expectedValue};
-}
-
 template <typename T>
 std::pair<std::vector<T>, std::vector<T>> writeOnlyOramHelper(
     std::unique_ptr<IWriteOnlyOramFactory<T>> factory,
     size_t oramSize,
-    const WritingType& input) {
+    const util::WritingType& input) {
   auto oram = factory->create(oramSize);
   oram->obliviousAddBatch(input.indexShares, input.valueShares);
   std::vector<T> rst(oramSize);
@@ -115,18 +60,18 @@ void testWriteOnlyOram(
   size_t batchSize = 16384;
 
   auto [input0, input1, expectedValue] =
-      generateRandomValuesToAdd<T>(oramSize, batchSize);
+      util::generateRandomValuesToAdd<T>(oramSize, batchSize);
 
   auto future0 = std::async(
       writeOnlyOramHelper<T>,
       std::move(factory0),
       oramSize,
-      std::reference_wrapper<WritingType>(input0));
+      std::reference_wrapper<util::WritingType>(input0));
   auto future1 = std::async(
       writeOnlyOramHelper<T>,
       std::move(factory1),
       oramSize,
-      std::reference_wrapper<WritingType>(input1));
+      std::reference_wrapper<util::WritingType>(input1));
 
   auto result0 = future0.get();
   auto result1 = future1.get();

--- a/fbpcf/mpc_std_lib/oram/test/benchmarks/OramBenchmark.cpp
+++ b/fbpcf/mpc_std_lib/oram/test/benchmarks/OramBenchmark.cpp
@@ -13,7 +13,9 @@
 #include "fbpcf/engine/util/test/benchmarks/NetworkedBenchmark.h"
 #include "fbpcf/mpc_std_lib/oram/DifferenceCalculatorFactory.h"
 #include "fbpcf/mpc_std_lib/oram/IDifferenceCalculatorFactory.h"
+#include "fbpcf/mpc_std_lib/oram/ISinglePointArrayGenerator.h"
 #include "fbpcf/mpc_std_lib/oram/ObliviousDeltaCalculatorFactory.h"
+#include "fbpcf/mpc_std_lib/oram/SinglePointArrayGeneratorFactory.h"
 #include "fbpcf/mpc_std_lib/util/test/util.h"
 #include "fbpcf/scheduler/IScheduler.h"
 #include "fbpcf/scheduler/SchedulerHelper.h"
@@ -152,6 +154,83 @@ class ObliviousDeltaCalculatorBenchmark
 
 BENCHMARK_COUNTERS(ObliviousDeltaCalculator_Benchmark, counters) {
   ObliviousDeltaCalculatorBenchmark benchmark;
+  benchmark.runBenchmark(counters);
+}
+
+class SinglePointArrayGeneratorBenchmark
+    : public engine::util::NetworkedBenchmark {
+ public:
+  void setup() override {
+    auto [agentFactory0, agentFactory1] =
+        engine::util::getSocketAgentFactories();
+    agentFactory0_ = std::move(agentFactory0);
+    agentFactory1_ = std::move(agentFactory1);
+
+    size_t width = std::ceil(std::log2(length_));
+    size_t batchSize = 128;
+
+    party0Input_ =
+        std::vector<std::vector<bool>>(width, std::vector<bool>(batchSize));
+    party1Input_ =
+        std::vector<std::vector<bool>>(width, std::vector<bool>(batchSize));
+    for (size_t i = 0; i < batchSize; i++) {
+      auto [share0, share1, _] =
+          util::generateSharedRandomBoolVectorForSinglePointArrayGenerator(
+              length_);
+      for (size_t j = 0; j < width; j++) {
+        party0Input_[j][i] = share0.at(j);
+        party1Input_[j][i] = share1.at(j);
+      }
+    }
+  }
+
+ protected:
+  void initSender() override {
+    scheduler::SchedulerKeeper<0>::setScheduler(
+        scheduler::createLazySchedulerWithRealEngine(0, *agentFactory0_));
+    SinglePointArrayGeneratorFactory factory(
+        true, std::make_unique<ObliviousDeltaCalculatorFactory<0>>(true, 0, 1));
+    sender_ = factory.create();
+  }
+
+  void runSender() override {
+    sender_->generateSinglePointArrays(party0Input_, length_);
+  }
+
+  void initReceiver() override {
+    scheduler::SchedulerKeeper<1>::setScheduler(
+        scheduler::createLazySchedulerWithRealEngine(1, *agentFactory1_));
+    SinglePointArrayGeneratorFactory factory(
+        false,
+        std::make_unique<ObliviousDeltaCalculatorFactory<1>>(false, 0, 1));
+    receiver_ = factory.create();
+  }
+
+  void runReceiver() override {
+    receiver_->generateSinglePointArrays(party1Input_, length_);
+  }
+
+  std::pair<uint64_t, uint64_t> getTrafficStatistics() override {
+    return scheduler::SchedulerKeeper<0>::getTrafficStatistics();
+  }
+
+ private:
+  size_t length_ = 16384;
+
+  std::unique_ptr<engine::communication::IPartyCommunicationAgentFactory>
+      agentFactory0_;
+  std::unique_ptr<engine::communication::IPartyCommunicationAgentFactory>
+      agentFactory1_;
+
+  std::unique_ptr<ISinglePointArrayGenerator> sender_;
+  std::unique_ptr<ISinglePointArrayGenerator> receiver_;
+
+  std::vector<std::vector<bool>> party0Input_;
+  std::vector<std::vector<bool>> party1Input_;
+};
+
+BENCHMARK_COUNTERS(SinglePointArrayGenerator_Benchmark, counters) {
+  SinglePointArrayGeneratorBenchmark benchmark;
   benchmark.runBenchmark(counters);
 }
 } // namespace fbpcf::mpc_std_lib::oram

--- a/fbpcf/mpc_std_lib/oram/test/benchmarks/OramBenchmark.cpp
+++ b/fbpcf/mpc_std_lib/oram/test/benchmarks/OramBenchmark.cpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <folly/Benchmark.h>
+
+#include "common/init/Init.h"
+
+#include "fbpcf/engine/util/test/benchmarks/BenchmarkHelper.h"
+#include "fbpcf/engine/util/test/benchmarks/NetworkedBenchmark.h"
+#include "fbpcf/mpc_std_lib/oram/DifferenceCalculatorFactory.h"
+#include "fbpcf/mpc_std_lib/oram/IDifferenceCalculatorFactory.h"
+#include "fbpcf/mpc_std_lib/util/test/util.h"
+#include "fbpcf/scheduler/IScheduler.h"
+#include "fbpcf/scheduler/SchedulerHelper.h"
+
+namespace fbpcf::mpc_std_lib::oram {
+
+const int8_t indicatorWidth = 16;
+
+class DifferenceCalculatorBenchmark : public engine::util::NetworkedBenchmark {
+ public:
+  void setup() override {
+    auto [agentFactory0, agentFactory1] =
+        engine::util::getSocketAgentFactories();
+    agentFactory0_ = std::move(agentFactory0);
+    agentFactory1_ = std::move(agentFactory1);
+
+    auto [input0, input1, _] =
+        util::generateRandomInputs<uint32_t, indicatorWidth>(batchSize_);
+    input0_ = input0;
+    input1_ = input1;
+  }
+
+ protected:
+  void initSender() override {
+    scheduler::SchedulerKeeper<0>::setScheduler(
+        scheduler::createLazySchedulerWithRealEngine(0, *agentFactory0_));
+    DifferenceCalculatorFactory<uint32_t, indicatorWidth, 0> factory(
+        true, 0, 1);
+    sender_ = factory.create();
+  }
+
+  void runSender() override {
+    sender_->calculateDifferenceBatch(
+        input0_.indicatorShares,
+        input0_.minuendShares,
+        input0_.subtrahendShares);
+  }
+
+  void initReceiver() override {
+    scheduler::SchedulerKeeper<1>::setScheduler(
+        scheduler::createLazySchedulerWithRealEngine(1, *agentFactory1_));
+    DifferenceCalculatorFactory<uint32_t, indicatorWidth, 1> factory(
+        false, 0, 1);
+    receiver_ = factory.create();
+  }
+
+  void runReceiver() override {
+    receiver_->calculateDifferenceBatch(
+        input1_.indicatorShares,
+        input1_.minuendShares,
+        input1_.subtrahendShares);
+  }
+
+  std::pair<uint64_t, uint64_t> getTrafficStatistics() override {
+    return scheduler::SchedulerKeeper<0>::getTrafficStatistics();
+  }
+
+ private:
+  size_t batchSize_ = 16384;
+
+  std::unique_ptr<engine::communication::IPartyCommunicationAgentFactory>
+      agentFactory0_;
+  std::unique_ptr<engine::communication::IPartyCommunicationAgentFactory>
+      agentFactory1_;
+
+  std::unique_ptr<IDifferenceCalculator<uint32_t>> sender_;
+  std::unique_ptr<IDifferenceCalculator<uint32_t>> receiver_;
+
+  util::InputType<uint32_t> input0_;
+  util::InputType<uint32_t> input1_;
+};
+
+BENCHMARK_COUNTERS(DifferenceCalculator_Benchmark, counters) {
+  DifferenceCalculatorBenchmark benchmark;
+  benchmark.runBenchmark(counters);
+}
+} // namespace fbpcf::mpc_std_lib::oram
+
+int main(int argc, char* argv[]) {
+  facebook::initFacebook(&argc, &argv);
+  folly::runBenchmarks();
+  return 0;
+}

--- a/fbpcf/mpc_std_lib/util/test/UtilFunctionTests.cpp
+++ b/fbpcf/mpc_std_lib/util/test/UtilFunctionTests.cpp
@@ -19,6 +19,7 @@
 #include "fbpcf/engine/util/util.h"
 #include "fbpcf/mpc_std_lib/util/test/util.h"
 #include "fbpcf/mpc_std_lib/util/util.h"
+#include "fbpcf/test/TestHelper.h"
 
 namespace fbpcf::mpc_std_lib::util {
 

--- a/fbpcf/mpc_std_lib/util/test/util.h
+++ b/fbpcf/mpc_std_lib/util/test/util.h
@@ -14,7 +14,6 @@
 #include <stdexcept>
 
 #include "fbpcf/mpc_std_lib/util/util.h"
-#include "fbpcf/test/TestHelper.h"
 
 namespace fbpcf::mpc_std_lib::util {
 // the 3 returned valeus are: true value, first share, second share
@@ -52,6 +51,63 @@ getRandomData<AggregationValue>(std::mt19937_64& e) {
   valueShare1.conversionValue =
       value.conversionValue ^ valueShare0.conversionValue;
   return {value, valueShare0, valueShare1};
+}
+
+template <typename T>
+struct InputType {
+  std::vector<uint32_t> indicatorShares;
+  std::vector<std::vector<bool>> minuendShares;
+  std::vector<T> subtrahendShares;
+};
+
+template <typename T, int indicatorWidth>
+std::tuple<InputType<T>, InputType<T>, std::vector<T>> generateRandomInputs(
+    size_t batchSize) {
+  InputType<T> rst0{
+      .indicatorShares = std::vector<uint32_t>(batchSize),
+      .minuendShares = std::vector<std::vector<bool>>(),
+      .subtrahendShares = std::vector<T>(batchSize),
+  };
+  InputType<T> rst1{
+      .indicatorShares = std::vector<uint32_t>(batchSize),
+      .minuendShares = std::vector<std::vector<bool>>(),
+      .subtrahendShares = std::vector<T>(batchSize),
+  };
+  std::vector<T> expectedValue(batchSize);
+
+  std::random_device rd;
+  std::mt19937_64 e(rd());
+  std::uniform_int_distribution<uint32_t> randomIndicator(0, 0xFFFF);
+  std::uniform_int_distribution<int32_t> randomBit(0, 1);
+
+  for (size_t i = 0; i < batchSize; i++) {
+    auto [minuend, minuendShare0, minuendShare1] = util::getRandomData<T>(e);
+    auto subtrahend = std::get<0>(util::getRandomData<T>(e));
+    // indicator is 1 or -1;
+    int32_t indicator = static_cast<int32_t>(-1) + 2 * randomBit(e);
+    expectedValue[i] =
+        indicator == 1 ? (minuend - subtrahend) : (subtrahend - minuend);
+
+    rst0.indicatorShares[i] = randomIndicator(e);
+    rst1.indicatorShares[i] =
+        (rst0.indicatorShares.at(i) - indicator) % (1 << indicatorWidth);
+
+    rst0.subtrahendShares[i] = std::get<0>(util::getRandomData<T>(e));
+    rst1.subtrahendShares[i] = rst0.subtrahendShares.at(i) - subtrahend;
+
+    auto tmp0 = util::Adapters<T>::convertToBits(minuendShare0);
+    auto tmp1 = util::Adapters<T>::convertToBits(minuendShare1);
+    for (size_t j = 0; j < tmp0.size(); j++) {
+      if (j >= rst0.minuendShares.size()) {
+        rst0.minuendShares.push_back(std::vector<bool>(batchSize));
+        rst1.minuendShares.push_back(std::vector<bool>(batchSize));
+      }
+      rst0.minuendShares[j][i] = tmp0[j];
+      rst1.minuendShares[j][i] = tmp1[j];
+    }
+  }
+
+  return {rst0, rst1, expectedValue};
 }
 
 } // namespace fbpcf::mpc_std_lib::util

--- a/fbpcf/mpc_std_lib/util/test/util.h
+++ b/fbpcf/mpc_std_lib/util/test/util.h
@@ -175,4 +175,23 @@ generateObliviousDeltaCalculatorInputs(size_t batchSize) {
       {delta, t0, t1}};
 }
 
+inline std::tuple<std::vector<bool>, std::vector<bool>, uint32_t>
+generateSharedRandomBoolVectorForSinglePointArrayGenerator(size_t length) {
+  uint32_t width = std::ceil(std::log2(length));
+  std::random_device rd;
+  std::mt19937_64 e(rd());
+  std::uniform_int_distribution<uint32_t> dist(0, length - 1);
+  std::uniform_int_distribution<uint32_t> randomMask(
+      0, (uint64_t(1) << width) - 1);
+
+  auto value = dist(e);
+  auto mask0 = randomMask(e);
+  auto mask1 = mask0 ^ value;
+  auto rst0 = util::Adapters<uint32_t>::convertToBits(mask0);
+  auto rst1 = util::Adapters<uint32_t>::convertToBits(mask1);
+  rst0.erase(rst0.begin() + width, rst0.end());
+  rst1.erase(rst1.begin() + width, rst1.end());
+
+  return {rst0, rst1, value};
+}
 } // namespace fbpcf::mpc_std_lib::util


### PR DESCRIPTION
Summary: This diff sets up a base class for benchmarking WriteOnlyOram, which will be used in the next diff.

Reviewed By: chualynn

Differential Revision: D34969389

