### PR TITLE
Change the behavior of BitString (#758)

### DIFF
--- a/fbpcf/frontend/BitString.h
+++ b/fbpcf/frontend/BitString.h
@@ -132,6 +132,9 @@ class BitString : public scheduler::SchedulerKeeper<schedulerId> {
   std::vector<Bit<isSecret, schedulerId, usingBatch>> data_;
 
   friend class BitString<!isSecret, schedulerId, usingBatch>;
+
+  static std::vector<std::vector<bool>> transposeVector(
+      const std::vector<std::vector<bool>>& src);
 };
 
 } // namespace fbpcf::frontend

--- a/fbpcf/frontend/test/BitStringTest.cpp
+++ b/fbpcf/frontend/test/BitStringTest.cpp
@@ -295,7 +295,7 @@ TEST(StringTest, testMux) {
   }
   std::vector<std::vector<bool>> testBatchValue1(
       dSize(e), std::vector<bool>(dSize(e)));
-  std::vector<bool> testBatchChoice(testBatchValue1.at(0).size());
+  std::vector<bool> testBatchChoice(testBatchValue1.size());
   auto testBatchValue2 = testBatchValue1;
   for (size_t i = 0; i < testBatchValue1.size(); i++) {
     for (size_t j = 0; j < testBatchValue1.at(0).size(); j++) {
@@ -303,7 +303,7 @@ TEST(StringTest, testMux) {
       testBatchValue2[i][j] = dBool(e);
     }
   }
-  for (size_t j = 0; j < testBatchValue1.at(0).size(); j++) {
+  for (size_t j = 0; j < testBatchValue1.size(); j++) {
     testBatchChoice[j] = dBool(e);
   }
 
@@ -346,7 +346,7 @@ TEST(StringTest, testMux) {
   for (size_t i = 0; i < testBatchValue1.size(); i++) {
     for (size_t j = 0; j < testBatchValue1.at(0).size(); j++) {
       testBatchValue1[i][j] =
-          testBatchChoice[j] ? testBatchValue2[i][j] : testBatchValue1[i][j];
+          testBatchChoice[i] ? testBatchValue2[i][j] : testBatchValue1[i][j];
     }
   }
 
@@ -397,14 +397,12 @@ TEST(StringTest, testResizeWithAND) {
   std::vector<std::vector<bool>> testBatchValue1(
       dSize(e), std::vector<bool>(dSize(e)));
   auto testBatchValue2 = testBatchValue1;
-  testBatchValue2.resize(testBatchValue1.size() * 2);
   for (size_t i = 0; i < testBatchValue1.size(); i++) {
-    testBatchValue2[i + testBatchValue1.size()] =
-        std::vector<bool>(testBatchValue1.at(0).size());
+    testBatchValue2[i].resize(testBatchValue1.at(0).size() * 2);
     for (size_t j = 0; j < testBatchValue1.at(0).size(); j++) {
       testBatchValue1[i][j] = dBool(e);
       testBatchValue2[i][j] = dBool(e);
-      testBatchValue2[i + testBatchValue1.size()][j] = dBool(e);
+      testBatchValue2[i][j + testBatchValue1.at(0).size()] = dBool(e);
     }
   }
 
@@ -476,21 +474,21 @@ TEST(StringTest, testRebatching) {
   uint32_t batchSize2 = dSize(e);
   uint32_t batchSize3 = dSize(e);
   std::vector<std::vector<bool>> testBatchValue1(
-      length, std::vector<bool>(batchSize1));
+      batchSize1, std::vector<bool>(length));
   std::vector<std::vector<bool>> testBatchValue2(
-      length, std::vector<bool>(batchSize2));
+      batchSize2, std::vector<bool>(length));
   std::vector<std::vector<bool>> testBatchValue3(
-      length, std::vector<bool>(batchSize3));
+      batchSize3, std::vector<bool>(length));
 
   for (size_t i = 0; i < length; i++) {
     for (size_t j = 0; j < batchSize1; j++) {
-      testBatchValue1[i][j] = dBool(e);
+      testBatchValue1[j][i] = dBool(e);
     }
     for (size_t j = 0; j < batchSize2; j++) {
-      testBatchValue2[i][j] = dBool(e);
+      testBatchValue2[j][i] = dBool(e);
     }
     for (size_t j = 0; j < batchSize3; j++) {
-      testBatchValue3[i][j] = dBool(e);
+      testBatchValue3[j][i] = dBool(e);
     }
   }
 
@@ -507,18 +505,20 @@ TEST(StringTest, testRebatching) {
   auto t6 = v123.at(1).openToParty(0).getValue();
   auto t7 = v123.at(2).openToParty(0).getValue();
 
-  for (size_t i = 0; i < length; i++) {
+  for (size_t i = 0; i < batchSize1; i++) {
     testVectorEq(t5.at(i), testBatchValue1.at(i));
+  }
+  for (size_t i = 0; i < batchSize2; i++) {
     testVectorEq(t6.at(i), testBatchValue2.at(i));
+  }
+  for (size_t i = 0; i < batchSize3; i++) {
     testVectorEq(t7.at(i), testBatchValue3.at(i));
-    testBatchValue1[i].insert(
-        testBatchValue1[i].end(),
-        testBatchValue2[i].begin(),
-        testBatchValue2[i].end());
-    testBatchValue1[i].insert(
-        testBatchValue1[i].end(),
-        testBatchValue3[i].begin(),
-        testBatchValue3[i].end());
+  }
+  testBatchValue1.insert(
+      testBatchValue1.end(), testBatchValue2.begin(), testBatchValue2.end());
+  testBatchValue1.insert(
+      testBatchValue1.end(), testBatchValue3.begin(), testBatchValue3.end());
+  for (size_t i = 0; i < batchSize1 + batchSize2 + batchSize3; i++) {
     testVectorEq(t4.at(i), testBatchValue1.at(i));
   }
 }


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/fbpcs/pull/758

As title.
Current BitString type have some inconsistent behavior.

For example, when initialized by a batch of `std::vector<bool>`, it is expecting {the vector of first bits in all vecs, the vector of second bits in all vecs...} instead of "the first vector, the second vector". This doesn't agree with other batched types.

This diff changes this behavior to align with other batch types.

Reviewed By: elliottlawrence

Differential Revision: D35122217

