### PR TITLE
Migrate PID sharder to use new BufferedReader

### DIFF
--- a/fbpcf/aws/S3Util.cpp
+++ b/fbpcf/aws/S3Util.cpp
@@ -118,6 +118,8 @@ std::unique_ptr<Aws::S3::S3Client> createS3Client(
     config.proxySSLCertPath = std::getenv("AWS_PROXY_CERT_PATH");
   }
 
+  config.requestTimeoutMs = 30000;
+
   if (option.accessKeyId.has_value() && option.secretKey.has_value()) {
     Aws::Auth::AWSCredentials credentials(
         option.accessKeyId.value(), option.secretKey.value());


### PR DESCRIPTION
Summary:
This diff makes the change in production to use the new Buffered Reader. Google doc for context is linked below (internal only).

See test plan for full details of how this was tested.

There is one workaround about `SIGPIPE` that is explained with an in-line comment.

Differential Revision: D35729872

