### PR TITLE
Add a `Intp` type that can support any integer

### DIFF
--- a/fbpcf/mpc_std_lib/oram/test/WriteOnlyORAMTest.cpp
+++ b/fbpcf/mpc_std_lib/oram/test/WriteOnlyORAMTest.cpp
@@ -118,7 +118,7 @@ void runOramTestWithDummyComponents() {
 }
 
 TEST(WriteOnlyORAMTest, TestWriteOnlyORAMWithDummyComponents) {
-  runOramTestWithDummyComponents<uint32_t>();
+  runOramTestWithDummyComponents<util::TestIntp>();
   runOramTestWithDummyComponents<util::AggregationValue>();
 }
 
@@ -145,7 +145,7 @@ void runOramTestWithRealDifferenceCalculatorAndDummySinglePointArrayGenerator(
       std::make_unique<DifferenceCalculatorFactory<T, indicatorSumWidth, 1>>(
           false, 0, 1));
 
-  size_t oramSize = 150;
+  size_t oramSize = 30;
   testWriteOnlyOram<T>(std::move(factory0), std::move(factory1), oramSize);
 }
 
@@ -156,7 +156,7 @@ TEST(
   setupRealBackend<0, 1>(*factories[0], *factories[1]);
 
   runOramTestWithRealDifferenceCalculatorAndDummySinglePointArrayGenerator<
-      uint32_t>(*factories[0], *factories[1]);
+      util::TestIntp>(*factories[0], *factories[1]);
   runOramTestWithRealDifferenceCalculatorAndDummySinglePointArrayGenerator<
       util::AggregationValue>(*factories[0], *factories[1]);
 }
@@ -188,7 +188,7 @@ void runOramTestWithDummyOblivousDeltaCalculator(
       std::make_unique<DifferenceCalculatorFactory<T, indicatorSumWidth, 1>>(
           false, 0, 1));
 
-  size_t oramSize = 150;
+  size_t oramSize = 30;
   testWriteOnlyOram<T>(std::move(factory0), std::move(factory1), oramSize);
 }
 
