### PR TITLE
Move scheduler benchmarks to one file

### DIFF
--- a/fbpcf/scheduler/test/benchmarks/AllocatorBenchmark.h
+++ b/fbpcf/scheduler/test/benchmarks/AllocatorBenchmark.h
@@ -53,31 +53,4 @@ inline void benchmarkGet(std::unique_ptr<IAllocator<T>> allocator, int n) {
   }
 }
 
-BENCHMARK(VectorArenaAllocator_allocate, n) {
-  benchmarkAllocate<int64_t>(
-      std::make_unique<VectorArenaAllocator<int64_t, unsafe>>(), n);
-}
-
-BENCHMARK(VectorArenaAllocator_free, n) {
-  benchmarkFree<int64_t>(
-      std::make_unique<VectorArenaAllocator<int64_t, unsafe>>(), n);
-}
-
-BENCHMARK(VectorArenaAllocator_get, n) {
-  benchmarkGet<int64_t>(
-      std::make_unique<VectorArenaAllocator<int64_t, unsafe>>(), n);
-}
-
-BENCHMARK(UnorderedMapAllocator_allocate, n) {
-  benchmarkAllocate<int64_t>(
-      std::make_unique<UnorderedMapAllocator<int64_t>>(), n);
-}
-
-BENCHMARK(UnorderedMapAllocator_free, n) {
-  benchmarkFree<int64_t>(std::make_unique<UnorderedMapAllocator<int64_t>>(), n);
-}
-
-BENCHMARK(UnorderedMapAllocator_get, n) {
-  benchmarkGet<int64_t>(std::make_unique<UnorderedMapAllocator<int64_t>>(), n);
-}
 } // namespace fbpcf::scheduler

--- a/fbpcf/scheduler/test/benchmarks/SchedulerBenchmark.cpp
+++ b/fbpcf/scheduler/test/benchmarks/SchedulerBenchmark.cpp
@@ -12,6 +12,83 @@
 #include "fbpcf/scheduler/test/benchmarks/AllocatorBenchmark.h"
 #include "fbpcf/scheduler/test/benchmarks/WireKeeperBenchmark.h"
 
+namespace fbpcf::scheduler {
+
+// IAllocator benchmarks
+
+BENCHMARK(VectorArenaAllocator_allocate, n) {
+  benchmarkAllocate<int64_t>(
+      std::make_unique<VectorArenaAllocator<int64_t, unsafe>>(), n);
+}
+
+BENCHMARK(VectorArenaAllocator_free, n) {
+  benchmarkFree<int64_t>(
+      std::make_unique<VectorArenaAllocator<int64_t, unsafe>>(), n);
+}
+
+BENCHMARK(VectorArenaAllocator_get, n) {
+  benchmarkGet<int64_t>(
+      std::make_unique<VectorArenaAllocator<int64_t, unsafe>>(), n);
+}
+
+BENCHMARK(UnorderedMapAllocator_allocate, n) {
+  benchmarkAllocate<int64_t>(
+      std::make_unique<UnorderedMapAllocator<int64_t>>(), n);
+}
+
+BENCHMARK(UnorderedMapAllocator_free, n) {
+  benchmarkFree<int64_t>(std::make_unique<UnorderedMapAllocator<int64_t>>(), n);
+}
+
+BENCHMARK(UnorderedMapAllocator_get, n) {
+  benchmarkGet<int64_t>(std::make_unique<UnorderedMapAllocator<int64_t>>(), n);
+}
+
+// WireKeeper benchmarks
+
+BENCHMARK(WireKeeperBenchmark_allocateBooleanValue, n) {
+  BENCHMARK_WIREKEEPER {
+    wireKeeper->allocateBooleanValue();
+  }
+}
+
+BENCHMARK(WireKeeperBenchmark_getBooleanValue, n) {
+  BENCHMARK_WIREKEEPER {
+    wireKeeper->getBooleanValue(wireIds.at(n));
+  }
+}
+
+BENCHMARK(WireKeeperBenchmark_setBooleanValue, n) {
+  BENCHMARK_WIREKEEPER {
+    wireKeeper->setBooleanValue(wireIds.at(n), n & 1);
+  }
+}
+
+BENCHMARK(WireKeeperBenchmark_getFirstAvailableLevel, n) {
+  BENCHMARK_WIREKEEPER {
+    wireKeeper->getFirstAvailableLevel(wireIds.at(n));
+  }
+}
+
+BENCHMARK(WireKeeperBenchmark_setFirstAvailableLevel, n) {
+  BENCHMARK_WIREKEEPER {
+    wireKeeper->setFirstAvailableLevel(wireIds.at(n), n);
+  }
+}
+
+BENCHMARK(WireKeeperBenchmark_increaseReferenceCount, n) {
+  BENCHMARK_WIREKEEPER {
+    wireKeeper->increaseReferenceCount(wireIds.at(n));
+  }
+}
+
+BENCHMARK(WireKeeperBenchmark_decreaseReferenceCount, n) {
+  BENCHMARK_WIREKEEPER {
+    wireKeeper->decreaseReferenceCount(wireIds.at(n));
+  }
+}
+} // namespace fbpcf::scheduler
+
 int main(int argc, char* argv[]) {
   facebook::initFacebook(&argc, &argv);
   folly::runBenchmarks();

--- a/fbpcf/scheduler/test/benchmarks/WireKeeperBenchmark.h
+++ b/fbpcf/scheduler/test/benchmarks/WireKeeperBenchmark.h
@@ -25,49 +25,4 @@ namespace fbpcf::scheduler {
   braces.dismiss();                                              \
   while (n--)
 
-BENCHMARK(WireKeeperBenchmark_allocateBooleanValue, n) {
-  folly::BenchmarkSuspender braces;
-  auto wireKeeper = WireKeeper::createWithVectorArena<unsafe>();
-  braces.dismiss();
-
-  while (n--) {
-    wireKeeper->allocateBooleanValue();
-  }
-}
-
-BENCHMARK(WireKeeperBenchmark_getBooleanValue, n) {
-  BENCHMARK_WIREKEEPER {
-    wireKeeper->getBooleanValue(wireIds.at(n));
-  }
-}
-
-BENCHMARK(WireKeeperBenchmark_setBooleanValue, n) {
-  BENCHMARK_WIREKEEPER {
-    wireKeeper->setBooleanValue(wireIds.at(n), n & 1);
-  }
-}
-
-BENCHMARK(WireKeeperBenchmark_getFirstAvailableLevel, n) {
-  BENCHMARK_WIREKEEPER {
-    wireKeeper->getFirstAvailableLevel(wireIds.at(n));
-  }
-}
-
-BENCHMARK(WireKeeperBenchmark_setFirstAvailableLevel, n) {
-  BENCHMARK_WIREKEEPER {
-    wireKeeper->setFirstAvailableLevel(wireIds.at(n), n);
-  }
-}
-
-BENCHMARK(WireKeeperBenchmark_increaseReferenceCount, n) {
-  BENCHMARK_WIREKEEPER {
-    wireKeeper->increaseReferenceCount(wireIds.at(n));
-  }
-}
-
-BENCHMARK(WireKeeperBenchmark_decreaseReferenceCount, n) {
-  BENCHMARK_WIREKEEPER {
-    wireKeeper->decreaseReferenceCount(wireIds.at(n));
-  }
-}
 } // namespace fbpcf::scheduler


### PR DESCRIPTION
Summary:
I'm seeing some errors about "no metric data" from the scheduler benchmark: https://www.internalfb.com/intern/servicelab/trial/603915226/

It turns out all the benchmark macros need to be in one file for this to work.

Differential Revision: D35086855

