### PR TITLE
Fix fbpcf github e2e tests

### DIFF
--- a/fbpcf/tests/github/fbpcf_e2e_aws.yml
+++ b/fbpcf/tests/github/fbpcf_e2e_aws.yml
@@ -26,6 +26,7 @@ private_computation:
         constructor:
           tmp_directory: /tmp
           binary_version: latest
+          repository_path: LOCAL
     OneDockerServiceConfig:
       constructor:
         task_definition: onedocker-task-fbpcf-e2e-workflow:7#onedocker-container-fbpcf-e2e-workflow


### PR DESCRIPTION
Summary:
Our "Publish Docker image" github action is failing with an INPUT_DATA_VALIDATION_FAILED error: https://github.com/facebookresearch/fbpcf/actions/runs/2080666541

Based on [this comment thread](https://fb.workplace.com/groups/988664215009283/posts/1143773839498319/?comment_id=1145096412699395&reply_comment_id=1145105812698455) and the fix in D35223183, I think we need to do the same thing for fbpcf.

Differential Revision: D35338684

