### PR TITLE
Use size_t in NpBaseObliviousTransfer

### DIFF
--- a/fbpcf/engine/tuple_generator/oblivious_transfer/NpBaseObliviousTransfer.cpp
+++ b/fbpcf/engine/tuple_generator/oblivious_transfer/NpBaseObliviousTransfer.cpp
@@ -44,12 +44,11 @@ void NpBaseObliviousTransfer::sendPoint(const EC_POINT& point) const {
           group_.get(), &point, POINT_CONVERSION_COMPRESSED, ctx.get()),
       free);
 
-  uint16_t size;
-  size = strlen(buf.get());
+  size_t size = strlen(buf.get());
   if (size == 0) {
     throw std::runtime_error("Can't convert point to hex.");
   }
-  agent_->sendSingleT<uint16_t>(size);
+  agent_->sendSingleT<size_t>(size);
   std::vector<unsigned char> tmp(buf.get(), buf.get() + size);
   agent_->send(tmp);
 }
@@ -58,7 +57,7 @@ NpBaseObliviousTransfer::PointPointer NpBaseObliviousTransfer::receivePoint()
     const {
   PointPointer rst(EC_POINT_new(group_.get()), EC_POINT_free);
 
-  uint16_t size = agent_->receiveSingleT<uint16_t>();
+  size_t size = agent_->receiveSingleT<size_t>();
   auto tmp = agent_->receive(size);
   // Create a CTX variable. CTX variables are used as temporary variable for
   // many Openssl functions.


### PR DESCRIPTION
Summary:
We're seeing some random failures in the oblivious transfer benchmark.
https://www.internalfb.com/intern/servicelab/everstore_log/?handle=GD64rAjRdkkAm9gBANTW64QvwFdHbqMrAABn
  what():  Cant convert hex to point: 268857446: error:10067066:elliptic curve routines:ec_GFp_simple_oct2point:invalid encoding

I'm not entirely sure why, but I suspect there's an issue with sending/receiving data. I wonder if the size is overflowing, so perhaps using `size_t` instead will fix it. (I'm not able to repro this consistently, it only fails in ServiceLab sometimes.)

Reviewed By: RuiyuZhu

Differential Revision: D35118099

