### PR TITLE
Fix race condition when assigning version string

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,13 +23,8 @@ jobs:
       contents: write
       packages: write
 
-    outputs:
-      version_tag: ${{ steps.create_version.outputs.version_tag }}
-
     steps:
     - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
 
     - name: Build fbpcf docker image
       run: |
@@ -46,15 +41,6 @@ jobs:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Create version string
-      id: create_version
-      uses: paulhatch/semantic-version@v4.0.2
-      with:
-        tag_prefix: "v"
-        major_pattern: "((MAJOR))"
-        minor_pattern: "((MINOR))"
-        format: "${major}.${minor}.${patch}-pre${increment}"
 
     - name: Clone latest stable fbpcs
       run: |
@@ -73,7 +59,6 @@ jobs:
     - name: Tag fbpcf docker image
       run: |
         docker tag ${{ env.LOCAL_IMAGE_NAME }} ${{ env.REGISTRY_IMAGE_NAME }}:${{ github.sha }}
-        docker tag ${{ env.LOCAL_IMAGE_NAME }} ${{ env.REGISTRY_IMAGE_NAME }}:${{ steps.create_version.outputs.version }}
 
     - name: Push fbpcf image to registry
       run: |
@@ -335,6 +320,10 @@ jobs:
       packages: write
 
     steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
     - name: Log into registry ${{ env.REGISTRY }}
       uses: docker/login-action@v1
       with:
@@ -342,12 +331,21 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Create version string
+      id: create_version
+      uses: paulhatch/semantic-version@v4.0.2
+      with:
+        tag_prefix: "v"
+        major_pattern: "((MAJOR))"
+        minor_pattern: "((MINOR))"
+        format: "${major}.${minor}.${patch}-pre${increment}"
+
     - name: Add tag to commit
       id: tag_version
       uses: mathieudutour/github-tag-action@v6.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        custom_tag: ${{ needs.build_prerelease_images.outputs.version_tag }}
+        custom_tag: ${{ steps.create_version.outputs.version_tag }}
         tag_prefix: ""
 
     - name: Set output
@@ -361,7 +359,7 @@ jobs:
     - name: Tag Docker image
       run: |
         docker tag ${{ env.REGISTRY_IMAGE_NAME }}:${{ github.sha }} ${{ env.REGISTRY_IMAGE_NAME }}:${{ steps.vars.outputs.ref }}
-        docker tag ${{ env.REGISTRY_IMAGE_NAME }}:${{ github.sha }} ${{ env.REGISTRY_IMAGE_NAME }}:${{ needs.build_prerelease_images.outputs.version_tag }}
+        docker tag ${{ env.REGISTRY_IMAGE_NAME }}:${{ github.sha }} ${{ env.REGISTRY_IMAGE_NAME }}:${{ steps.create_version.outputs.version_tag }}
         docker tag ${{ env.REGISTRY_IMAGE_NAME }}:${{ github.sha }} ${{ env.REGISTRY_IMAGE_NAME }}:latest
 
     - name: Push Docker image
@@ -373,8 +371,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        release_name: ${{ needs.build_prerelease_images.outputs.version_tag }}
-        tag_name: ${{ needs.build_prerelease_images.outputs.version_tag }}
+        release_name: ${{ steps.create_version.outputs.version_tag }}
+        tag_name: ${{ steps.create_version.outputs.version_tag }}
 
     - name: Cleanup
       run: |


### PR DESCRIPTION
Summary:
Last night, a workflow failed with an interesting issue: https://fburl.com/xov78dbj

There were two commits landing at similar times, and the following sequence of events happened
1) `build_prerelease_image` of commit 1 was executed. it was assigned a version string of 1.0.3.
2) Then `private_attribution_e2e_test`/`lift` were executed for commit 1
3) The github executor decided to then execute `build_prerelease_image` for commit 2 (it does that a lot, the granularity is at the job level not the workflow level)
4) `build_prerelease_image` for commit 2 examined the history of the repo and also assigned a version string of 1.0.3 because there was never a tag of 1.0.3.
5) commit 1 ran `tag_and_push` and created a release of version 1.0.3.
6) commit 2 tried to release 1.0.3 and got an error

This diff moves the version string generation into the final tag and push stage so it will be atomic.

The only functionality we lose here is that there is no increment assigned for prereleases. This is fine for now since it's totally unused. We can revisit this.

Differential Revision: D35255590

