### PR TITLE
Add login step to publish job

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -335,6 +335,13 @@ jobs:
       packages: write
 
     steps:
+    - name: Log into registry ${{ env.REGISTRY }}
+      uses: docker/login-action@v1
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Add tag to commit
       id: tag_version
       uses: mathieudutour/github-tag-action@v6.0


### PR DESCRIPTION
Summary: Because we split the workflow into multiple jobs, we need to re-log in for each job

Reviewed By: wuman

Differential Revision: D35132962

