### PR TITLE
Remove memcpy from EmpNetworkAdapter

### DIFF
--- a/fbpcf/engine/communication/IPartyCommunicationAgent.h
+++ b/fbpcf/engine/communication/IPartyCommunicationAgent.h
@@ -16,8 +16,11 @@
 #error "Machine must be little endian"
 #endif
 
-namespace fbpcf::engine::communication {
+namespace fbpcf::engine::util {
+class EmpNetworkAdapter;
+}
 
+namespace fbpcf::engine::communication {
 /**
  * This is the network API between two parties.
  * NOTE: sendT/receiveT only work when the two parties have the same endianness
@@ -89,6 +92,8 @@ class IPartyCommunicationAgent {
   virtual std::pair<uint64_t, uint64_t> getTrafficStatistics() const = 0;
 
  private:
+  friend class util::EmpNetworkAdapter;
+
   // convert a vector of bits into a vector of bytes
   static std::vector<unsigned char> compressToBytes(
       const std::vector<bool>& bits) {
@@ -125,6 +130,10 @@ class IPartyCommunicationAgent {
     }
     return bits;
   }
+
+  virtual void recvImpl(void* data, int nBytes) = 0;
+
+  virtual void sendImpl(const void* data, int nBytes) = 0;
 };
 
 template <>

--- a/fbpcf/engine/communication/InMemoryPartyCommunicationAgentHost.h
+++ b/fbpcf/engine/communication/InMemoryPartyCommunicationAgentHost.h
@@ -45,6 +45,10 @@ class InMemoryPartyCommunicationAgent final : public IPartyCommunicationAgent {
     return {sentData_, receivedData_};
   }
 
+  void recvImpl(void* data, int nBytes) override;
+
+  void sendImpl(const void* data, int nBytes) override;
+
  private:
   InMemoryPartyCommunicationAgentHost& host_;
   int myId_;

--- a/fbpcf/engine/communication/SocketPartyCommunicationAgent.h
+++ b/fbpcf/engine/communication/SocketPartyCommunicationAgent.h
@@ -57,6 +57,10 @@ class SocketPartyCommunicationAgent final : public IPartyCommunicationAgent {
     return {sentData_, receivedData_};
   }
 
+  void recvImpl(void* data, int nBytes) override;
+
+  void sendImpl(const void* data, int nBytes) override;
+
  private:
   void openServerPort(int portNo);
   void openClientPort(const std::string& serverAddress, int portNo);

--- a/fbpcf/engine/util/EmpNetworkAdapter.h
+++ b/fbpcf/engine/util/EmpNetworkAdapter.h
@@ -22,15 +22,12 @@ class EmpNetworkAdapter {
   explicit EmpNetworkAdapter(communication::IPartyCommunicationAgent& agent)
       : agent_(agent) {}
 
-  void send_data(const void* data, int nByte) {
-    std::vector<unsigned char> buffer(nByte);
-    memcpy(buffer.data(), data, nByte);
-    agent_.send(buffer);
+  void send_data(const void* data, int nBytes) {
+    agent_.sendImpl(data, nBytes);
   }
 
-  void recv_data(void* data, int nByte) {
-    auto buffer = agent_.receive(nByte);
-    memcpy(data, buffer.data(), nByte);
+  void recv_data(void* data, int nBytes) {
+    agent_.recvImpl(data, nBytes);
   }
 
   void send_block(const __m128i* data, int nBlock) {


### PR DESCRIPTION
Summary:
This diff remove `memcpy` from EmpNetworkAdapter to improve performance. `memcpy` is expensive, as it is essentially adding linear overhead for every single operation.

Changes:

- Add `send_impl` and `recv_impl` functions to IPartyCommunicationAgent
- Refactor classes that implemented IPartyCommunicationAgent to call `send_impl` and `recv_impl` in their respective `send` and `receive` functions
- Refactor EmpNetworkAdapter to use `send_impl` and `recv_impl`

Differential Revision: D35818108

