### PR TITLE
Change to use BitString in shuffler/permuter tests

### DIFF
--- a/fbpcf/frontend/BitString.h
+++ b/fbpcf/frontend/BitString.h
@@ -132,6 +132,9 @@ class BitString : public scheduler::SchedulerKeeper<schedulerId> {
   std::vector<Bit<isSecret, schedulerId, usingBatch>> data_;
 
   friend class BitString<!isSecret, schedulerId, usingBatch>;
+
+  static std::vector<std::vector<bool>> transposeVector(
+      const std::vector<std::vector<bool>>& src);
 };
 
 } // namespace fbpcf::frontend

--- a/fbpcf/frontend/test/BitStringTest.cpp
+++ b/fbpcf/frontend/test/BitStringTest.cpp
@@ -295,7 +295,7 @@ TEST(StringTest, testMux) {
   }
   std::vector<std::vector<bool>> testBatchValue1(
       dSize(e), std::vector<bool>(dSize(e)));
-  std::vector<bool> testBatchChoice(testBatchValue1.at(0).size());
+  std::vector<bool> testBatchChoice(testBatchValue1.size());
   auto testBatchValue2 = testBatchValue1;
   for (size_t i = 0; i < testBatchValue1.size(); i++) {
     for (size_t j = 0; j < testBatchValue1.at(0).size(); j++) {
@@ -303,7 +303,7 @@ TEST(StringTest, testMux) {
       testBatchValue2[i][j] = dBool(e);
     }
   }
-  for (size_t j = 0; j < testBatchValue1.at(0).size(); j++) {
+  for (size_t j = 0; j < testBatchValue1.size(); j++) {
     testBatchChoice[j] = dBool(e);
   }
 
@@ -346,7 +346,7 @@ TEST(StringTest, testMux) {
   for (size_t i = 0; i < testBatchValue1.size(); i++) {
     for (size_t j = 0; j < testBatchValue1.at(0).size(); j++) {
       testBatchValue1[i][j] =
-          testBatchChoice[j] ? testBatchValue2[i][j] : testBatchValue1[i][j];
+          testBatchChoice[i] ? testBatchValue2[i][j] : testBatchValue1[i][j];
     }
   }
 
@@ -397,14 +397,12 @@ TEST(StringTest, testResizeWithAND) {
   std::vector<std::vector<bool>> testBatchValue1(
       dSize(e), std::vector<bool>(dSize(e)));
   auto testBatchValue2 = testBatchValue1;
-  testBatchValue2.resize(testBatchValue1.size() * 2);
   for (size_t i = 0; i < testBatchValue1.size(); i++) {
-    testBatchValue2[i + testBatchValue1.size()] =
-        std::vector<bool>(testBatchValue1.at(0).size());
+    testBatchValue2[i].resize(testBatchValue1.at(0).size() * 2);
     for (size_t j = 0; j < testBatchValue1.at(0).size(); j++) {
       testBatchValue1[i][j] = dBool(e);
       testBatchValue2[i][j] = dBool(e);
-      testBatchValue2[i + testBatchValue1.size()][j] = dBool(e);
+      testBatchValue2[i][j + testBatchValue1.at(0).size()] = dBool(e);
     }
   }
 
@@ -476,21 +474,21 @@ TEST(StringTest, testRebatching) {
   uint32_t batchSize2 = dSize(e);
   uint32_t batchSize3 = dSize(e);
   std::vector<std::vector<bool>> testBatchValue1(
-      length, std::vector<bool>(batchSize1));
+      batchSize1, std::vector<bool>(length));
   std::vector<std::vector<bool>> testBatchValue2(
-      length, std::vector<bool>(batchSize2));
+      batchSize2, std::vector<bool>(length));
   std::vector<std::vector<bool>> testBatchValue3(
-      length, std::vector<bool>(batchSize3));
+      batchSize3, std::vector<bool>(length));
 
   for (size_t i = 0; i < length; i++) {
     for (size_t j = 0; j < batchSize1; j++) {
-      testBatchValue1[i][j] = dBool(e);
+      testBatchValue1[j][i] = dBool(e);
     }
     for (size_t j = 0; j < batchSize2; j++) {
-      testBatchValue2[i][j] = dBool(e);
+      testBatchValue2[j][i] = dBool(e);
     }
     for (size_t j = 0; j < batchSize3; j++) {
-      testBatchValue3[i][j] = dBool(e);
+      testBatchValue3[j][i] = dBool(e);
     }
   }
 
@@ -507,18 +505,20 @@ TEST(StringTest, testRebatching) {
   auto t6 = v123.at(1).openToParty(0).getValue();
   auto t7 = v123.at(2).openToParty(0).getValue();
 
-  for (size_t i = 0; i < length; i++) {
+  for (size_t i = 0; i < batchSize1; i++) {
     testVectorEq(t5.at(i), testBatchValue1.at(i));
+  }
+  for (size_t i = 0; i < batchSize2; i++) {
     testVectorEq(t6.at(i), testBatchValue2.at(i));
+  }
+  for (size_t i = 0; i < batchSize3; i++) {
     testVectorEq(t7.at(i), testBatchValue3.at(i));
-    testBatchValue1[i].insert(
-        testBatchValue1[i].end(),
-        testBatchValue2[i].begin(),
-        testBatchValue2[i].end());
-    testBatchValue1[i].insert(
-        testBatchValue1[i].end(),
-        testBatchValue3[i].begin(),
-        testBatchValue3[i].end());
+  }
+  testBatchValue1.insert(
+      testBatchValue1.end(), testBatchValue2.begin(), testBatchValue2.end());
+  testBatchValue1.insert(
+      testBatchValue1.end(), testBatchValue3.begin(), testBatchValue3.end());
+  for (size_t i = 0; i < batchSize1 + batchSize2 + batchSize3; i++) {
     testVectorEq(t4.at(i), testBatchValue1.at(i));
   }
 }

--- a/fbpcf/mpc_std_lib/shuffler/test/ShufflerTest.cpp
+++ b/fbpcf/mpc_std_lib/shuffler/test/ShufflerTest.cpp
@@ -20,6 +20,7 @@
 #include "fbpcf/mpc_std_lib/shuffler/NonShufflerFactory.h"
 #include "fbpcf/mpc_std_lib/shuffler/PermuteBasedShufflerFactory.h"
 #include "fbpcf/mpc_std_lib/util/test/util.h"
+#include "fbpcf/mpc_std_lib/util/util.h"
 #include "fbpcf/scheduler/SchedulerHelper.h"
 #include "fbpcf/test/TestHelper.h"
 
@@ -28,32 +29,38 @@ namespace fbpcf::mpc_std_lib::shuffler {
 const int testIntWidth = 32;
 
 template <int schedulerId>
-std::vector<uint64_t> task(
-    std::unique_ptr<IShuffler<
-        frontend::Int<false, testIntWidth, true, schedulerId, true>>> shuffler,
-    const std::vector<uint32_t>& data) {
-  frontend::Int<false, testIntWidth, true, schedulerId, true> ints(data, 0);
-  auto shuffled = shuffler->shuffle(ints, data.size());
+std::vector<std::vector<bool>> task(
+    std::unique_ptr<IShuffler<frontend::BitString<true, schedulerId, true>>>
+        shuffler,
+    const std::vector<std::vector<bool>>& data) {
+  frontend::BitString<true, schedulerId, true> bits(data, 0);
+  auto shuffled = shuffler->shuffle(bits, data.size());
   auto rst = shuffled.openToParty(0).getValue();
   return rst;
 }
 
 void shufflerTest(
-    IShufflerFactory<frontend::Int<false, testIntWidth, true, 0, true>>&
-        shufflerFactory0,
-    IShufflerFactory<frontend::Int<false, testIntWidth, true, 1, true>>&
-        shufflerFactory1) {
+    IShufflerFactory<frontend::BitString<true, 0, true>>& shufflerFactory0,
+    IShufflerFactory<frontend::BitString<true, 1, true>>& shufflerFactory1) {
   auto agentFactories = engine::communication::getInMemoryAgentFactory(2);
   setupRealBackend<0, 1>(*agentFactories[0], *agentFactories[1]);
   auto shuffler0 = shufflerFactory0.create();
   auto shuffler1 = shufflerFactory1.create();
   size_t size = 16;
   auto data = util::generateRandomPermutation(size);
-  auto future0 = std::async(task<0>, std::move(shuffler0), data);
-  auto future1 = std::async(task<1>, std::move(shuffler1), data);
-  auto rst = future0.get();
+  std::vector<std::vector<bool>> bitData(size);
+  for (size_t i = 0; i < size; i++) {
+    bitData[i] = util::Adapters<uint32_t>::convertToBits(data.at(i));
+  }
+  auto future0 = std::async(task<0>, std::move(shuffler0), bitData);
+  auto future1 = std::async(task<1>, std::move(shuffler1), bitData);
+  auto bitRst = future0.get();
   future1.get();
-  ASSERT_EQ(data.size(), rst.size());
+  ASSERT_EQ(data.size(), bitRst.size());
+  std::vector<uint32_t> rst(size);
+  for (size_t i = 0; i < size; i++) {
+    rst[i] = util::Adapters<uint32_t>::convertFromBits(bitRst.at(i));
+  }
 
   for (size_t i = 0; i < data.size(); i++) {
     ASSERT_TRUE(std::find(rst.begin(), rst.end(), data.at(i)) != rst.end());
@@ -61,50 +68,42 @@ void shufflerTest(
 }
 
 TEST(shufflerTest, testNonShuffler) {
-  insecure::NonShufflerFactory<
-      frontend::Int<false, testIntWidth, true, 0, true>>
-      factory0;
-  insecure::NonShufflerFactory<
-      frontend::Int<false, testIntWidth, true, 1, true>>
-      factory1;
+  insecure::NonShufflerFactory<frontend::BitString<true, 0, true>> factory0;
+  insecure::NonShufflerFactory<frontend::BitString<true, 1, true>> factory1;
 
   shufflerTest(factory0, factory1);
 }
 
 TEST(shufflerTest, testPermuteBasedShufflerWithDummyPermuter) {
-  PermuteBasedShufflerFactory<frontend::Int<false, testIntWidth, true, 0, true>>
-      factory0(
-          0,
-          1,
-          std::make_unique<permuter::insecure::DummyPermuterFactory<
-              frontend::Int<false, testIntWidth, true, 0, true>>>(0, 1),
-          std::make_unique<engine::util::AesPrgFactory>());
-  PermuteBasedShufflerFactory<frontend::Int<false, testIntWidth, true, 1, true>>
-      factory1(
-          1,
-          0,
-          std::make_unique<permuter::insecure::DummyPermuterFactory<
-              frontend::Int<false, testIntWidth, true, 1, true>>>(1, 0),
-          std::make_unique<engine::util::AesPrgFactory>());
+  PermuteBasedShufflerFactory<frontend::BitString<true, 0, true>> factory0(
+      0,
+      1,
+      std::make_unique<permuter::insecure::DummyPermuterFactory<
+          frontend::BitString<true, 0, true>>>(0, 1),
+      std::make_unique<engine::util::AesPrgFactory>());
+  PermuteBasedShufflerFactory<frontend::BitString<true, 1, true>> factory1(
+      1,
+      0,
+      std::make_unique<permuter::insecure::DummyPermuterFactory<
+          frontend::BitString<true, 1, true>>>(1, 0),
+      std::make_unique<engine::util::AesPrgFactory>());
 
   shufflerTest(factory0, factory1);
 }
 
 TEST(shufflerTest, testPermuteBasedShufflerWithAsWaksmanPermuter) {
-  PermuteBasedShufflerFactory<frontend::Int<false, testIntWidth, true, 0, true>>
-      factory0(
-          0,
-          1,
-          std::make_unique<permuter::AsWaksmanPermuterFactory<uint32_t, 0>>(
-              0, 1),
-          std::make_unique<engine::util::AesPrgFactory>());
-  PermuteBasedShufflerFactory<frontend::Int<false, testIntWidth, true, 1, true>>
-      factory1(
-          1,
-          0,
-          std::make_unique<permuter::AsWaksmanPermuterFactory<uint32_t, 1>>(
-              1, 0),
-          std::make_unique<engine::util::AesPrgFactory>());
+  PermuteBasedShufflerFactory<frontend::BitString<true, 0, true>> factory0(
+      0,
+      1,
+      std::make_unique<
+          permuter::AsWaksmanPermuterFactory<std::vector<bool>, 0>>(0, 1),
+      std::make_unique<engine::util::AesPrgFactory>());
+  PermuteBasedShufflerFactory<frontend::BitString<true, 1, true>> factory1(
+      1,
+      0,
+      std::make_unique<
+          permuter::AsWaksmanPermuterFactory<std::vector<bool>, 1>>(1, 0),
+      std::make_unique<engine::util::AesPrgFactory>());
 
   shufflerTest(factory0, factory1);
 }

--- a/fbpcf/mpc_std_lib/util/bitstring_impl.h
+++ b/fbpcf/mpc_std_lib/util/bitstring_impl.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "fbpcf/frontend/BitString.h"
+
+namespace fbpcf::mpc_std_lib::util {
+
+template <int schedulerId>
+struct SecBatchType<std::vector<bool>, schedulerId> {
+  using type = frontend::BitString<true, schedulerId, true>;
+};
+
+template <int schedulerId>
+class MpcAdapters<std::vector<bool>, schedulerId> {
+ public:
+  using SecBatchType =
+      typename SecBatchType<std::vector<bool>, schedulerId>::type;
+  static SecBatchType processSecretInputs(
+      const std::vector<std::vector<bool>>& secrets,
+      int secretOwnerPartyId);
+
+  static SecBatchType recoverBatchSharedSecrets(
+      const std::vector<std::vector<bool>>& src);
+
+  static std::pair<SecBatchType, SecBatchType> obliviousSwap(
+      const SecBatchType& src1,
+      const SecBatchType& src2,
+      frontend::Bit<true, schedulerId, true> indicator) {
+    auto rst1 = src1.mux(indicator, src2);
+    SecBatchType rst2(rst1.size());
+    for (size_t i = 0; i < rst2.size(); i++) {
+      rst2[i] = rst1.at(i) ^ src1.at(i) ^ src2.at(i);
+    }
+    return {rst1, rst2};
+  }
+
+  static std::vector<std::vector<bool>> openToParty(
+      const SecBatchType& src,
+      int partyId);
+};
+
+} // namespace fbpcf::mpc_std_lib::util

--- a/fbpcf/mpc_std_lib/util/util.h
+++ b/fbpcf/mpc_std_lib/util/util.h
@@ -66,3 +66,5 @@ std::vector<__m128i> convertFromBits(const std::vector<std::vector<bool>>& src);
 #include "fbpcf/mpc_std_lib/util/uint32_impl.h"
 
 #include "fbpcf/mpc_std_lib/util/aggregationValue_impl.h"
+
+#include "fbpcf/mpc_std_lib/util/bitstring_impl.h"


### PR DESCRIPTION
Summary:
As title.
Since we are going to use BitString type for UDP, change the test to use this type as well.

Reviewed By: elliottlawrence

Differential Revision: D35132717

