### PR TITLE
Utilize composite tuples in SecretShareEngine AND execution

### DIFF
--- a/fbpcf/engine/SecretShareEngine.h
+++ b/fbpcf/engine/SecretShareEngine.h
@@ -296,15 +296,39 @@ class SecretShareEngine final : public ISecretShareEngine {
       std::vector<ScheduledBatchAND>& batchAnds,
       std::vector<ScheduledCompositeAND>& compositeAnds,
       std::vector<ScheduledBatchCompositeAND>& batchCompositeAnds,
-      std::vector<tuple_generator::ITupleGenerator::BooleanTuple>& tuples);
+      std::vector<tuple_generator::ITupleGenerator::BooleanTuple>& normalTuples,
+      std::map<
+          size_t,
+          std::vector<tuple_generator::ITupleGenerator::CompositeBooleanTuple>>&
+          compositeTuples,
+      size_t openedSecretCount);
 
   ExecutionResults computeExecutionResultsFromOpenedShares(
       std::vector<ScheduledAND>& ands,
       std::vector<ScheduledBatchAND>& batchAnds,
       std::vector<ScheduledCompositeAND>& compositeAnds,
       std::vector<ScheduledBatchCompositeAND>& batchCompositeAnds,
-      std::vector<bool> openedSecrets,
-      std::vector<tuple_generator::ITupleGenerator::BooleanTuple> tuples);
+      std::vector<bool>& openedSecrets,
+      std::vector<tuple_generator::ITupleGenerator::BooleanTuple>& normalTuples,
+      std::map<
+          size_t,
+          std::vector<tuple_generator::ITupleGenerator::CompositeBooleanTuple>>&
+          compositeTuples);
+
+  std::vector<bool> computeSecretSharesToOpenLegacy(
+      std::vector<ScheduledAND>& ands,
+      std::vector<ScheduledBatchAND>& batchAnds,
+      std::vector<ScheduledCompositeAND>& compositeAnds,
+      std::vector<ScheduledBatchCompositeAND>& batchCompositeAnds,
+      std::vector<tuple_generator::ITupleGenerator::BooleanTuple>& tuples);
+
+  ExecutionResults computeExecutionResultsFromOpenedSharesLegacy(
+      std::vector<ScheduledAND>& ands,
+      std::vector<ScheduledBatchAND>& batchAnds,
+      std::vector<ScheduledCompositeAND>& compositeAnds,
+      std::vector<ScheduledBatchCompositeAND>& batchCompositeAnds,
+      std::vector<bool>& openedSecrets,
+      std::vector<tuple_generator::ITupleGenerator::BooleanTuple>& tuples);
 
   std::unique_ptr<tuple_generator::ITupleGenerator> tupleGenerator_;
   std::unique_ptr<communication::ISecretShareEngineCommunicationAgent>

--- a/fbpcf/test/TestHelper.h
+++ b/fbpcf/test/TestHelper.h
@@ -12,6 +12,7 @@
 #include <emmintrin.h>
 #include <smmintrin.h>
 
+#include "fbpcf/engine/SecretShareEngineFactory.h"
 #include "fbpcf/engine/communication/IPartyCommunicationAgentFactory.h"
 #include "fbpcf/scheduler/IScheduler.h"
 #include "fbpcf/scheduler/SchedulerHelper.h"


### PR DESCRIPTION
Summary:
Replaces the current dummy composite AND implementation in the SSE engine which just uses a regular tuple for each composite value.

- Added two new methods for computing secret shares to reveal and to fill in results from revealed shares
- Updated Secret Share engine test to use real engine (dummy engine will always have a = b so the logic wasn't being tested well)

Differential Revision: D35195299

