### PR TITLE
Slightly refactor async buffer object

### DIFF
--- a/fbpcf/engine/tuple_generator/TupleGenerator.cpp
+++ b/fbpcf/engine/tuple_generator/TupleGenerator.cpp
@@ -19,7 +19,9 @@ TupleGenerator::TupleGenerator(
     : productShareGeneratorMap_{std::move(productShareGeneratorMap)},
       prg_{std::move(prg)},
       asyncBuffer_{bufferSize, [this](uint64_t size) {
-                     return generateTuples(size);
+                     return std::async(
+                         [this](uint64_t size) { return generateTuples(size); },
+                         size);
                    }} {}
 
 std::vector<ITupleGenerator::BooleanTuple> TupleGenerator::getBooleanTuple(

--- a/fbpcf/engine/tuple_generator/TwoPartyTupleGenerator.cpp
+++ b/fbpcf/engine/tuple_generator/TwoPartyTupleGenerator.cpp
@@ -24,7 +24,9 @@ TwoPartyTupleGenerator::TwoPartyTupleGenerator(
       receiverRcot_{std::move(receiverRcot)},
       delta_{delta},
       buffer_{bufferSize, [this](uint64_t size) {
-                return generateTuples(size);
+                return std::async(
+                    [this](uint64_t size) { return generateTuples(size); },
+                    size);
               }} {}
 
 std::vector<ITupleGenerator::BooleanTuple>

--- a/fbpcf/engine/util/AesPrg.cpp
+++ b/fbpcf/engine/util/AesPrg.cpp
@@ -16,7 +16,11 @@ AesPrg::AesPrg(__m128i seed, int bufferSize)
       prgCounter_(0),
       asyncBuffer_{std::make_unique<AsyncBuffer<unsigned char>>(
           sizeof(__m128i) * bufferSize,
-          [this](uint64_t size) { return generateRandomData(size); })} {}
+          [this](uint64_t size) {
+            return std::async(
+                [this](uint64_t size) { return generateRandomData(size); },
+                size);
+          })} {}
 
 AesPrg::AesPrg(__m128i seed)
     : cipher_(seed), prgCounter_(0), asyncBuffer_(nullptr) {}

--- a/fbpcf/engine/util/AsyncBuffer.h
+++ b/fbpcf/engine/util/AsyncBuffer.h
@@ -23,11 +23,11 @@ class AsyncBuffer {
  public:
   AsyncBuffer(
       uint64_t bufferSize,
-      std::function<std::vector<T>(uint64_t size)> generateData)
+      std::function<std::future<std::vector<T>>(uint64_t size)> generateData)
       : bufferSize_{bufferSize},
         bufferIndex_{bufferSize},
         generateData_{generateData} {
-    futureBuffer_ = std::async(generateData_, bufferSize_);
+    futureBuffer_ = generateData_(bufferSize_);
   }
 
   ~AsyncBuffer() {
@@ -40,7 +40,7 @@ class AsyncBuffer {
       if (bufferIndex_ >= bufferSize_) {
         buffer_ = futureBuffer_.get();
         bufferIndex_ = 0;
-        futureBuffer_ = std::async(generateData_, bufferSize_);
+        futureBuffer_ = generateData_(bufferSize_);
       }
 
       auto insertSize = std::min(size - rst.size(), bufferSize_ - bufferIndex_);
@@ -57,7 +57,7 @@ class AsyncBuffer {
   uint64_t bufferSize_;
   uint64_t bufferIndex_;
 
-  std::function<std::vector<T>(uint64_t size)> generateData_;
+  std::function<std::future<std::vector<T>>(uint64_t size)> generateData_;
 
   std::vector<T> buffer_;
 

--- a/fbpcf/engine/util/test/AsyncBufferTest.cpp
+++ b/fbpcf/engine/util/test/AsyncBufferTest.cpp
@@ -18,11 +18,15 @@ TEST(AsyncBufferTest, TestGetData) {
       AsyncBuffer<int32_t>(100, [&index, &generationCount](uint64_t size) {
         generationCount++;
 
-        std::vector<int32_t> res;
-        for (auto i = 0; i < size; ++i) {
-          res.push_back(index++);
-        }
-        return res;
+        return std::async(
+            [&index](int size) {
+              std::vector<int32_t> res;
+              for (auto i = 0; i < size; ++i) {
+                res.push_back(index++);
+              }
+              return res;
+            },
+            size);
       });
 
   // The data is generated asynchronously.


### PR DESCRIPTION
Summary:
as title.
Instead of using the hardcoded async, now asyncBuffer will ask the creater to specify how to potentially "multi-threading". This gives the caller more flexibility.

Reviewed By: elliottlawrence

Differential Revision: D35373180

