### PR TITLE
Add method to AESPrg for generating bits in place

### DIFF
--- a/fbpcf/engine/tuple_generator/DummyTupleGenerator.h
+++ b/fbpcf/engine/tuple_generator/DummyTupleGenerator.h
@@ -26,9 +26,9 @@ class DummyTupleGenerator final : public ITupleGenerator {
   /**
    * @inherit doc
    */
-  std::unordered_map<size_t, std::vector<CompositeBooleanTuple>>
-  getCompositeTuple(std::unordered_map<size_t, uint32_t>& tupleSizes) override {
-    std::unordered_map<size_t, std::vector<CompositeBooleanTuple>> result;
+  std::map<size_t, std::vector<CompositeBooleanTuple>> getCompositeTuple(
+      std::map<size_t, uint32_t>& tupleSizes) override {
+    std::map<size_t, std::vector<CompositeBooleanTuple>> result;
     for (auto& countOfTuples : tupleSizes) {
       size_t tupleSize = countOfTuples.first;
       uint32_t tupleCount = countOfTuples.second;
@@ -50,10 +50,10 @@ class DummyTupleGenerator final : public ITupleGenerator {
    */
   std::pair<
       std::vector<BooleanTuple>,
-      std::unordered_map<size_t, std::vector<CompositeBooleanTuple>>>
+      std::map<size_t, std::vector<CompositeBooleanTuple>>>
   getNormalAndCompositeBooleanTuples(
       uint32_t tupleSizes,
-      std::unordered_map<size_t, uint32_t>& compositeTupleSizes) override {
+      std::map<size_t, uint32_t>& compositeTupleSizes) override {
     auto boolResult = getBooleanTuple(tupleSizes);
     auto compositeBoolResult = getCompositeTuple(compositeTupleSizes);
     return std::make_pair(

--- a/fbpcf/engine/tuple_generator/ITupleGenerator.h
+++ b/fbpcf/engine/tuple_generator/ITupleGenerator.h
@@ -8,8 +8,8 @@
 #pragma once
 
 #include <stdint.h>
+#include <map>
 #include <stdexcept>
-#include <unordered_map>
 #include <vector>
 
 namespace fbpcf::engine::tuple_generator {
@@ -107,8 +107,8 @@ class ITupleGenerator {
    * tuples to generate.
    * @return A map of tuple sizes to vector of those tuples
    */
-  virtual std::unordered_map<size_t, std::vector<CompositeBooleanTuple>>
-  getCompositeTuple(std::unordered_map<size_t, uint32_t>& tupleSizes) = 0;
+  virtual std::map<size_t, std::vector<CompositeBooleanTuple>>
+  getCompositeTuple(std::map<size_t, uint32_t>& tupleSizes) = 0;
 
   /**
    * Wrapper method for getBooleanTuple() and getCompositeTuple() which performs
@@ -116,10 +116,10 @@ class ITupleGenerator {
    */
   virtual std::pair<
       std::vector<BooleanTuple>,
-      std::unordered_map<size_t, std::vector<CompositeBooleanTuple>>>
+      std::map<size_t, std::vector<CompositeBooleanTuple>>>
   getNormalAndCompositeBooleanTuples(
       uint32_t tupleSize,
-      std::unordered_map<size_t, uint32_t>& compositeTupleSizes) = 0;
+      std::map<size_t, uint32_t>& compositeTupleSizes) = 0;
 
   /**
    * Get the total amount of traffic transmitted.

--- a/fbpcf/engine/tuple_generator/TupleGenerator.cpp
+++ b/fbpcf/engine/tuple_generator/TupleGenerator.cpp
@@ -56,20 +56,17 @@ std::vector<TupleGenerator::BooleanTuple> TupleGenerator::generateTuples(
   return booleanTuples;
 }
 
-std::unordered_map<size_t, std::vector<ITupleGenerator::CompositeBooleanTuple>>
-TupleGenerator::getCompositeTuple(
-    std::unordered_map<size_t, uint32_t>& tupleSizes) {
+std::map<size_t, std::vector<ITupleGenerator::CompositeBooleanTuple>>
+TupleGenerator::getCompositeTuple(std::map<size_t, uint32_t>& tupleSizes) {
   throw std::runtime_error("Not implemented");
 }
 
 std::pair<
     std::vector<ITupleGenerator::BooleanTuple>,
-    std::unordered_map<
-        size_t,
-        std::vector<ITupleGenerator::CompositeBooleanTuple>>>
+    std::map<size_t, std::vector<ITupleGenerator::CompositeBooleanTuple>>>
 TupleGenerator::getNormalAndCompositeBooleanTuples(
     uint32_t tupleSize,
-    std::unordered_map<size_t, uint32_t>& tupleSizes) {
+    std::map<size_t, uint32_t>& tupleSizes) {
   throw std::runtime_error("Not implemented");
 }
 

--- a/fbpcf/engine/tuple_generator/TupleGenerator.h
+++ b/fbpcf/engine/tuple_generator/TupleGenerator.h
@@ -42,18 +42,18 @@ class TupleGenerator final : public ITupleGenerator {
   /**
    * @inherit doc
    */
-  std::unordered_map<size_t, std::vector<CompositeBooleanTuple>>
-  getCompositeTuple(std::unordered_map<size_t, uint32_t>& tupleSizes) override;
+  std::map<size_t, std::vector<CompositeBooleanTuple>> getCompositeTuple(
+      std::map<size_t, uint32_t>& tupleSizes) override;
 
   /**
    * @inherit doc
    */
   std::pair<
       std::vector<BooleanTuple>,
-      std::unordered_map<size_t, std::vector<CompositeBooleanTuple>>>
+      std::map<size_t, std::vector<CompositeBooleanTuple>>>
   getNormalAndCompositeBooleanTuples(
       uint32_t tupleSize,
-      std::unordered_map<size_t, uint32_t>& compositeTupleSizes) override;
+      std::map<size_t, uint32_t>& compositeTupleSizes) override;
 
   std::pair<uint64_t, uint64_t> getTrafficStatistics() const override;
 

--- a/fbpcf/engine/tuple_generator/TwoPartyTupleGenerator.cpp
+++ b/fbpcf/engine/tuple_generator/TwoPartyTupleGenerator.cpp
@@ -107,20 +107,18 @@ TwoPartyTupleGenerator::generateTuples(uint64_t size) {
   return booleanTuples;
 }
 
-std::unordered_map<size_t, std::vector<ITupleGenerator::CompositeBooleanTuple>>
+std::map<size_t, std::vector<ITupleGenerator::CompositeBooleanTuple>>
 TwoPartyTupleGenerator::getCompositeTuple(
-    std::unordered_map<size_t, uint32_t>& tupleSizes) {
+    std::map<size_t, uint32_t>& tupleSizes) {
   throw std::runtime_error("Not implemented");
 }
 
 std::pair<
     std::vector<ITupleGenerator::BooleanTuple>,
-    std::unordered_map<
-        size_t,
-        std::vector<ITupleGenerator::CompositeBooleanTuple>>>
+    std::map<size_t, std::vector<ITupleGenerator::CompositeBooleanTuple>>>
 TwoPartyTupleGenerator::getNormalAndCompositeBooleanTuples(
     uint32_t tupleSize,
-    std::unordered_map<size_t, uint32_t>& tupleSizes) {
+    std::map<size_t, uint32_t>& tupleSizes) {
   throw std::runtime_error("Not implemented");
 }
 

--- a/fbpcf/engine/tuple_generator/TwoPartyTupleGenerator.h
+++ b/fbpcf/engine/tuple_generator/TwoPartyTupleGenerator.h
@@ -34,18 +34,18 @@ class TwoPartyTupleGenerator final : public ITupleGenerator {
   /**
    * @inherit doc
    */
-  std::unordered_map<size_t, std::vector<CompositeBooleanTuple>>
-  getCompositeTuple(std::unordered_map<size_t, uint32_t>& tupleSizes) override;
+  std::map<size_t, std::vector<CompositeBooleanTuple>> getCompositeTuple(
+      std::map<size_t, uint32_t>& tupleSizes) override;
 
   /**
    * @inherit doc
    */
   std::pair<
       std::vector<BooleanTuple>,
-      std::unordered_map<size_t, std::vector<CompositeBooleanTuple>>>
+      std::map<size_t, std::vector<CompositeBooleanTuple>>>
   getNormalAndCompositeBooleanTuples(
       uint32_t tupleSize,
-      std::unordered_map<size_t, uint32_t>& compositeTupleSizes) override;
+      std::map<size_t, uint32_t>& compositeTupleSizes) override;
 
   /**
    * @inherit doc

--- a/fbpcf/engine/util/AesPrg.cpp
+++ b/fbpcf/engine/util/AesPrg.cpp
@@ -11,10 +11,6 @@
 
 namespace fbpcf::engine::util {
 
-inline uint64_t ceilDiv(uint64_t a, uint64_t b) {
-  return a / b + (a % b != 0);
-}
-
 AesPrg::AesPrg(__m128i seed, int bufferSize)
     : cipher_(seed),
       prgCounter_(0),

--- a/fbpcf/engine/util/test/prgTest.cpp
+++ b/fbpcf/engine/util/test/prgTest.cpp
@@ -10,6 +10,7 @@
 #include <random>
 #include <stdexcept>
 #include "fbpcf/engine/util/AesPrg.h"
+#include "fbpcf/engine/util/util.h"
 
 namespace fbpcf::engine::util {
 
@@ -39,6 +40,40 @@ TEST(AesPrgTest, testGetRandomBits) {
 
     EXPECT_EQ(bitVal, randomBytes.at(byte));
   }
+}
+
+TEST(AesPrgTest, testInPlaceGeneration) {
+  __m128i aes_key = _mm_set_epi32(1, 2, 3, 4);
+  AesPrg prg1(aes_key);
+  std::vector<bool> randomBits(192);
+  std::vector<__m128i> randomData(2);
+  prg1.getRandomBitsInPlace(randomBits);
+  prg1.getRandomDataInPlace(randomData);
+
+  Aes cipher(aes_key);
+  std::vector<__m128i> vals{
+      _mm_set_epi64x(0, 0),
+      _mm_set_epi64x(0, 1),
+      _mm_set_epi64x(0, 2),
+      _mm_set_epi64x(0, 3)};
+  cipher.encryptInPlace(vals);
+
+  std::vector<bool> first(128);
+  std::vector<bool> second(64);
+  util::extractLnbToVector(vals[0], first);
+  util::extractLnbToVector(vals[1], second);
+  for (int i = 0; i < 128; i++) {
+    EXPECT_EQ(randomBits[i], first[i]);
+  }
+
+  for (int i = 0; i < 64; i++) {
+    EXPECT_EQ(randomBits[i + 128], second[i]);
+  }
+
+  EXPECT_EQ(_mm_extract_epi64(randomData[0], 0), _mm_extract_epi64(vals[2], 0));
+  EXPECT_EQ(_mm_extract_epi64(randomData[0], 1), _mm_extract_epi64(vals[2], 1));
+  EXPECT_EQ(_mm_extract_epi64(randomData[1], 0), _mm_extract_epi64(vals[3], 0));
+  EXPECT_EQ(_mm_extract_epi64(randomData[1], 1), _mm_extract_epi64(vals[3], 1));
 }
 
 TEST(AesPrgTest, testThrow) {

--- a/fbpcf/engine/util/test/utilTest.cpp
+++ b/fbpcf/engine/util/test/utilTest.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "fbpcf/engine/util/util.h"
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <smmintrin.h>
+
+namespace fbpcf::engine::util {
+
+TEST(UtilTest, testGetLsb) {
+  for (size_t i = 0; i < 1024; i++) {
+    __m128i val = getRandomM128iFromSystemNoise();
+    EXPECT_EQ(util::getLsb(val), _mm_extract_epi64(val, 0) % 2 != 0);
+  }
+}
+
+TEST(UtilTest, testExtractLnbToVector) {
+  for (size_t i = 0; i < 20; i++) {
+    __m128i val = getRandomM128iFromSystemNoise();
+    for (size_t j = 0; j < 128; j++) {
+      std::vector<bool> bits(j);
+      util::extractLnbToVector(val, bits);
+
+      uint64_t lower64 = _mm_extract_epi64(val, 0);
+      uint64_t upper64 = _mm_extract_epi64(val, 1);
+
+      for (size_t k = 0; k < j; k++) {
+        if (k < 64) {
+          EXPECT_EQ(bits[k], (lower64 >> k) & 1);
+        } else {
+          EXPECT_EQ(bits[k], (upper64 >> (k - 64) & 1));
+        }
+      }
+    }
+  }
+}
+
+TEST(UtilTest, setLsb) {
+  for (size_t i = 0; i < 1024; i++) {
+    __m128i val = getRandomM128iFromSystemNoise();
+    util::setLsbTo0(val);
+    EXPECT_EQ(util::getLsb(val), false);
+    util::setLsbTo1(val);
+    EXPECT_EQ(util::getLsb(val), true);
+  }
+}
+} // namespace fbpcf::engine::util

--- a/fbpcf/engine/util/util.h
+++ b/fbpcf/engine/util/util.h
@@ -29,6 +29,29 @@ inline bool getLsb(__m128i src) {
   return _mm_extract_epi8(src, 0) & 1;
 }
 
+/*
+ * Extracts the last n bits in a 128 bit integer to the passed in boolean
+ * vector. The order of bits will be from least significant to most significant.
+ */
+inline void extractLnbToVector(__m128i& src, std::vector<bool>& data) {
+  if (data.size() > sizeof(src) * 8) {
+    throw std::runtime_error("Vector size is larger than __m128i size");
+  }
+  uint64_t lower64 = _mm_extract_epi64(src, 0);
+  uint64_t upper64 = _mm_extract_epi64(src, 1);
+
+  size_t lowerBitsToCopy = std::min(sizeof(lower64) * 8, data.size());
+  size_t upperBitsToCopy = data.size() - lowerBitsToCopy;
+  for (size_t i = 0; i < lowerBitsToCopy; i++) {
+    data[i] = lower64 & 1;
+    lower64 = lower64 >> 1;
+  }
+  for (size_t i = 0; i < upperBitsToCopy; i++) {
+    data[i + sizeof(lower64) * 8] = upper64 & 1;
+    upper64 = upper64 >> 1;
+  }
+}
+
 inline void setLsbTo0(__m128i& src) {
   src = _mm_andnot_si128(_mm_set_epi64x(0, 1), src);
 }


### PR DESCRIPTION
Summary: In the next diff for composite tuples with size > 128 there is a need to construct a new AESPrg from each rcotMessage (3 per tuple). The AES PRG class was modified to be able to generate bits in place without needing a buffer. Because the buffer will invoke another future on destruction it would be a waste to create a new one with each AESPrg we need.

Differential Revision: D35063562

