### PR TITLE
Remove the depreciated || operator

### DIFF
--- a/fbpcf/frontend/Bit.h
+++ b/fbpcf/frontend/Bit.h
@@ -101,10 +101,6 @@ class Bit : public scheduler::SchedulerKeeper<schedulerId> {
   Bit<isSecret || isSecretOther, schedulerId, usingBatch> operator|(
       const Bit<isSecretOther, schedulerId, usingBatch>& other) const;
 
-  template <bool isSecretOther>
-  Bit<isSecret || isSecretOther, schedulerId, usingBatch> operator||(
-      const Bit<isSecretOther, schedulerId, usingBatch>& other) const;
-
   /**
    * Create a new bit that will carry the plaintext signal of this bit.
    * However only party with partyId will receive the actual value, other

--- a/fbpcf/frontend/Bit_impl.h
+++ b/fbpcf/frontend/Bit_impl.h
@@ -250,14 +250,6 @@ Bit<isSecret, schedulerId, usingBatch>::operator|(
 }
 
 template <bool isSecret, int schedulerId, bool usingBatch>
-template <bool isSecretOther>
-Bit<isSecret || isSecretOther, schedulerId, usingBatch>
-Bit<isSecret, schedulerId, usingBatch>::operator||(
-    const Bit<isSecretOther, schedulerId, usingBatch>& other) const {
-  return (*this ^ other) ^ (*this & other);
-}
-
-template <bool isSecret, int schedulerId, bool usingBatch>
 typename Bit<isSecret, schedulerId, usingBatch>::BoolType
 Bit<isSecret, schedulerId, usingBatch>::getValue() const {
   static_assert(!isSecret, "Can't get value on secret wires.");

--- a/fbpcf/frontend/test/benchmarks/FrontendBenchmark.cpp
+++ b/fbpcf/frontend/test/benchmarks/FrontendBenchmark.cpp
@@ -153,7 +153,7 @@ class BitOrGame : public BitGame<schedulerId, usingBatch> {
   typename BitGame<schedulerId, usingBatch>::SecBit operation(
       typename BitGame<schedulerId, usingBatch>::SecBit b1,
       typename BitGame<schedulerId, usingBatch>::SecBit b2) override {
-    return b1 || b2;
+    return b1 | b2;
   }
 };
 


### PR DESCRIPTION
Summary: As title

Differential Revision: D35443622

