### PR TITLE
Fix traffic statistics in TwoPartyTupleGenerator

### DIFF
--- a/fbpcf/engine/tuple_generator/TwoPartyTupleGenerator.cpp
+++ b/fbpcf/engine/tuple_generator/TwoPartyTupleGenerator.cpp
@@ -129,7 +129,7 @@ std::pair<uint64_t, uint64_t> TwoPartyTupleGenerator::getTrafficStatistics()
   auto senderStats = senderRcot_->getTrafficStatistics();
   auto receiverStats = receiverRcot_->getTrafficStatistics();
   rst.first += senderStats.first + receiverStats.first;
-  rst.second += senderStats.first + receiverStats.second;
+  rst.second += senderStats.second + receiverStats.second;
 
   return rst;
 }


### PR DESCRIPTION
Summary:
gorel raised the issue in D34779616 that the number of bytes sent/received was roughly the same for publisher and partner, whereas they should just be inverted.

This should fix it.

Differential Revision: D35199261

