### PR TITLE
Improve BufferedWriterTest to use parametrized tests and do the same random logic from D35053135

### DIFF
--- a/fbpcf/io/api/BufferedReader.cpp
+++ b/fbpcf/io/api/BufferedReader.cpp
@@ -80,11 +80,10 @@ std::string BufferedReader::readLine() {
     loadNextChunk();
   }
 
-  auto c = buffer_.at(currentPosition_);
+  auto c = buffer_.at(currentPosition_++);
   std::string output = "";
   while (c != '\n') {
     output += c;
-    currentPosition_++;
 
     if (currentPosition_ == lastPosition_) {
       // we've run out of data, try to get the next chunk
@@ -96,9 +95,17 @@ std::string BufferedReader::readLine() {
       loadNextChunk();
     }
 
-    c = buffer_.at(currentPosition_);
+    c = buffer_.at(currentPosition_++);
   }
-  currentPosition_++;
+
+  if (currentPosition_ == lastPosition_ && !eof()) {
+    // if we are at the end of the buffer and there is more data
+    // to be loaded, we should load the next chunk.
+    // otherwise we risk the next invocation of readLine()
+    // to not return any data (in case the most recent \n was the
+    // final character of the file)
+    loadNextChunk();
+  }
 
   return output;
 }

--- a/fbpcf/io/api/test/BufferedReaderTest.cpp
+++ b/fbpcf/io/api/test/BufferedReaderTest.cpp
@@ -14,12 +14,48 @@
 
 namespace fbpcf::io {
 
-TEST(BufferedReaderTest, testBufferedReaderWithBothReadAndReadLine) {
+inline void runBufferedReaderTestForReadLineOnly(size_t chunkSize) {
+  // this more accurately resembles a production style usage
   auto fileReader = fbpcf::io::FileReader(
       IOTestHelper::getBaseDirFromPath(__FILE__) +
       "data/buffered_reader_test_file.txt");
   auto bufferedReader =
-      std::make_unique<fbpcf::io::BufferedReader>(fileReader, 40);
+      std::make_unique<fbpcf::io::BufferedReader>(fileReader, chunkSize);
+
+  auto expectedLines = std::vector<std::string>{
+      "this is a simple first line",
+      "this is a second line that is intended to be longer than a line that can fit in a single buffer",
+      "this is a third line that should take at least three iterations of the buffer so that we can properly check the iterative functionality",
+      "",
+      "we also test a blank line and",
+      "a line that will include a newline",
+      "",
+      "finally, we want to test a really long block of",
+      "text, that will take 3 or 4 chunks, but this time",
+      "using the read API instead of the readLine API to",
+      "make sure that we have adequate test coverage. the",
+      "total size of this paragraph is 242 bytes."};
+
+  auto i = 0;
+  while (!bufferedReader->eof()) {
+    auto line = bufferedReader->readLine();
+    EXPECT_EQ(line, expectedLines.at(i)) << "Strings don't match at row " << i;
+    i++;
+
+    if (i == expectedLines.size()) {
+      EXPECT_TRUE(bufferedReader->eof()) << "Failed to assert eof at row " << i;
+    } else {
+      EXPECT_FALSE(bufferedReader->eof()) << "Unexpected eof at row " << i;
+    }
+  }
+}
+
+inline void runBufferedReaderTestForReadAndReadLine(size_t chunkSize) {
+  auto fileReader = fbpcf::io::FileReader(
+      IOTestHelper::getBaseDirFromPath(__FILE__) +
+      "data/buffered_reader_test_file.txt");
+  auto bufferedReader =
+      std::make_unique<fbpcf::io::BufferedReader>(fileReader, chunkSize);
 
   auto firstLine = bufferedReader->readLine();
 
@@ -68,40 +104,35 @@ TEST(BufferedReaderTest, testBufferedReaderWithBothReadAndReadLine) {
   bufferedReader->close();
 }
 
-TEST(BufferedReaderTest, testBufferedReaderWithReadLineOnly) {
-  // this more accurately resembles a production style usage
-  auto fileReader = fbpcf::io::FileReader(
-      IOTestHelper::getBaseDirFromPath(__FILE__) +
-      "data/buffered_reader_test_file.txt");
-  auto bufferedReader =
-      std::make_unique<fbpcf::io::BufferedReader>(fileReader, 40);
+class BufferedReaderTest
+    : public ::testing::TestWithParam<size_t> { // the only parameter is the
+                                                // chunk size
+ protected:
+  void SetUp() override {}
 
-  auto expectedLines = std::vector<std::string>{
-      "this is a simple first line",
-      "this is a second line that is intended to be longer than a line that can fit in a single buffer",
-      "this is a third line that should take at least three iterations of the buffer so that we can properly check the iterative functionality",
-      "",
-      "we also test a blank line and",
-      "a line that will include a newline",
-      "",
-      "finally, we want to test a really long block of",
-      "text, that will take 3 or 4 chunks, but this time",
-      "using the read API instead of the readLine API to",
-      "make sure that we have adequate test coverage. the",
-      "total size of this paragraph is 242 bytes."};
+  void TearDown() override {}
+};
 
-  auto i = 0;
-  while (!bufferedReader->eof()) {
-    auto line = bufferedReader->readLine();
-    EXPECT_EQ(line, expectedLines.at(i));
-    i++;
+TEST_P(BufferedReaderTest, testBufferedReaderWithReadLineOnly) {
+  auto chunkSize = GetParam();
 
-    if (i == expectedLines.size()) {
-      EXPECT_TRUE(bufferedReader->eof());
-    } else {
-      EXPECT_FALSE(bufferedReader->eof());
-    }
-  }
+  runBufferedReaderTestForReadLineOnly(chunkSize);
 }
+
+TEST_P(BufferedReaderTest, testBufferedReaderWithReadAndReadLine) {
+  auto chunkSize = GetParam();
+
+  runBufferedReaderTestForReadAndReadLine(chunkSize);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    BufferedReaderTest,
+    BufferedReaderTest,
+    ::testing::Values(1, 10, 40, 100, 200, 500, 1000, 4096),
+    [](const testing::TestParamInfo<BufferedReaderTest::ParamType>& info) {
+      auto chunkSize = std::to_string(info.param);
+      std::string name = "Chunk_size_" + chunkSize;
+      return name;
+    });
 
 } // namespace fbpcf::io


### PR DESCRIPTION
Summary:
See diff summary of previous diff, this does the same thing where we iterate over many chunk sizes

Plus, see D35053135 (https://github.com/facebookresearch/fbpcf/commit/3eb24841d2e15dd4d6325e7b48accea958d5034e) where we fixed flaky tests. we do the same here

Reviewed By: elliottlawrence

Differential Revision: D35058622

