### PR TITLE
Fixing Bit OR operator in method name

### DIFF
--- a/fbpcf/frontend/Bit.h
+++ b/fbpcf/frontend/Bit.h
@@ -98,6 +98,10 @@ class Bit : public scheduler::SchedulerKeeper<schedulerId> {
       const Bit<isSecretOther, schedulerId, usingBatch>& other) const;
 
   template <bool isSecretOther>
+  Bit<isSecret || isSecretOther, schedulerId, usingBatch> operator|(
+      const Bit<isSecretOther, schedulerId, usingBatch>& other) const;
+
+  template <bool isSecretOther>
   Bit<isSecret || isSecretOther, schedulerId, usingBatch> operator||(
       const Bit<isSecretOther, schedulerId, usingBatch>& other) const;
 

--- a/fbpcf/frontend/Bit_impl.h
+++ b/fbpcf/frontend/Bit_impl.h
@@ -244,6 +244,14 @@ Bit<isSecret, schedulerId, usingBatch>::operator^(
 template <bool isSecret, int schedulerId, bool usingBatch>
 template <bool isSecretOther>
 Bit<isSecret || isSecretOther, schedulerId, usingBatch>
+Bit<isSecret, schedulerId, usingBatch>::operator|(
+    const Bit<isSecretOther, schedulerId, usingBatch>& other) const {
+  return (*this ^ other) ^ (*this & other);
+}
+
+template <bool isSecret, int schedulerId, bool usingBatch>
+template <bool isSecretOther>
+Bit<isSecret || isSecretOther, schedulerId, usingBatch>
 Bit<isSecret, schedulerId, usingBatch>::operator||(
     const Bit<isSecretOther, schedulerId, usingBatch>& other) const {
   return (*this ^ other) ^ (*this & other);

--- a/fbpcf/frontend/test/BitTest.cpp
+++ b/fbpcf/frontend/test/BitTest.cpp
@@ -327,11 +327,11 @@ TEST(BitTest, testOr) {
     PubBit b4(v);
 
     // id 7
-    auto b5 = b1 || b2;
+    auto b5 = b1 | b2;
     // id 10
-    auto b6 = b1 || b3;
+    auto b6 = b1 | b3;
     // id 13
-    auto b7 = b3 || b4;
+    auto b7 = b3 | b4;
   }
   scheduler::SchedulerKeeper<0>::freeScheduler();
 }
@@ -367,9 +367,9 @@ TEST(BitTest, testOrBatch) {
 
     PubBitBatch b4(v);
 
-    auto b5 = b1 || b2;
-    auto b6 = b1 || b3;
-    auto b7 = b3 || b4;
+    auto b5 = b1 | b2;
+    auto b6 = b1 | b3;
+    auto b7 = b3 | b4;
   }
   scheduler::SchedulerKeeper<0>::freeScheduler();
 }
@@ -395,9 +395,9 @@ TEST(BitTest, testOrPlaintextScheduler) {
         SecBit b3(v3, partyId);
         PubBit b4(v4);
 
-        auto b5 = b1 || b3;
-        auto b6 = b2 || b4;
-        auto b7 = b1 || b4;
+        auto b5 = b1 | b3;
+        auto b6 = b2 | b4;
+        auto b7 = b1 | b4;
 
         EXPECT_EQ(b5.openToParty(partyId).getValue(), v1 || v3);
         EXPECT_EQ(b6.getValue(), v2 || v4);
@@ -429,9 +429,9 @@ TEST(BitTest, testOrBatchPlaintextScheduler) {
         SecBitBatch b3({v3, v1}, partyId);
         PubBitBatch b4({v4, v2});
 
-        auto b5 = b1 || b3;
-        auto b6 = b2 || b4;
-        auto b7 = b1 || b4;
+        auto b5 = b1 | b3;
+        auto b6 = b2 | b4;
+        auto b7 = b1 | b4;
 
         auto output1 = b5.openToParty(partyId).getValue();
         auto output2 = b6.getValue();


### PR DESCRIPTION
Summary: A method was incorrectly implemented, in the name, with logic operator || instead of the bit operator |. This diff corrects that.

Differential Revision: D35271995

