### PR TITLE
Use openSSL to implement TLS communication

### DIFF
--- a/fbpcf/engine/communication/SocketPartyCommunicationAgent.h
+++ b/fbpcf/engine/communication/SocketPartyCommunicationAgent.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <openssl/ssl.h>
 #include <string>
 
 #include "fbpcf/engine/communication/IPartyCommunicationAgent.h"
@@ -60,6 +61,12 @@ class SocketPartyCommunicationAgent final : public IPartyCommunicationAgent {
   void openServerPort(int portNo);
   void openClientPort(const std::string& serverAddress, int portNo);
 
+  void openServerPortWithTls(int portNo, std::string tlsDir);
+  void openClientPortWithTls(
+      const std::string& serverAddress,
+      int portNo,
+      std::string tlsDir);
+
   /*
    * helper functions for shared code between TLS and non-TLS implementations
    */
@@ -70,6 +77,8 @@ class SocketPartyCommunicationAgent final : public IPartyCommunicationAgent {
 
   uint64_t sentData_;
   uint64_t receivedData_;
+
+  SSL* ssl_;
 };
 
 } // namespace fbpcf::engine::communication


### PR DESCRIPTION
Summary:
NOTE:This is a relatively complex diff, but it is necessary because we need all functionality to be implemented to be able to test end to end (client setup, server setup, read, write, and destroy). Otherwise, each individual diff would be untestable.

This diff sets up end to end TLS communication between the partner and publisher.
- Use SSL_CTX_use_certificate_file and SSL_CTX_use_Privatekey_file to load credentials.
- Use SSL_accept to listen for handshake requests from a client
- On the client side, use SSL_connect to initiate a handshake
- Both parties use SSL_read and SSL_write to communicate

There are a few other nuances (blocking vs nonblocking reads, passphrases) that are all explained with inline comments.

There are a few NON-goals of this diff
1) We are not testing whether this works on PC infra. That will happen in the future.
2) We are not analyzing performance regressions.

Differential Revision: D35555496

