### PR TITLE
Change composite tuple generator to use map instead of unordered_map

### DIFF
--- a/fbpcf/engine/tuple_generator/DummyTupleGenerator.h
+++ b/fbpcf/engine/tuple_generator/DummyTupleGenerator.h
@@ -26,9 +26,9 @@ class DummyTupleGenerator final : public ITupleGenerator {
   /**
    * @inherit doc
    */
-  std::unordered_map<size_t, std::vector<CompositeBooleanTuple>>
-  getCompositeTuple(std::unordered_map<size_t, uint32_t>& tupleSizes) override {
-    std::unordered_map<size_t, std::vector<CompositeBooleanTuple>> result;
+  std::map<size_t, std::vector<CompositeBooleanTuple>> getCompositeTuple(
+      std::map<size_t, uint32_t>& tupleSizes) override {
+    std::map<size_t, std::vector<CompositeBooleanTuple>> result;
     for (auto& countOfTuples : tupleSizes) {
       size_t tupleSize = countOfTuples.first;
       uint32_t tupleCount = countOfTuples.second;
@@ -50,10 +50,10 @@ class DummyTupleGenerator final : public ITupleGenerator {
    */
   std::pair<
       std::vector<BooleanTuple>,
-      std::unordered_map<size_t, std::vector<CompositeBooleanTuple>>>
+      std::map<size_t, std::vector<CompositeBooleanTuple>>>
   getNormalAndCompositeBooleanTuples(
       uint32_t tupleSizes,
-      std::unordered_map<size_t, uint32_t>& compositeTupleSizes) override {
+      std::map<size_t, uint32_t>& compositeTupleSizes) override {
     auto boolResult = getBooleanTuple(tupleSizes);
     auto compositeBoolResult = getCompositeTuple(compositeTupleSizes);
     return std::make_pair(

--- a/fbpcf/engine/tuple_generator/ITupleGenerator.h
+++ b/fbpcf/engine/tuple_generator/ITupleGenerator.h
@@ -8,8 +8,8 @@
 #pragma once
 
 #include <stdint.h>
+#include <map>
 #include <stdexcept>
-#include <unordered_map>
 #include <vector>
 
 namespace fbpcf::engine::tuple_generator {
@@ -107,8 +107,8 @@ class ITupleGenerator {
    * tuples to generate.
    * @return A map of tuple sizes to vector of those tuples
    */
-  virtual std::unordered_map<size_t, std::vector<CompositeBooleanTuple>>
-  getCompositeTuple(std::unordered_map<size_t, uint32_t>& tupleSizes) = 0;
+  virtual std::map<size_t, std::vector<CompositeBooleanTuple>>
+  getCompositeTuple(std::map<size_t, uint32_t>& tupleSizes) = 0;
 
   /**
    * Wrapper method for getBooleanTuple() and getCompositeTuple() which performs
@@ -116,10 +116,10 @@ class ITupleGenerator {
    */
   virtual std::pair<
       std::vector<BooleanTuple>,
-      std::unordered_map<size_t, std::vector<CompositeBooleanTuple>>>
+      std::map<size_t, std::vector<CompositeBooleanTuple>>>
   getNormalAndCompositeBooleanTuples(
       uint32_t tupleSize,
-      std::unordered_map<size_t, uint32_t>& compositeTupleSizes) = 0;
+      std::map<size_t, uint32_t>& compositeTupleSizes) = 0;
 
   /**
    * Get the total amount of traffic transmitted.

--- a/fbpcf/engine/tuple_generator/TupleGenerator.cpp
+++ b/fbpcf/engine/tuple_generator/TupleGenerator.cpp
@@ -56,20 +56,17 @@ std::vector<TupleGenerator::BooleanTuple> TupleGenerator::generateTuples(
   return booleanTuples;
 }
 
-std::unordered_map<size_t, std::vector<ITupleGenerator::CompositeBooleanTuple>>
-TupleGenerator::getCompositeTuple(
-    std::unordered_map<size_t, uint32_t>& tupleSizes) {
+std::map<size_t, std::vector<ITupleGenerator::CompositeBooleanTuple>>
+TupleGenerator::getCompositeTuple(std::map<size_t, uint32_t>& tupleSizes) {
   throw std::runtime_error("Not implemented");
 }
 
 std::pair<
     std::vector<ITupleGenerator::BooleanTuple>,
-    std::unordered_map<
-        size_t,
-        std::vector<ITupleGenerator::CompositeBooleanTuple>>>
+    std::map<size_t, std::vector<ITupleGenerator::CompositeBooleanTuple>>>
 TupleGenerator::getNormalAndCompositeBooleanTuples(
     uint32_t tupleSize,
-    std::unordered_map<size_t, uint32_t>& tupleSizes) {
+    std::map<size_t, uint32_t>& tupleSizes) {
   throw std::runtime_error("Not implemented");
 }
 

--- a/fbpcf/engine/tuple_generator/TupleGenerator.h
+++ b/fbpcf/engine/tuple_generator/TupleGenerator.h
@@ -42,18 +42,18 @@ class TupleGenerator final : public ITupleGenerator {
   /**
    * @inherit doc
    */
-  std::unordered_map<size_t, std::vector<CompositeBooleanTuple>>
-  getCompositeTuple(std::unordered_map<size_t, uint32_t>& tupleSizes) override;
+  std::map<size_t, std::vector<CompositeBooleanTuple>> getCompositeTuple(
+      std::map<size_t, uint32_t>& tupleSizes) override;
 
   /**
    * @inherit doc
    */
   std::pair<
       std::vector<BooleanTuple>,
-      std::unordered_map<size_t, std::vector<CompositeBooleanTuple>>>
+      std::map<size_t, std::vector<CompositeBooleanTuple>>>
   getNormalAndCompositeBooleanTuples(
       uint32_t tupleSize,
-      std::unordered_map<size_t, uint32_t>& compositeTupleSizes) override;
+      std::map<size_t, uint32_t>& compositeTupleSizes) override;
 
   std::pair<uint64_t, uint64_t> getTrafficStatistics() const override;
 

--- a/fbpcf/engine/tuple_generator/TwoPartyTupleGenerator.cpp
+++ b/fbpcf/engine/tuple_generator/TwoPartyTupleGenerator.cpp
@@ -107,20 +107,18 @@ TwoPartyTupleGenerator::generateTuples(uint64_t size) {
   return booleanTuples;
 }
 
-std::unordered_map<size_t, std::vector<ITupleGenerator::CompositeBooleanTuple>>
+std::map<size_t, std::vector<ITupleGenerator::CompositeBooleanTuple>>
 TwoPartyTupleGenerator::getCompositeTuple(
-    std::unordered_map<size_t, uint32_t>& tupleSizes) {
+    std::map<size_t, uint32_t>& tupleSizes) {
   throw std::runtime_error("Not implemented");
 }
 
 std::pair<
     std::vector<ITupleGenerator::BooleanTuple>,
-    std::unordered_map<
-        size_t,
-        std::vector<ITupleGenerator::CompositeBooleanTuple>>>
+    std::map<size_t, std::vector<ITupleGenerator::CompositeBooleanTuple>>>
 TwoPartyTupleGenerator::getNormalAndCompositeBooleanTuples(
     uint32_t tupleSize,
-    std::unordered_map<size_t, uint32_t>& tupleSizes) {
+    std::map<size_t, uint32_t>& tupleSizes) {
   throw std::runtime_error("Not implemented");
 }
 

--- a/fbpcf/engine/tuple_generator/TwoPartyTupleGenerator.h
+++ b/fbpcf/engine/tuple_generator/TwoPartyTupleGenerator.h
@@ -34,18 +34,18 @@ class TwoPartyTupleGenerator final : public ITupleGenerator {
   /**
    * @inherit doc
    */
-  std::unordered_map<size_t, std::vector<CompositeBooleanTuple>>
-  getCompositeTuple(std::unordered_map<size_t, uint32_t>& tupleSizes) override;
+  std::map<size_t, std::vector<CompositeBooleanTuple>> getCompositeTuple(
+      std::map<size_t, uint32_t>& tupleSizes) override;
 
   /**
    * @inherit doc
    */
   std::pair<
       std::vector<BooleanTuple>,
-      std::unordered_map<size_t, std::vector<CompositeBooleanTuple>>>
+      std::map<size_t, std::vector<CompositeBooleanTuple>>>
   getNormalAndCompositeBooleanTuples(
       uint32_t tupleSize,
-      std::unordered_map<size_t, uint32_t>& compositeTupleSizes) override;
+      std::map<size_t, uint32_t>& compositeTupleSizes) override;
 
   /**
    * @inherit doc


### PR DESCRIPTION
Summary:
Since `unordered_map` might have a different order of iteration depending on the platform, there is a potential for different parties to try to generate each tuple size in a different order. This will cause the tuples to not match up since the rcot results will be consumed out of order from the buffer.

I split this up from the next diff to make it easier to review.

Reviewed By: elliottlawrence

Differential Revision: D34980786

