### PR TITLE
Increase benchmark size in tuple generator

### DIFF
--- a/fbpcf/engine/tuple_generator/test/benchmarks/TupleGeneratorBenchmark.cpp
+++ b/fbpcf/engine/tuple_generator/test/benchmarks/TupleGeneratorBenchmark.cpp
@@ -69,7 +69,7 @@ class ProductShareGeneratorBenchmark : public util::NetworkedBenchmark {
   }
 
  private:
-  size_t size_ = 1000000;
+  size_t size_ = 10000000;
 
   std::unique_ptr<communication::IPartyCommunicationAgentFactory>
       agentFactory0_;
@@ -133,7 +133,7 @@ class BaseTupleGeneratorBenchmark : public util::NetworkedBenchmark {
   size_t bufferSize_ = 1600000;
 
  private:
-  size_t size_ = 1000000;
+  size_t size_ = 10000000;
 
   std::unique_ptr<communication::IPartyCommunicationAgentFactory>
       agentFactory0_;


### PR DESCRIPTION
Summary:
Curently the benckmark for tuple generators are a bit inaccurate - the leftover results from setup is too many such that the actual test is not testing regenerating buffers. This diff is to fix this issue.

Before change:

{F719539161}

After change:

Reviewed By: elliottlawrence

Differential Revision: D35479302

