### PR TITLE
Fix a bug for a corner case in Intp

### DIFF
--- a/fbpcf/mpc_std_lib/util/Intp_impl.h
+++ b/fbpcf/mpc_std_lib/util/Intp_impl.h
@@ -58,7 +58,15 @@ class Intp {
   }
 
   Intp<isSigned, width> operator-() const {
-    return Intp<isSigned, width>(round(kOffSet - v_));
+    if constexpr (isSigned) {
+      if (v_ == kMin) {
+        return v_;
+      } else {
+        return -v_;
+      }
+    } else {
+      return kOffSet - v_;
+    }
   }
 
   Intp<isSigned, width> operator-(const Intp<isSigned, width>& other) const {


### PR DESCRIPTION
Summary:
As title.
The inverse of `kMin` should still be `kMin`.
E.g. for 8bit signed integer, the range is [-128, 127]. The inverse of -128 is 128, which is mapped to -128 again.

When k is an unsigned n-bit integer, then -k is defined as 2^n - k.

Reviewed By: ashiquemfb

Differential Revision: D35262756

