### PR TITLE
Clean up build warnings from FBPCF build

### DIFF
--- a/fbpcf/engine/SecretShareEngine.cpp
+++ b/fbpcf/engine/SecretShareEngine.cpp
@@ -262,7 +262,7 @@ std::vector<bool> SecretShareEngine::computeBatchANDImmediately(
   std::vector<ScheduledBatchAND> scheduledBatchANDs;
   std::vector<ScheduledCompositeAND> scheduledCompositeANDs;
   std::vector<ScheduledBatchCompositeAND> scheduledBatchCompositeANDs;
-  for (int i = 0; i < left.size(); i++) {
+  for (size_t i = 0; i < left.size(); i++) {
     scheduledANDs.push_back(ScheduledAND(left.at(i), right.at(i)));
   }
   return computeAllANDsFromScheduledANDs(
@@ -361,7 +361,7 @@ std::vector<bool> SecretShareEngine::computeSecretSharesToOpen(
   for (size_t i = 0; i < batchAnds.size(); i++) {
     auto& leftValues = batchAnds[i].getLeft();
     auto& rightValues = batchAnds[i].getRight();
-    for (int j = 0; j < leftValues.size(); j++) {
+    for (size_t j = 0; j < leftValues.size(); j++) {
       secretsToOpen[index * 2] = leftValues[j] ^ tuples.at(index).getA();
       secretsToOpen[index * 2 + 1] =
           rightValues.at(j) ^ tuples.at(index).getB();
@@ -382,7 +382,7 @@ std::vector<bool> SecretShareEngine::computeSecretSharesToOpen(
   for (size_t i = 0; i < batchCompositeAnds.size(); i++) {
     auto& leftValues = batchCompositeAnds[i].getLeft();
     for (auto& rightValues : batchCompositeAnds[i].getRights()) {
-      for (int j = 0; j < leftValues.size(); j++) {
+      for (size_t j = 0; j < leftValues.size(); j++) {
         secretsToOpen[index * 2] = leftValues[j] ^ tuples.at(index).getA();
         secretsToOpen[index * 2 + 1] =
             rightValues.at(j) ^ tuples.at(index).getB();
@@ -428,7 +428,7 @@ SecretShareEngine::computeExecutionResultsFromOpenedShares(
     auto& leftValues = batchAnds[i].getLeft();
     auto batchSize = leftValues.size();
     std::vector<bool> rst(batchSize);
-    for (int j = 0; j < batchSize; j++) {
+    for (size_t j = 0; j < batchSize; j++) {
       bool val = tuples.at(index).getC() ^
           (openedSecrets.at(2 * index) & tuples.at(index).getB()) ^
           (openedSecrets.at(2 * index + 1) & tuples.at(index).getA());
@@ -464,9 +464,9 @@ SecretShareEngine::computeExecutionResultsFromOpenedShares(
     auto batchSize = leftValues.size();
     auto outputSize = batchCompositeAnds[i].getRights().size();
     std::vector<std::vector<bool>> compositeResult(outputSize);
-    for (int j = 0; j < outputSize; j++) {
+    for (size_t j = 0; j < outputSize; j++) {
       std::vector<bool> innerBatchResult(batchSize);
-      for (int k = 0; k < batchSize; k++) {
+      for (size_t k = 0; k < batchSize; k++) {
         bool val = tuples.at(index).getC() ^
             (openedSecrets.at(2 * index) & tuples.at(index).getB()) ^
             (openedSecrets.at(2 * index + 1) & tuples.at(index).getA());

--- a/fbpcf/engine/communication/IPartyCommunicationAgent.h
+++ b/fbpcf/engine/communication/IPartyCommunicationAgent.h
@@ -6,6 +6,7 @@
  */
 
 #pragma once
+
 #include <emmintrin.h>
 #include <stdint.h>
 #include <string.h>
@@ -36,7 +37,7 @@ class IPartyCommunicationAgent {
    * @param size the expected size;
    * @return the received content
    */
-  virtual std::vector<unsigned char> receive(int size) = 0;
+  virtual std::vector<unsigned char> receive(size_t size) = 0;
 
   /**
    * send a byte string to the partner

--- a/fbpcf/engine/communication/InMemoryPartyCommunicationAgentHost.cpp
+++ b/fbpcf/engine/communication/InMemoryPartyCommunicationAgentHost.cpp
@@ -15,7 +15,8 @@ void InMemoryPartyCommunicationAgent::send(
   sentData_ += data.size();
 }
 
-std::vector<unsigned char> InMemoryPartyCommunicationAgent::receive(int size) {
+std::vector<unsigned char> InMemoryPartyCommunicationAgent::receive(
+    size_t size) {
   auto result = host_.receive(myId_, size);
   if (result.size() != size) {
     throw std::runtime_error("unexpected message size!");
@@ -48,7 +49,7 @@ void InMemoryPartyCommunicationAgentHost::send(
 
 std::vector<unsigned char> InMemoryPartyCommunicationAgentHost::receive(
     int myId,
-    int size) {
+    size_t size) {
   std::vector<unsigned char> result;
 
   while (result.size() < size) {

--- a/fbpcf/engine/communication/InMemoryPartyCommunicationAgentHost.h
+++ b/fbpcf/engine/communication/InMemoryPartyCommunicationAgentHost.h
@@ -36,7 +36,7 @@ class InMemoryPartyCommunicationAgent final : public IPartyCommunicationAgent {
   /**
    * @inherit doc
    */
-  std::vector<unsigned char> receive(int size) override;
+  std::vector<unsigned char> receive(size_t size) override;
 
   /**
    * @inherit doc
@@ -78,7 +78,7 @@ class InMemoryPartyCommunicationAgentHost {
   /**
    * Allow an in memory communication agent receive data from the other.
    */
-  std::vector<unsigned char> receive(int myId, int size);
+  std::vector<unsigned char> receive(int myId, size_t size);
 
   std::unique_ptr<InMemoryPartyCommunicationAgent> agents_[2];
 

--- a/fbpcf/engine/communication/SocketPartyCommunicationAgent.cpp
+++ b/fbpcf/engine/communication/SocketPartyCommunicationAgent.cpp
@@ -52,7 +52,7 @@ void SocketPartyCommunicationAgent::send(
   fflush(outgoingPort_);
 }
 
-std::vector<unsigned char> SocketPartyCommunicationAgent::receive(int size) {
+std::vector<unsigned char> SocketPartyCommunicationAgent::receive(size_t size) {
   std::vector<unsigned char> rst(size);
   auto s = fread(rst.data(), sizeof(unsigned char), size, incomingPort_);
   assert(s == size);

--- a/fbpcf/engine/communication/SocketPartyCommunicationAgent.h
+++ b/fbpcf/engine/communication/SocketPartyCommunicationAgent.h
@@ -47,7 +47,7 @@ class SocketPartyCommunicationAgent final : public IPartyCommunicationAgent {
   /**
    * @inherit doc
    */
-  std::vector<unsigned char> receive(int size) override;
+  std::vector<unsigned char> receive(size_t size) override;
 
   /**
    * @inherit doc

--- a/fbpcf/engine/tuple_generator/TwoPartyTupleGenerator.cpp
+++ b/fbpcf/engine/tuple_generator/TwoPartyTupleGenerator.cpp
@@ -67,7 +67,7 @@ TwoPartyTupleGenerator::generateTuples(uint64_t size) {
   auto sender0Messages = senderRcot_->rcot(size);
 
   std::vector<__m128i> sender1Messages(size);
-  for (auto i = 0; i < size; ++i) {
+  for (size_t i = 0; i < size; ++i) {
     // k1 / l1
     sender1Messages[i] = _mm_xor_si128(sender0Messages.at(i), delta_);
   }
@@ -76,7 +76,7 @@ TwoPartyTupleGenerator::generateTuples(uint64_t size) {
   auto receiverMessages = receiverMessagesFuture.get();
 
   std::vector<bool> choiceBits(size);
-  for (auto i = 0; i < size; ++i) {
+  for (size_t i = 0; i < size; ++i) {
     // r / p
     choiceBits[i] = util::getLsb(receiverMessages.at(i));
   }

--- a/fbpcf/engine/tuple_generator/oblivious_transfer/ExtenderBasedRandomCorrelatedObliviousTransfer.h
+++ b/fbpcf/engine/tuple_generator/oblivious_transfer/ExtenderBasedRandomCorrelatedObliviousTransfer.h
@@ -66,7 +66,7 @@ class ExtenderBasedRandomCorrelatedObliviousTransfer final
 
   // buffered RCOT results
   std::vector<__m128i> rcotResults_;
-  int64_t otIndex_;
+  size_t otIndex_;
 };
 
 } // namespace fbpcf::engine::tuple_generator::oblivious_transfer

--- a/fbpcf/engine/tuple_generator/oblivious_transfer/IknpShRandomCorrelatedObliviousTransfer.cpp
+++ b/fbpcf/engine/tuple_generator/oblivious_transfer/IknpShRandomCorrelatedObliviousTransfer.cpp
@@ -164,7 +164,7 @@ std::vector<__m128i> IknpShRandomCorrelatedObliviousTransfer::rcot(
     int64_t size) {
   std::vector<__m128i> rst;
   // must work with a multiplication of 128;
-  int64_t blockCount = ((size + 127) / 128);
+  size_t blockCount = ((size + 127) / 128);
   if (role_ == util::receiver) {
     std::vector<__m128i> t0(blockCount * 128);
     std::vector<__m128i> u(blockCount * 127);

--- a/fbpcf/engine/tuple_generator/oblivious_transfer/ferret/RegularErrorMultiPointCot.h
+++ b/fbpcf/engine/tuple_generator/oblivious_transfer/ferret/RegularErrorMultiPointCot.h
@@ -86,10 +86,10 @@ class RegularErrorMultiPointCot final : public IMultiPointCot {
   __m128i delta_;
 
   util::Role role_;
-  int baseCotSize_;
+  size_t baseCotSize_;
 
   int64_t spcotLength_;
-  int spcotCount_;
+  size_t spcotCount_;
 };
 
 } // namespace

--- a/fbpcf/engine/tuple_generator/oblivious_transfer/ferret/SinglePointCot.cpp
+++ b/fbpcf/engine/tuple_generator/oblivious_transfer/ferret/SinglePointCot.cpp
@@ -40,7 +40,7 @@ std::vector<__m128i> SinglePointCot::constructALayerOfKeyForReceiver(
     int missingPosition) {
   auto rst = expander_->expand(std::move(previousLayer));
 
-  auto positionToFix = (missingPosition << 1) + util::getLsb(baseCot);
+  size_t positionToFix = (missingPosition << 1) + util::getLsb(baseCot);
 
   std::vector<__m128i> tmp({baseCot});
   cipherForHash_->encryptInPlace(tmp);

--- a/fbpcf/engine/util/AesPrg.cpp
+++ b/fbpcf/engine/util/AesPrg.cpp
@@ -28,7 +28,7 @@ std::vector<bool> AesPrg::getRandomBits(uint32_t size) {
   auto randomBytes = asyncBuffer_->getData(ceilDiv(size, 8));
 
   std::vector<bool> rst(size);
-  for (auto i = 0; i < size; ++i) {
+  for (size_t i = 0; i < size; ++i) {
     rst[i] = (randomBytes[i >> 3] >> (i & 7)) & 1;
   }
   return rst;

--- a/fbpcf/gcp/GCSUtil.cpp
+++ b/fbpcf/gcp/GCSUtil.cpp
@@ -22,7 +22,7 @@ namespace fbpcf::gcp {
 GCSObjectReference uriToObjectReference(std::string url) {
   std::string bucket;
   std::string key;
-  int pos = 0;
+  size_t pos = 0;
   auto uri = folly::Uri(url);
   auto scheme = uri.scheme();
   auto host = uri.host();

--- a/fbpcf/scheduler/PlaintextScheduler.cpp
+++ b/fbpcf/scheduler/PlaintextScheduler.cpp
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <cstddef>
 #include <stdexcept>
 #include <vector>
 
@@ -109,7 +110,7 @@ PlaintextScheduler::privateAndPrivateBatch(
   }
   nonFreeGates_ += leftValue.size();
   std::vector<bool> rst(leftValue.size());
-  for (int i = 0; i < leftValue.size(); i++) {
+  for (size_t i = 0; i < leftValue.size(); i++) {
     rst[i] = leftValue[i] & rightValue[i];
   }
   return wireKeeper_->allocateBatchBooleanValue(rst);
@@ -134,7 +135,7 @@ PlaintextScheduler::privateAndPublicBatch(
   }
   freeGates_ += leftValue.size();
   std::vector<bool> rst(leftValue.size());
-  for (int i = 0; i < leftValue.size(); i++) {
+  for (size_t i = 0; i < leftValue.size(); i++) {
     rst[i] = leftValue.at(i) & rightValue.at(i);
   }
   return wireKeeper_->allocateBatchBooleanValue(rst);
@@ -214,7 +215,7 @@ PlaintextScheduler::privateXorPrivateBatch(
   }
   freeGates_ += leftValue.size();
   std::vector<bool> rst(leftValue.size());
-  for (int i = 0; i < leftValue.size(); i++) {
+  for (size_t i = 0; i < leftValue.size(); i++) {
     rst[i] = leftValue[i] ^ rightValue[i];
   }
   return wireKeeper_->allocateBatchBooleanValue(rst);
@@ -257,7 +258,7 @@ IScheduler::WireId<IScheduler::Boolean> PlaintextScheduler::notPrivateBatch(
   auto& value = wireKeeper_->getBatchBooleanValue(src);
   freeGates_ += value.size();
   std::vector<bool> rst(value.size());
-  for (int i = 0; i < value.size(); i++) {
+  for (size_t i = 0; i < value.size(); i++) {
     rst[i] = !value[i];
   }
   return wireKeeper_->allocateBatchBooleanValue(rst);
@@ -363,7 +364,7 @@ PlaintextScheduler::validateAndComputeBatchCompositeAND(
       throw std::invalid_argument("Batch inputs have differing sizes");
     }
     std::vector<bool> rst;
-    for (int i = 0; i < leftValue.size(); i++) {
+    for (size_t i = 0; i < leftValue.size(); i++) {
       rst.push_back(leftValue[i] & rightValue[i]);
     }
     returnWires.push_back(wireKeeper_->allocateBatchBooleanValue(rst));

--- a/fbpcf/scheduler/gate_keeper/BatchCompositeGate.h
+++ b/fbpcf/scheduler/gate_keeper/BatchCompositeGate.h
@@ -52,7 +52,7 @@ class BatchCompositeGate final : public ICompositeGate {
         auto leftValues = wireKeeper_.getBatchBooleanValue(left_);
         numberOfResults_ = leftValues.size() * outputWireIDs_.size();
 
-        for (int i = 0; i < outputWireIDs_.size(); i++) {
+        for (size_t i = 0; i < outputWireIDs_.size(); i++) {
           wireKeeper_.setBatchBooleanValue(
               outputWireIDs_[i],
               engine.computeBatchFreeAND(
@@ -63,7 +63,7 @@ class BatchCompositeGate final : public ICompositeGate {
       case GateType::NonFreeAnd: {
         auto leftValues = wireKeeper_.getBatchBooleanValue(left_);
         std::vector<std::vector<bool>> rightWireValues(outputWireIDs_.size());
-        for (int i = 0; i < outputWireIDs_.size(); i++) {
+        for (size_t i = 0; i < outputWireIDs_.size(); i++) {
           rightWireValues[i] = wireKeeper_.getBatchBooleanValue(rights_[i]);
         }
         numberOfResults_ = leftValues.size() * outputWireIDs_.size();
@@ -83,7 +83,7 @@ class BatchCompositeGate final : public ICompositeGate {
       case GateType::NonFreeAnd: {
         result =
             engine.getBatchCompositeANDExecutionResult(scheduledResultIndex_);
-        for (int i = 0; i < result.size(); i++) {
+        for (size_t i = 0; i < result.size(); i++) {
           wireKeeper_.setBatchBooleanValue(outputWireIDs_[i], result[i]);
         }
         break;


### PR DESCRIPTION
Summary: Almost all of the build warnings are about a faulty comparison between size_t and int in C++. The purpose of this diff is to update the code to get rid of these build warnings.

Reviewed By: RuiyuZhu

Differential Revision: D35092151

