### PR TITLE
Add fast mux operation to Int class

### DIFF
--- a/fbpcf/frontend/Bit.h
+++ b/fbpcf/frontend/Bit.h
@@ -93,6 +93,17 @@ class Bit : public scheduler::SchedulerKeeper<schedulerId> {
   Bit<isSecret || isSecretOther, schedulerId, usingBatch> operator&(
       const Bit<isSecretOther, schedulerId, usingBatch>& other) const;
 
+  template <bool isSecretOther, size_t width>
+  std::array<Bit<isSecret || isSecretOther, schedulerId, usingBatch>, width>
+  operator&(
+      const std::array<Bit<isSecretOther, schedulerId, usingBatch>, width>&
+          otherBits) const;
+
+  template <bool isSecretOther>
+  std::vector<Bit<isSecret || isSecretOther, schedulerId, usingBatch>>
+  operator&(const std::vector<Bit<isSecretOther, schedulerId, usingBatch>>&
+                otherBits) const;
+
   template <bool isSecretOther>
   Bit<isSecret || isSecretOther, schedulerId, usingBatch> operator^(
       const Bit<isSecretOther, schedulerId, usingBatch>& other) const;
@@ -125,6 +136,13 @@ class Bit : public scheduler::SchedulerKeeper<schedulerId> {
       std::shared_ptr<std::vector<uint32_t>> unbatchingStrategy) const;
 
  private:
+  template <bool isSecretOther>
+  std::vector<typename Bit<isSecret || isSecretOther, schedulerId, usingBatch>::
+                  WireType>
+  compositeAND(const std::vector<
+               typename Bit<isSecretOther, schedulerId, usingBatch>::WireType>&
+                   otherWires) const;
+
   void increaseReferenceCount(const WireType& v) const;
   void decreaseReferenceCount(const WireType& v) const;
   void moveId(WireType& dst, WireType& src) const;

--- a/fbpcf/frontend/Int.h
+++ b/fbpcf/frontend/Int.h
@@ -215,6 +215,34 @@ class Int {
   unbatching(std::shared_ptr<std::vector<uint32_t>> unbatchingStrategy) const;
 
  private:
+  /**
+   * Traditional multiplexer algorithm.
+   */
+  template <bool isSecretChoice, bool isSecretOther>
+  Int<isSigned,
+      width,
+      isSecret || isSecretChoice || isSecretOther,
+      schedulerId,
+      usingBatch>
+  slowMux(
+      const Bit<isSecretChoice, schedulerId, usingBatch>& choice,
+      const Int<isSigned, width, isSecretOther, schedulerId, usingBatch>& other)
+      const;
+
+  /**
+   * Alternate version of multiplexer which uses composite AND to compute result
+   */
+  template <bool isSecretChoice, bool isSecretOther>
+  Int<isSigned,
+      width,
+      isSecret || isSecretChoice || isSecretOther,
+      schedulerId,
+      usingBatch>
+  fastMux(
+      const Bit<isSecretChoice, schedulerId, usingBatch>& choice,
+      const Int<isSigned, width, isSecretOther, schedulerId, usingBatch>& other)
+      const;
+
   template <typename T>
   std::vector<UnitIntType> convertTo64BitIntVector(
       const std::vector<T>& src) const;


### PR DESCRIPTION
Summary:
Adds a fastMux API to the BitString and Int frontend classes. This API can be automatically turned on by setting the preprocessor flag

-DUSE_COMPOSITE_AND_FOR_MUX

Differential Revision: D34807936

