### PR TITLE
Update ITupleGenerator Interface. Add const + switch composite tuple order

### DIFF
--- a/fbpcf/engine/tuple_generator/DummyTupleGenerator.h
+++ b/fbpcf/engine/tuple_generator/DummyTupleGenerator.h
@@ -27,7 +27,7 @@ class DummyTupleGenerator final : public ITupleGenerator {
    * @inherit doc
    */
   std::map<size_t, std::vector<CompositeBooleanTuple>> getCompositeTuple(
-      std::map<size_t, uint32_t>& tupleSizes) override {
+      const std::map<size_t, uint32_t>& tupleSizes) override {
     std::map<size_t, std::vector<CompositeBooleanTuple>> result;
     for (auto& countOfTuples : tupleSizes) {
       size_t tupleSize = countOfTuples.first;
@@ -36,8 +36,8 @@ class DummyTupleGenerator final : public ITupleGenerator {
       result.emplace(tupleSize, std::vector<CompositeBooleanTuple>(tupleCount));
       for (int i = 0; i < tupleCount; i++) {
         result.at(tupleSize).at(i) = CompositeBooleanTuple(
-            std::vector<bool>(tupleSize, 0),
             0,
+            std::vector<bool>(tupleSize, 0),
             std::vector<bool>(tupleSize, 0));
       }
     }
@@ -53,11 +53,18 @@ class DummyTupleGenerator final : public ITupleGenerator {
       std::map<size_t, std::vector<CompositeBooleanTuple>>>
   getNormalAndCompositeBooleanTuples(
       uint32_t tupleSizes,
-      std::map<size_t, uint32_t>& compositeTupleSizes) override {
+      const std::map<size_t, uint32_t>& compositeTupleSizes) override {
     auto boolResult = getBooleanTuple(tupleSizes);
     auto compositeBoolResult = getCompositeTuple(compositeTupleSizes);
     return std::make_pair(
         std::move(boolResult), std::move(compositeBoolResult));
+  }
+
+  /**
+   * @inherit doc
+   */
+  bool supportsCompositeTupleGeneration() override {
+    return true;
   }
 
   std::pair<uint64_t, uint64_t> getTrafficStatistics() const override {

--- a/fbpcf/engine/tuple_generator/ITupleGenerator.h
+++ b/fbpcf/engine/tuple_generator/ITupleGenerator.h
@@ -68,20 +68,20 @@ class ITupleGenerator {
    public:
     CompositeBooleanTuple() {}
 
-    CompositeBooleanTuple(std::vector<bool> a, bool b, std::vector<bool> c)
-        : a_{a}, c_{c}, b_{b} {
-      if (a.size() != c.size()) {
+    CompositeBooleanTuple(bool a, std::vector<bool> b, std::vector<bool> c)
+        : a_{a}, b_{b}, c_{c} {
+      if (b.size() != c.size()) {
         throw std::invalid_argument("Sizes of a and c must be equal");
       }
     }
 
-    // get the vector of A bit shares
-    std::vector<bool> getA() {
+    // get the secret-share of shared bit A
+    bool getA() {
       return a_;
     }
 
-    // get the secret-share of shared bit B
-    bool getB() {
+    // get the vector of B bit shares
+    std::vector<bool> getB() {
       return b_;
     }
 
@@ -91,8 +91,8 @@ class ITupleGenerator {
     }
 
    private:
-    std::vector<bool> a_, c_;
-    bool b_;
+    bool a_;
+    std::vector<bool> b_, c_;
   };
 
   /**
@@ -108,7 +108,7 @@ class ITupleGenerator {
    * @return A map of tuple sizes to vector of those tuples
    */
   virtual std::map<size_t, std::vector<CompositeBooleanTuple>>
-  getCompositeTuple(std::map<size_t, uint32_t>& tupleSizes) = 0;
+  getCompositeTuple(const std::map<size_t, uint32_t>& tupleSizes) = 0;
 
   /**
    * Wrapper method for getBooleanTuple() and getCompositeTuple() which performs
@@ -119,7 +119,13 @@ class ITupleGenerator {
       std::map<size_t, std::vector<CompositeBooleanTuple>>>
   getNormalAndCompositeBooleanTuples(
       uint32_t tupleSize,
-      std::map<size_t, uint32_t>& compositeTupleSizes) = 0;
+      const std::map<size_t, uint32_t>& compositeTupleSizes) = 0;
+
+  /**
+   * Temporary method to indicate whether it's safe to call composite tuple
+   * generation methods
+   */
+  virtual bool supportsCompositeTupleGeneration() = 0;
 
   /**
    * Get the total amount of traffic transmitted.

--- a/fbpcf/engine/tuple_generator/TupleGenerator.cpp
+++ b/fbpcf/engine/tuple_generator/TupleGenerator.cpp
@@ -59,7 +59,8 @@ std::vector<TupleGenerator::BooleanTuple> TupleGenerator::generateTuples(
 }
 
 std::map<size_t, std::vector<ITupleGenerator::CompositeBooleanTuple>>
-TupleGenerator::getCompositeTuple(std::map<size_t, uint32_t>& tupleSizes) {
+TupleGenerator::getCompositeTuple(
+    const std::map<size_t, uint32_t>& tupleSizes) {
   throw std::runtime_error("Not implemented");
 }
 
@@ -68,7 +69,7 @@ std::pair<
     std::map<size_t, std::vector<ITupleGenerator::CompositeBooleanTuple>>>
 TupleGenerator::getNormalAndCompositeBooleanTuples(
     uint32_t tupleSize,
-    std::map<size_t, uint32_t>& tupleSizes) {
+    const std::map<size_t, uint32_t>& tupleSizes) {
   throw std::runtime_error("Not implemented");
 }
 

--- a/fbpcf/engine/tuple_generator/TupleGenerator.h
+++ b/fbpcf/engine/tuple_generator/TupleGenerator.h
@@ -43,7 +43,7 @@ class TupleGenerator final : public ITupleGenerator {
    * @inherit doc
    */
   std::map<size_t, std::vector<CompositeBooleanTuple>> getCompositeTuple(
-      std::map<size_t, uint32_t>& tupleSizes) override;
+      const std::map<size_t, uint32_t>& tupleSizes) override;
 
   /**
    * @inherit doc
@@ -53,7 +53,11 @@ class TupleGenerator final : public ITupleGenerator {
       std::map<size_t, std::vector<CompositeBooleanTuple>>>
   getNormalAndCompositeBooleanTuples(
       uint32_t tupleSize,
-      std::map<size_t, uint32_t>& compositeTupleSizes) override;
+      const std::map<size_t, uint32_t>& compositeTupleSizes) override;
+
+  bool supportsCompositeTupleGeneration() override {
+    return false;
+  }
 
   std::pair<uint64_t, uint64_t> getTrafficStatistics() const override;
 

--- a/fbpcf/engine/tuple_generator/TwoPartyTupleGenerator.cpp
+++ b/fbpcf/engine/tuple_generator/TwoPartyTupleGenerator.cpp
@@ -7,6 +7,7 @@
 
 #include "fbpcf/engine/tuple_generator/TwoPartyTupleGenerator.h"
 #include <stdexcept>
+#include "fbpcf/engine/util/AesPrg.h"
 #include "fbpcf/engine/util/util.h"
 
 namespace fbpcf::engine::tuple_generator {
@@ -23,15 +24,118 @@ TwoPartyTupleGenerator::TwoPartyTupleGenerator(
       senderRcot_{std::move(senderRcot)},
       receiverRcot_{std::move(receiverRcot)},
       delta_{delta},
-      buffer_{bufferSize, [this](uint64_t size) {
-                return std::async(
-                    [this](uint64_t size) { return generateTuples(size); },
-                    size);
-              }} {}
+      booleanTupleBuffer_{
+          bufferSize,
+          [this](uint64_t size) {
+            {
+              std::lock_guard<std::mutex> lock(scheduleMutex_);
+              toGenerate_.push_back(Boolean);
+            }
+            return std::async(
+                [this](uint64_t size) { return generateNormalTuples(size); },
+                size);
+          }},
+      rcotBuffer_{bufferSize, [this](uint64_t size) {
+                    {
+                      std::lock_guard<std::mutex> lock(scheduleMutex_);
+                      toGenerate_.push_back(Composite);
+                    }
+                    return std::async(
+                        [this](uint64_t size) {
+                          return generateRcotResults(size);
+                        },
+                        size);
+                  }} {}
 
 std::vector<ITupleGenerator::BooleanTuple>
 TwoPartyTupleGenerator::getBooleanTuple(uint32_t size) {
-  return buffer_.getData(size);
+  return booleanTupleBuffer_.getData(size);
+}
+
+std::map<size_t, std::vector<ITupleGenerator::CompositeBooleanTuple>>
+TwoPartyTupleGenerator::getCompositeTuple(
+    std::map<size_t, uint32_t>& tupleSizes) {
+  std::map<size_t, std::vector<ITupleGenerator::CompositeBooleanTuple>> tuples;
+  for (auto& tupleSizeToCount : tupleSizes) {
+    size_t tupleSize = std::get<0>(tupleSizeToCount);
+    uint64_t count = std::get<1>(tupleSizeToCount);
+    auto bufferedRcotResult = rcotBuffer_.getData(count);
+    std::vector<__m128i> sender0Messages(count);
+    std::vector<__m128i> receiverMessages(count);
+    for (size_t i = 0; i < count; i++) {
+      sender0Messages[i] = std::get<0>(bufferedRcotResult.at(i));
+      receiverMessages[i] = std::get<1>(bufferedRcotResult.at(i));
+    }
+    tuples.emplace(
+        tupleSize,
+        expandRCOTResults<true>(
+            std::move(sender0Messages),
+            std::move(receiverMessages),
+            tupleSize));
+  }
+  return tuples;
+}
+
+std::pair<
+    std::vector<ITupleGenerator::BooleanTuple>,
+    std::map<size_t, std::vector<ITupleGenerator::CompositeBooleanTuple>>>
+TwoPartyTupleGenerator::getNormalAndCompositeBooleanTuples(
+    uint32_t tupleSize,
+    std::map<size_t, uint32_t>& tupleSizes) {
+  auto normalTuples = getBooleanTuple(tupleSize);
+  auto compositeTuples = getCompositeTuple(tupleSizes);
+  return std::make_pair(std::move(normalTuples), std::move(compositeTuples));
+}
+
+std::vector<ITupleGenerator::BooleanTuple>
+TwoPartyTupleGenerator::generateNormalTuples(uint64_t size) {
+  {
+    std::unique_lock<std::mutex> scheduleLock(scheduleMutex_);
+    cv_.wait(scheduleLock, [this] { return toGenerate_.front() == Boolean; });
+  }
+
+  auto receiverMessagesFuture =
+      std::async([size, this]() { return receiverRcot_->rcot(size); });
+
+  auto sender0Messages = senderRcot_->rcot(size);
+  auto receiverMessages = receiverMessagesFuture.get();
+
+  {
+    std::unique_lock<std::mutex> scheduleLock(scheduleMutex_);
+    toGenerate_.pop_front();
+    cv_.notify_one();
+  }
+
+  return expandRCOTResults<false>(
+      std::move(sender0Messages), std::move(receiverMessages), 1);
+}
+
+std::vector<std::pair<__m128i, __m128i>>
+TwoPartyTupleGenerator::generateRcotResults(uint64_t size) {
+  {
+    std::unique_lock<std::mutex> scheduleLock(scheduleMutex_);
+    cv_.wait(scheduleLock, [this] { return toGenerate_.front() == Composite; });
+  }
+  auto receiverMessagesFuture =
+      std::async([size, this]() { return receiverRcot_->rcot(size); });
+
+  auto sender0Messages = senderRcot_->rcot(size);
+  auto receiverMessages = receiverMessagesFuture.get();
+
+  {
+    std::unique_lock<std::mutex> scheduleLock(scheduleMutex_);
+    toGenerate_.pop_front();
+    cv_.notify_one();
+  }
+
+  std::vector<std::pair<__m128i, __m128i>> rcotMessages(size);
+
+  for (size_t i = 0; i < size; i++) {
+    rcotMessages[i] =
+        std::make_pair(sender0Messages.at(i), receiverMessages.at(i));
+  }
+
+  return rcotMessages;
 }
 
 /**
@@ -59,69 +163,106 @@ TwoPartyTupleGenerator::getBooleanTuple(uint32_t size) {
  * = h(k_0) ^ h(k_r) ^ h(k_0) ^ h(k_p) ^ h(l_0) ^ h(l_r) ^ h(l_0) ^ h(l_p)
  * = h(k_r) ^ h(k_p) ^ h(l_r) ^ h(l_p)
  * = c_1 ^ c_2
+ *
+ * h is defined as a piecewise function depending on key and size
+ * h(key, n) = AES_HASH(0, key) & ((1 << n) - 1) if n <= 128
+ * h(key, n) = AES_PRG(key, n) if n > 128
  */
-std::vector<ITupleGenerator::BooleanTuple>
-TwoPartyTupleGenerator::generateTuples(uint64_t size) {
-  auto receiverMessagesFuture =
-      std::async([size, this]() { return receiverRcot_->rcot(size); });
+template <bool isComposite>
+std::vector<TwoPartyTupleGenerator::TupleType<isComposite>>
+TwoPartyTupleGenerator::expandRCOTResults(
+    std::vector<__m128i> sender0Messages,
+    std::vector<__m128i> receiverMessages,
+    size_t requestedTupleSize) {
+  std::vector<__m128i> sender1Messages(sender0Messages.size());
+  std::vector<bool> choiceBits(receiverMessages.size());
 
-  // k0 / l0
-  auto sender0Messages = senderRcot_->rcot(size);
-
-  std::vector<__m128i> sender1Messages(size);
-  for (size_t i = 0; i < size; ++i) {
-    // k1 / l1
-    sender1Messages[i] = _mm_xor_si128(sender0Messages.at(i), delta_);
+  for (size_t i = 0; i < sender0Messages.size(); i++) {
+    // k1 = k0 + delta1 / l1 = l0 + delta2
+    sender1Messages.at(i) = _mm_xor_si128(sender0Messages.at(i), delta_);
+    // r = lsb(lr) / p = lsb(kp)
+    choiceBits.at(i) = util::getLsb(receiverMessages.at(i));
   }
 
-  // lr / kp
-  auto receiverMessages = receiverMessagesFuture.get();
+  std::vector<TwoPartyTupleGenerator::TupleType<isComposite>> result(
+      sender0Messages.size());
+  if constexpr (!isComposite) {
+    // H(k0) / H(l0)
+    hashFromAes_.inPlaceHash(sender0Messages);
+    // H(k1) / H(l1)
+    hashFromAes_.inPlaceHash(sender1Messages);
+    // H(lr) / H(kp)
+    hashFromAes_.inPlaceHash(receiverMessages);
+    for (size_t i = 0; i < sender0Messages.size(); i++) {
+      // a1 = H(k0) ^ H(k1) / a2 = H(l0) ^ H(l1)
+      auto a = util::getLsb(sender0Messages.at(i)) ^
+          util::getLsb(sender1Messages.at(i));
+      // b1 = r / b2 = p
+      auto b = choiceBits.at(i);
+      // c1 = (H(k0) ^ H(k1)) & r ^ H(k0) + H(lr)
+      //    = H(kr) + H(lr) /
+      // c2 = (H(l0) ^ H(l1)) & p ^ H(l0) + H(kp)
+      //    = H(lp) + H(kp)
+      auto c = (a & b) ^ util::getLsb(sender0Messages.at(i)) ^
+          util::getLsb(receiverMessages.at(i));
 
-  std::vector<bool> choiceBits(size);
-  for (size_t i = 0; i < size; ++i) {
-    // r / p
-    choiceBits[i] = util::getLsb(receiverMessages.at(i));
+      result[i] = BooleanTuple(a, b, c);
+    }
+  } else {
+    if (requestedTupleSize <= 128) {
+      // H(k0) / H(l0)
+      hashFromAes_.inPlaceHash(sender0Messages);
+      // H(k1) / H(l1)
+      hashFromAes_.inPlaceHash(sender1Messages);
+      // H(lr) / H(kp)
+      hashFromAes_.inPlaceHash(receiverMessages);
+
+      for (size_t i = 0; i < sender0Messages.size(); i++) {
+        // a1 = H(k0) ^ H(k1) / a2 = H(l0) ^ H(l1)
+        __m128i a = _mm_xor_si128(sender0Messages.at(i), sender1Messages.at(i));
+        // b1 = r / b2 = p
+        bool b = choiceBits.at(i);
+        // c1 = (H(k0) ^ H(k1)) & r ^ H(k0) + H(lr)
+        //    = H(kr) + H(lr) /
+        // c2 = (H(l0) ^ H(l1)) & p ^ H(l0) + H(kp)
+        //    = H(lp) + H(kp)
+        __m128i c = b
+            ? _mm_xor_si128(
+                  _mm_xor_si128(a, sender0Messages.at(i)),
+                  receiverMessages.at(i))
+            : _mm_xor_si128(sender0Messages.at(i), receiverMessages.at(i));
+
+        std::vector<bool> aBits(requestedTupleSize);
+        std::vector<bool> cBits(requestedTupleSize);
+        util::extractLnbToVector(a, aBits);
+        util::extractLnbToVector(c, cBits);
+        result[i] = CompositeBooleanTuple(aBits, b, cBits);
+      }
+    } else {
+      for (size_t i = 0; i < sender0Messages.size(); i++) {
+        std::vector<bool> sender0Gen(requestedTupleSize);
+        std::vector<bool> sender1Gen(requestedTupleSize);
+        std::vector<bool> receiverGen(requestedTupleSize);
+        // H(k0) / H(l0)
+        util::AesPrg(sender0Messages.at(i)).getRandomBitsInPlace(sender0Gen);
+        // H(k1) / H(l1)
+        util::AesPrg(sender1Messages.at(i)).getRandomBitsInPlace(sender1Gen);
+        // H(lr) / H(kp)
+        util::AesPrg(receiverMessages.at(i)).getRandomBitsInPlace(receiverGen);
+
+        std::vector<bool> a(requestedTupleSize);
+        auto b = choiceBits.at(i);
+        std::vector<bool> c(requestedTupleSize);
+        for (size_t j = 0; j < requestedTupleSize; j++) {
+          a[j] = sender0Gen[j] ^ sender1Gen[j];
+          c[j] = (a[j] & b) ^ sender0Gen[j] ^ receiverGen[j];
+        }
+        result[i] = CompositeBooleanTuple(a, b, c);
+      }
+    }
   }
 
-  // H(k0) / H(l0)
-  hashFromAes_.inPlaceHash(sender0Messages);
-  // H(k1) / H(l1)
-  hashFromAes_.inPlaceHash(sender1Messages);
-  // H(lr) / H(kp)
-  hashFromAes_.inPlaceHash(receiverMessages);
-
-  std::vector<ITupleGenerator::BooleanTuple> booleanTuples(size);
-  for (size_t i = 0; i < size; i++) {
-    // a1 = H(k0) ^ H(k1) / a2 = H(l0) ^ H(l1)
-    auto a = util::getLsb(sender0Messages.at(i)) ^
-        util::getLsb(sender1Messages.at(i));
-    // b1 = r / b2 = p
-    auto b = choiceBits.at(i);
-    // c1 = (H(k0) ^ H(k1)) & r ^ H(k0) + H(lr)
-    //    = H(kr) + H(lr) /
-    // c2 = (H(l0) ^ H(l1)) & p ^ H(l0) + H(kp)
-    //    = H(lp) + H(kp)
-    auto c = (a & b) ^ util::getLsb(sender0Messages.at(i)) ^
-        util::getLsb(receiverMessages.at(i));
-
-    booleanTuples[i] = BooleanTuple(a, b, c);
-  }
-  return booleanTuples;
-}
-
-std::map<size_t, std::vector<ITupleGenerator::CompositeBooleanTuple>>
-TwoPartyTupleGenerator::getCompositeTuple(
-    std::map<size_t, uint32_t>& tupleSizes) {
-  throw std::runtime_error("Not implemented");
-}
-
-std::pair<
-    std::vector<ITupleGenerator::BooleanTuple>,
-    std::map<size_t, std::vector<ITupleGenerator::CompositeBooleanTuple>>>
-TwoPartyTupleGenerator::getNormalAndCompositeBooleanTuples(
-    uint32_t tupleSize,
-    std::map<size_t, uint32_t>& tupleSizes) {
-  throw std::runtime_error("Not implemented");
+  return result;
 }
 
 std::pair<uint64_t, uint64_t> TwoPartyTupleGenerator::getTrafficStatistics()

--- a/fbpcf/engine/tuple_generator/TwoPartyTupleGenerator.h
+++ b/fbpcf/engine/tuple_generator/TwoPartyTupleGenerator.h
@@ -39,7 +39,7 @@ class TwoPartyTupleGenerator final : public ITupleGenerator {
    * @inherit doc
    */
   std::map<size_t, std::vector<CompositeBooleanTuple>> getCompositeTuple(
-      std::map<size_t, uint32_t>& tupleSizes) override;
+      const std::map<size_t, uint32_t>& tupleSizes) override;
 
   /**
    * @inherit doc
@@ -49,7 +49,11 @@ class TwoPartyTupleGenerator final : public ITupleGenerator {
       std::map<size_t, std::vector<CompositeBooleanTuple>>>
   getNormalAndCompositeBooleanTuples(
       uint32_t tupleSize,
-      std::map<size_t, uint32_t>& compositeTupleSizes) override;
+      const std::map<size_t, uint32_t>& compositeTupleSizes) override;
+
+  bool supportsCompositeTupleGeneration() override {
+    return true;
+  }
 
   /**
    * @inherit doc

--- a/fbpcf/engine/tuple_generator/oblivious_transfer/RcotBasedBidirectionObliviousTransfer_impl.h
+++ b/fbpcf/engine/tuple_generator/oblivious_transfer/RcotBasedBidirectionObliviousTransfer_impl.h
@@ -86,7 +86,7 @@ std::vector<T> RcotBasedBidirectionObliviousTransfer<T>::biDirectionOT(
   std::vector<T> maskedInput1(otSize);
 
   for (size_t i = 0; i < otSize; i++) {
-    // h(key, n) = key & (1 << |x| - 1) if n >=128
+    // h(key, n) = AES_HASH(0, key) & ((1 << n) - 1) if n <= 128
     // h(key, n) = AES_PRG(key, n) if n > 128
     // mask(x, key) = x + h(key, |x|)
 

--- a/fbpcf/engine/tuple_generator/test/TupleGeneratorTest.cpp
+++ b/fbpcf/engine/tuple_generator/test/TupleGeneratorTest.cpp
@@ -65,25 +65,25 @@ void assertResults(
       }
 
       for (int i = 0; i < tupleCount; i++) {
-        std::vector<bool> a(compositeSize);
-        bool b = false;
+        bool a = false;
+        std::vector<bool> b(compositeSize);
         std::vector<bool> c(compositeSize);
 
         for (int j = 0; j < numberOfParty; j++) {
-          b ^= std::get<1>(results[j]).at(compositeSize)[i].getB();
-          auto aShares = std::get<1>(results[j]).at(compositeSize)[i].getA();
+          a ^= std::get<1>(results[j]).at(compositeSize)[i].getA();
+          auto bShares = std::get<1>(results[j]).at(compositeSize)[i].getB();
           auto cShares = std::get<1>(results[j]).at(compositeSize)[i].getC();
 
-          ASSERT_EQ(aShares.size(), compositeSize);
+          ASSERT_EQ(bShares.size(), compositeSize);
           ASSERT_EQ(cShares.size(), compositeSize);
           for (int k = 0; k < compositeSize; k++) {
-            a.at(k) = a.at(k) ^ aShares[k];
+            b.at(k) = b.at(k) ^ bShares[k];
             c.at(k) = c.at(k) ^ cShares[k];
           }
         }
 
         for (int k = 0; k < compositeSize; k++) {
-          ASSERT_EQ(c[k], a[k] & b);
+          ASSERT_EQ(c[k], a & b[k]);
         }
       }
     }

--- a/fbpcf/engine/tuple_generator/test/TupleGeneratorTestHelper.h
+++ b/fbpcf/engine/tuple_generator/test/TupleGeneratorTestHelper.h
@@ -137,4 +137,19 @@ createTwoPartyTupleGeneratorFactoryWithRcotExtender(
       kTestBufferSize);
 }
 
+inline std::unique_ptr<ITupleGeneratorFactory>
+createTwoPartyTupleGeneratorFactoryWithRcotExtenderAndSmallBuffer(
+    int /*numberOfParty*/,
+    int myId,
+    communication::IPartyCommunicationAgentFactory& agentFactory) {
+  auto rcot = oblivious_transfer::createFerretRcotFactory(
+      kTestExtendedSize, kTestBaseSize, kTestWeight);
+  return std::make_unique<TwoPartyTupleGeneratorFactory>(
+      std::move(rcot),
+      std::reference_wrapper<communication::IPartyCommunicationAgentFactory>(
+          agentFactory),
+      myId,
+      1);
+}
+
 } // namespace fbpcf::engine::tuple_generator


### PR DESCRIPTION
Summary:
Couple of small changes in this diff. Separating out from next diff to ease review

- Make composite tuple input map const
- Switch order of composite tuple from `a = vec<bool>` and `b = bool` to `a = bool` and `b = vec<bool>`. This makes consuming the tuples in the Secret Share engine consistent with normal. (i.e the secrets to be revealed are `u + a` and `v[i] + b[i]` rather than `u + b` and `v[i] + a[i]`.
- Add boolean function to indicate whether composite tuples are supported and won't throw exception

Reviewed By: elliottlawrence

Differential Revision: D35197215

