### PR TITLE
NonAesCircuit as a placeholder.

### DIFF
--- a/fbpcf/mpc_std_lib/aes_circuit/DummyAesCircuit.h
+++ b/fbpcf/mpc_std_lib/aes_circuit/DummyAesCircuit.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "fbpcf/mpc_std_lib/aes_circuit/IAesCircuit.h"
+
+namespace fbpcf::mpc_std_lib::aes_circuit::insecure {
+
+/*
+ * This is merely a placeholder that basically does nothing other than input
+ * validation. This object is only meant to be used for test purpose. When
+ * testing, the corresponding encryption/decryption process should also do
+ * nothing to make the final result correct.
+ */
+template <typename BitType>
+class DummyAesCircuit final : public IAesCircuit<BitType> {
+ private:
+  std::vector<BitType> encrypt_impl(
+      const std::vector<BitType>& plaintext,
+      const std::vector<BitType>& /* expandedEncKey */) const {
+    return plaintext;
+  }
+
+  /**
+   * @inherit doc
+   */
+  std::vector<BitType> decrypt_impl(
+      const std::vector<BitType>& ciphertext,
+      const std::vector<BitType>& /* expandedDecKey */) const {
+    return ciphertext;
+  }
+};
+
+} // namespace fbpcf::mpc_std_lib::aes_circuit::insecure

--- a/fbpcf/mpc_std_lib/aes_circuit/DummyAesCircuitFactory.h
+++ b/fbpcf/mpc_std_lib/aes_circuit/DummyAesCircuitFactory.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "fbpcf/mpc_std_lib/aes_circuit/DummyAesCircuit.h"
+#include "fbpcf/mpc_std_lib/aes_circuit/IAesCircuitFactory.h"
+
+namespace fbpcf::mpc_std_lib::aes_circuit::insecure {
+
+template <typename BitType>
+class DummyAesCircuitFactory {
+ public:
+  std::unique_ptr<IAesCircuit<BitType>> create() {
+    return std::make_unique<insecure::DummyAesCircuit<BitType>>();
+  }
+
+  typename IAesCircuitFactory<BitType>::CircuitType getCircuitType() const {
+    return IAesCircuitFactory<BitType>::CircuitType::Dummy;
+  }
+};
+
+} // namespace fbpcf::mpc_std_lib::aes_circuit::insecure

--- a/fbpcf/mpc_std_lib/aes_circuit/IAesCircuit.h
+++ b/fbpcf/mpc_std_lib/aes_circuit/IAesCircuit.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <stdexcept>
+#include <vector>
+
+namespace fbpcf::mpc_std_lib::aes_circuit {
+
+/*
+ * An AES circuit object implements the AES algorithm at a conceptual-bit level.
+ * This "conceptual bit" can be anything that has an isomorphic behavior
+ * regarding AND and XOR as normal bits. Currently we only support decryption.
+ * We may add support for encryption in future.
+ */
+/**
+ * Bit type can be either bool or any MPC Bit types.
+ */
+template <typename BitType>
+class IAesCircuit {
+ public:
+  static const size_t kExpandedKeyWidth =
+      1408; /** The expanded AES key contains 11 16-byte keys. 1408 = 11 * 16 *
+               8 **/
+
+  virtual ~IAesCircuit() = default;
+
+  /**
+   * Encrypt the plaintext with the expanded key.
+   * @param plaintext the plaintext for AES inside MPC. It must be a
+   * multiplication of 128.
+   * @param expandedEncKey the expanded enc AES key inside MPC. It must be the
+   * expected expanded key size.
+   * @return the ciphertext inside MPC;
+   */
+  std::vector<BitType> encrypt(
+      const std::vector<BitType>& plaintext,
+      const std::vector<BitType>& expandedEncKey) const {
+    if (plaintext.size() % 128 != 0) {
+      throw std::runtime_error("Input plaintext must be a multiple of 128");
+    }
+    if (expandedEncKey.size() != kExpandedKeyWidth) {
+      throw std::runtime_error("Expanded Enc AES key must be 1408 bits.");
+    }
+    return encrypt_impl(plaintext, expandedEncKey);
+  }
+
+  /**
+   * decrypt the ciphertext with the expanded key.
+   * @param ciphertext the ciphertext for AES inside MPC. It must be a
+   * multiplication of 128.
+   * @param expandedKey the expanded AES key inside MPC. It must be the
+   * expected expanded key size.
+   * @return the plaintext inside MPC;
+   */
+  std::vector<BitType> decrypt(
+      const std::vector<BitType>& ciphertext,
+      const std::vector<BitType>& expandedDecKey) const {
+    if (ciphertext.size() % 128 != 0) {
+      throw std::runtime_error("Input ciphertext must be a multiple of 128");
+    }
+    if (expandedDecKey.size() != kExpandedKeyWidth) {
+      throw std::runtime_error("Expanded Dec AES key must be 1408 bits.");
+    }
+    return decrypt_impl(ciphertext, expandedDecKey);
+  }
+
+ private:
+  virtual std::vector<BitType> encrypt_impl(
+      const std::vector<BitType>& plaintext,
+      const std::vector<BitType>& expandedEncKey) const = 0;
+
+  virtual std::vector<BitType> decrypt_impl(
+      const std::vector<BitType>& ciphertext,
+      const std::vector<BitType>& expandedDecKey) const = 0;
+};
+
+} // namespace fbpcf::mpc_std_lib::aes_circuit

