### PR TITLE
Create workflow to publish new dependency for emp when we upgrade

### DIFF
--- a/.github/workflows/emp-publish.yml
+++ b/.github/workflows/emp-publish.yml
@@ -1,0 +1,64 @@
+name: Build and publish emp dependency
+
+on:
+  workflow_dispatch:
+    inputs:
+      name:
+        description: 'Build and publish an fbpcf/emp image for a particular version'
+        default: "Run"
+      emp_release:
+        description: "The emp version to build and publish (e.g. 0.2.3)"
+        required: true
+        type: string
+      emp_tool_release:
+        description: "The emp-tool version to build and publish (e.g. 0.2.2)"
+        required: true
+        type: string
+      os:
+        description: "Which os to use. Currently only supports ubuntu"
+        required: false
+        type: str
+        default: "ubuntu"
+      os_release: "The os version to use (e.g. 20.04 for ubuntu)"
+        required: false
+        type: str
+        default: "20.04"
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  permissions:
+    contents: read
+    packages: write
+
+  ubuntu:
+    runs-on: [self-hosted, e2e_test_runner]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Log into registry ${{ env.REGISTRY }}
+      uses: docker/login-action@v1
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build image
+      run: |
+        docker build \
+        --build-arg os_release=${{ github.event.inputs.os_release }} \
+        --build-arg emp_tool_release=${{ github.event.inputs.emp_tool_release }} \
+        --build-arg emp_release=${{ github.event.inputs.emp_release }} \
+        -t "fbpcf/${{ github.event.inputs.os }}-emp:${{ github.event.inputs.emp_tool_release }}" \
+        -f "docker/${DOCKER_DIR}/Dockerfile.${{ github.event.inputs.os }}" .
+
+    - name: Tag image
+    - run: |
+      docker tag fbpcf/${{ github.event.inputs.os }}-emp:${{ github.event.inputs.emp_tool_release }} \
+      ${{ env.REGISTRY }}/${{ github.repository }}/${{ github.event.inputs.os }}-emp:${{ github.event.inputs.emp_tool_release }}
+
+    - name: Publish image
+    run: |
+      docker push --all-tags ${{ env.REGISTRY }}/${{ github.repository }}/${{ github.event.inputs.os }}-emp


### PR DESCRIPTION
Summary:
# Context
FBPCF builds have a caching mechanism. When we build our docker image, we have cached the images for emp, aws, gcp, and folly (https://github.com/orgs/facebookresearch/packages?repo_name=fbpcf) so that we don't have to rebuild them every time. However, when we upgrade a dependency (like we did with emp a few months ago), this image is stale and gets rebuilt every time we build fbpcf. So, we need to create a process to rebuild the cached image.

The solution here, IMO, is to create 4 workflows, one for each dependency, that accepts a version number as an argument and will build and publish a dependent image for that version. It will only be called on `workflow_dispatch` (i.e. manually), not at `push` or `pull_request` time.

Each diff sets up a workflow for the respective based on the code here: https://fburl.com/code/zyma3fzr

# This Diff
Workflow for emp

# This Stack
1. **Workflow for emp**
2. Workflow for aws
3. Workflow for gcp
4. Workflow for folly

Differential Revision: D36284480