@@ -196,7 +196,7 @@ TEST(WriteOnlyORAMTest, TestWriteOnlyORAMWithDummyOblivousDeltaCalculator) {
   auto factories = engine::communication::getInMemoryAgentFactory(2);
   setupRealBackend<0, 1>(*factories[0], *factories[1]);
 
-  runOramTestWithDummyOblivousDeltaCalculator<uint32_t>(
+  runOramTestWithDummyOblivousDeltaCalculator<util::TestIntp>(
       *factories[0], *factories[1]);
   runOramTestWithDummyOblivousDeltaCalculator<util::AggregationValue>(
       *factories[0], *factories[1]);
@@ -214,7 +214,7 @@ void runOramTestWithSecureComponents(
   auto factory1 = getSecureWriteOnlyOramFactory<T, indicatorSumWidth, 1>(
       false, 0, 1, agentFactory1);
 
-  size_t oramSize = 150;
+  size_t oramSize = 30;
   testWriteOnlyOram<T>(std::move(factory0), std::move(factory1), oramSize);
 }
 
@@ -222,7 +222,7 @@ TEST(WriteOnlyORAMTest, TestWriteOnlyORAMWithSecureComponents) {
   auto factories = engine::communication::getInMemoryAgentFactory(2);
   setupRealBackend<0, 1>(*factories[0], *factories[1]);
 
-  runOramTestWithSecureComponents<uint32_t>(*factories[0], *factories[1]);
+  runOramTestWithSecureComponents<util::TestIntp>(*factories[0], *factories[1]);
   runOramTestWithSecureComponents<util::AggregationValue>(
       *factories[0], *factories[1]);
 }
@@ -243,7 +243,8 @@ TEST(LinearORAMTest, TestLinearOram) {
   auto factories = engine::communication::getInMemoryAgentFactory(2);
   setupRealBackend<0, 1>(*factories[0], *factories[1]);
 
-  runLinearOramTestWithSecureComponents<uint32_t>(*factories[0], *factories[1]);
+  runLinearOramTestWithSecureComponents<util::TestIntp>(
+      *factories[0], *factories[1]);
 
   runLinearOramTestWithSecureComponents<util::AggregationValue>(
       *factories[0], *factories[1]);

--- a/fbpcf/mpc_std_lib/util/Intp_impl.h
+++ b/fbpcf/mpc_std_lib/util/Intp_impl.h
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+#include <climits>
+#include <cstdint>
+#include <exception>
+#include <type_traits>
+#include <vector>
+
+namespace fbpcf::mpc_std_lib::util {
+
+/**
+ * This is the type for plaintext integers.
+ */
+template <bool isSigned, int8_t width>
+class Intp {
+  template <
+      typename T8,
+      typename T16,
+      typename T32,
+      typename T64,
+      int8_t intWidth>
+  using typeSelector = typename std::conditional<
+      intWidth <= 16,
+      typename std::conditional<intWidth <= 8, T8, T16>::type,
+      typename std::conditional<intWidth <= 32, T32, T64>::type>::type;
+
+ public:
+  using NativeType = typename std::conditional<
+      isSigned,
+      typeSelector<int8_t, int16_t, int32_t, int64_t, width>,
+      typeSelector<uint8_t, uint16_t, uint32_t, uint64_t, width>>::type;
+
+  Intp() : v_(0) {}
+
+  // intentionally allow implicit conversion here
+  /* implicit */ Intp(NativeType v) : v_(validateValue(v)) {}
+
+  operator NativeType() const {
+    return v_;
+  }
+
+  operator NativeType&() {
+    return v_;
+  }
+
+  explicit operator NativeType*() const {
+    return &v_;
+  }
+
+  Intp<isSigned, width> operator+(const Intp<isSigned, width>& other) const {
+    return Intp<isSigned, width>(round(v_ + other.v_));
+  }
+
+  Intp<isSigned, width> operator-() const {
+    return Intp<isSigned, width>(round(kOffSet - v_));
+  }
+
+  Intp<isSigned, width> operator-(const Intp<isSigned, width>& other) const {
+    return Intp<isSigned, width>(round(v_ - other.v_));
+  }
+
+ public:
+  static constexpr NativeType kMax = isSigned ? LLONG_MAX >> (64 - width)
+                                              : ULLONG_MAX >> (64 - width);
+  static constexpr NativeType kMin = isSigned ? LLONG_MIN >> (64 - width) : 0;
+
+  // this is the wrap-around offset for integers. For 64bit ints,
+  // wrap-around is automatic. Otherwise it needs to be done manually. This
+  // wrap-around is 2^width, which happen to be (ULLONG_MAX >> (64 - width))
+  // + 1.
+  static constexpr NativeType kOffSet =
+      width == 64 ? 0 : (ULLONG_MAX >> (64 - width)) + 1;
+
+  inline static NativeType round(NativeType v) {
+    if (v > kMax) {
+      return v - kOffSet;
+    } else if constexpr (isSigned) {
+      if (v < kMin) {
+        return v + kOffSet;
+      }
+    }
+    return v;
+  }
+
+ private:
+  static NativeType validateValue(NativeType v) {
+    if (v > kMax) {
+      throw std::runtime_error(
+          "Value is too large. The maximum of " + std::to_string(width) +
+          " bit " + (isSigned ? " signed " : "unsigned ") + "integer is " +
+          std::to_string(kMax) + ". But you provided " + std::to_string(v) +
+          ". ");
+    } else if (v < kMin) {
+      throw std::runtime_error(
+          "Value is too small. The minimum of " + std::to_string(width) +
+          " bit signed integer is " + std::to_string(kMin) +
+          ". But you provided " + std::to_string(v) + ". ");
+    } else {
+      return v;
+    }
+  }
+
+  NativeType v_;
+};
+
+template <bool isSigned, int8_t width>
+class Adapters<Intp<isSigned, width>> {
+ public:
+  static Intp<isSigned, width> convertFromBits(const std::vector<bool>& bits) {
+    uint64_t rst = 0;
+    if (bits.size() > width) {
+      throw std::invalid_argument("Too many input bits!");
+    }
+    for (size_t i = bits.size(); i > 0; i--) {
+      rst <<= 1;
+      rst += bits.at(i - 1);
+    }
+
+    return Intp<isSigned, width>::round(rst);
+  }
+
+  static std::vector<bool> convertToBits(const Intp<isSigned, width>& src) {
+    std::vector<bool> rst(width, 0);
+    uint64_t tmp = src;
+    for (size_t t = 0; tmp > 0; t++) {
+      rst[t] = tmp & 1;
+      tmp >>= 1;
+    }
+    return rst;
+  }
+
+  // when the size of T is <=128, this function can simply take a subset of the
+  // key to construct T; otherwise, this function needs to run a PRG with key as
+  // seed to generate sufficient amount of random data to construct T;
+  static Intp<isSigned, width> generateFromKey(__m128i key) {
+    return Intp<isSigned, width>::round(
+        _mm_extract_epi64(key, 0) & (ULLONG_MAX >> (64 - width)));
+  }
+};
+
+// these helpers are for MPC part
+
+template <bool isSigned, int8_t width, int schedulerId>
+struct SecBatchType<Intp<isSigned, width>, schedulerId> {
+  using type = frontend::Int<isSigned, width, true, schedulerId, true>;
+};
+
+template <bool isSigned, int8_t width, int schedulerId>
+class MpcAdapters<Intp<isSigned, width>, schedulerId> {
+ public:
+  using SecBatchType =
+      typename SecBatchType<Intp<isSigned, width>, schedulerId>::type;
+  static SecBatchType processSecretInputs(
+      const std::vector<Intp<isSigned, width>>& secrets,
+      int secretOwnerPartyId) {
+    std::vector<typename Intp<isSigned, width>::NativeType> tmp(secrets.size());
+    std::transform(
+        secrets.begin(), secrets.end(), tmp.begin(), [](auto v) { return v; });
+    return SecBatchType(std::move(tmp), secretOwnerPartyId);
+  }
+
+  static SecBatchType recoverBatchSharedSecrets(
+      const std::vector<std::vector<bool>>& src) {
+    typename SecBatchType::ExtractedInt rst;
+    for (size_t i = 0; i < width; i++) {
+      rst[i] = typename frontend::Bit<true, schedulerId, true>::ExtractedBit(
+          src.at(i));
+    }
+    return SecBatchType(std::move(rst));
+  }
+
+  static std::pair<SecBatchType, SecBatchType> obliviousSwap(
+      const SecBatchType& src1,
+      const SecBatchType& src2,
+      frontend::Bit<true, schedulerId, true> indicator) {
+    auto rst1 = src1.mux(indicator, src2);
+    auto rst2 = rst1;
+    for (size_t i = 0; i < width; i++) {
+      rst2[i] = rst2[i] ^ src1[i] ^ src2[i];
+    }
+    return {rst1, rst2};
+  }
+
+  static std::vector<Intp<isSigned, width>> openToParty(
+      const SecBatchType& src,
+      int partyId) {
+    auto buf = src.openToParty(partyId).getValue();
+    std::vector<Intp<isSigned, width>> rst(buf.size());
+    std::transform(
+        buf.begin(), buf.end(), rst.begin(), [](auto v) { return v; });
+    return rst;
+  }
+};
+
+} // namespace fbpcf::mpc_std_lib::util

--- a/fbpcf/mpc_std_lib/util/test/util.h
+++ b/fbpcf/mpc_std_lib/util/test/util.h
@@ -42,6 +42,22 @@ inline std::tuple<uint32_t, uint32_t, uint32_t> getRandomData<uint32_t>(
   return {value, share0, share1};
 }
 
+using TestIntp = Intp<true, 9>;
+
+template <>
+inline std::tuple<TestIntp, TestIntp, TestIntp> getRandomData<TestIntp>(
+    std::mt19937_64& e) {
+  std::uniform_int_distribution<typename TestIntp::NativeType> randomValue(
+      TestIntp::kMin / 50, TestIntp::kMax / 50);
+
+  std::uniform_int_distribution<typename TestIntp::NativeType> randomMask(
+      TestIntp::kMin, TestIntp::kMax);
+  uint32_t value = randomValue(e);
+  uint32_t share0 = randomMask(e);
+  uint32_t share1 = value ^ share0;
+  return {value, share0, share1};
+}
+
 template <>
 inline std::tuple<AggregationValue, AggregationValue, AggregationValue>
 getRandomData<AggregationValue>(std::mt19937_64& e) {

--- a/fbpcf/mpc_std_lib/util/util.h
+++ b/fbpcf/mpc_std_lib/util/util.h
@@ -65,6 +65,7 @@ std::vector<__m128i> convertFromBits(const std::vector<std::vector<bool>>& src);
 
 #include "fbpcf/mpc_std_lib/util/uint32_impl.h"
 
+#include "fbpcf/mpc_std_lib/util/Intp_impl.h"
 #include "fbpcf/mpc_std_lib/util/aggregationValue_impl.h"
 
 #include "fbpcf/mpc_std_lib/util/bitstring_impl.h"


### PR DESCRIPTION
Summary:
As title.
This diff adds a customized Intp type that can directly refect the behavoir of any integer (signed/unsigned with any reasonable width).
The point of this type is to allow using different width of integers in ORAM/shuffler/permuter for best performance.
Migrate to use it in ORAMs will be a BE task.

Reviewed By: chualynn

Differential Revision: D35098816