--- a/fbpcf/mpc_std_lib/aes_circuit/IAesCircuitFactory.h
+++ b/fbpcf/mpc_std_lib/aes_circuit/IAesCircuitFactory.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "fbpcf/mpc_std_lib/aes_circuit/IAesCircuit.h"
+
+namespace fbpcf::mpc_std_lib::aes_circuit {
+
+template <typename BitType>
+class IAesCircuitFactory {
+ public:
+  virtual ~IAesCircuitFactory() = default;
+  virtual std::unique_ptr<IAesCircuit<BitType>> create() = 0;
+
+  enum CircuitType {
+    Dummy,
+    Secure,
+  };
+
+  virtual CircuitType getCircuitType() const = 0;
+};
+
+} // namespace fbpcf::mpc_std_lib::aes_circuit

--- a/fbpcf/mpc_std_lib/aes_circuit/test/AesCircuitTest.cpp
+++ b/fbpcf/mpc_std_lib/aes_circuit/test/AesCircuitTest.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <cmath>
+#include <future>
+#include <memory>
+#include <random>
+#include <unordered_map>
+
+#include "fbpcf/engine/communication/test/AgentFactoryCreationHelper.h"
+#include "fbpcf/mpc_std_lib/aes_circuit/DummyAesCircuitFactory.h"
+#include "fbpcf/mpc_std_lib/aes_circuit/IAesCircuit.h"
+#include "fbpcf/mpc_std_lib/util/test/util.h"
+#include "fbpcf/mpc_std_lib/util/util.h"
+#include "fbpcf/scheduler/SchedulerHelper.h"
+#include "fbpcf/test/TestHelper.h"
+
+namespace fbpcf::mpc_std_lib::aes_circuit {
+
+std::vector<bool> generateRandomPlaintext(int size = 128) {
+  std::random_device rd;
+  std::mt19937_64 e(rd());
+  std::uniform_int_distribution<uint8_t> dist(0, 1);
+
+  std::vector<bool> plaintext(size);
+  for (size_t i = 0; i < size; i++) {
+    plaintext[i] = dist(e);
+  }
+  return plaintext;
+}
+
+void testDummyAesCircuitInPlaintext(
+    std::shared_ptr<insecure::DummyAesCircuitFactory<bool>>
+        DummyAesCircuitFactory) {
+  auto DummyAesCircuit = DummyAesCircuitFactory->create();
+  auto plaintext = generateRandomPlaintext();
+  std::vector<bool> dummyKey(11 * 16 * 8);
+  auto rst1 = DummyAesCircuit->encrypt(plaintext, dummyKey);
+  testVectorEq(rst1, plaintext);
+  auto rst2 = DummyAesCircuit->decrypt(rst1, dummyKey);
+  testVectorEq(rst2, rst1);
+}
+
+TEST(AesCircuitTest, testDummyAesCircuit) {
+  testDummyAesCircuitInPlaintext(
+      std::make_unique<insecure::DummyAesCircuitFactory<bool>>());
+}
+
+} // namespace fbpcf::mpc_std_lib::aes_circuit


### PR DESCRIPTION
Summary: As title. This implementation do nothing but merely output the inputs. They are only meant to be used as placeholder for tests.

Reviewed By: chualynn

Differential Revision: D34507629

