### PR TITLE
Create workflow to publish new dependency for folly when we upgrade

### DIFF
--- a/.github/workflows/aws-s3-publish.yml
+++ b/.github/workflows/aws-s3-publish.yml
@@ -1,0 +1,59 @@
+name: Build and publish aws s3 dependency
+
+on:
+  workflow_dispatch:
+    inputs:
+      name:
+        description: 'Build and publish an fbpcf/aws-s3-core image for a particular version'
+        default: "Run"
+      aws_release:
+        description: "The aws s3 version to build and publish (e.g. 1.8.177)"
+        required: true
+        type: string
+      os:
+        description: "Which os to use. Currently only supports ubuntu"
+        required: false
+        type: str
+        default: "ubuntu"
+      os_release: "The os version to use (e.g. 20.04 for ubuntu)"
+        required: false
+        type: str
+        default: "20.04"
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  permissions:
+    contents: read
+    packages: write
+
+  ubuntu:
+    runs-on: [self-hosted, e2e_test_runner]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Log into registry ${{ env.REGISTRY }}
+      uses: docker/login-action@v1
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build image
+      run: |
+        docker build \
+        --build-arg os_release=${{ github.event.inputs.os_release }} \
+        --build-arg aws_release=${{ github.event.inputs.aws_release }} \
+        -t "fbpcf/${{ github.event.inputs.os }}-aws-s3-core:${{ github.event.inputs.aws_release }}" \
+        -f "docker/${DOCKER_DIR}/Dockerfile.${{ github.event.inputs.os }}" .
+
+    - name: Tag image
+    - run: |
+      docker tag fbpcf/${{ github.event.inputs.os }}-aws-s3-core:${{ github.event.inputs.aws_release }} \
+      ${{ env.REGISTRY }}/${{ github.repository }}/${{ github.event.inputs.os }}-aws-s3-core:${{ github.event.inputs.aws_release }}
+
+    - name: Publish image
+    run: |
+      docker push --all-tags ${{ env.REGISTRY }}/${{ github.repository }}/${{ github.event.inputs.os }}-aws-s3-core

--- a/.github/workflows/emp-publish.yml
+++ b/.github/workflows/emp-publish.yml
@@ -1,0 +1,64 @@
+name: Build and publish emp dependency
+
+on:
+  workflow_dispatch:
+    inputs:
+      name:
+        description: 'Build and publish an fbpcf/emp image for a particular version'
+        default: "Run"
+      emp_release:
+        description: "The emp version to build and publish (e.g. 0.2.3)"
+        required: true
+        type: string
+      emp_tool_release:
+        description: "The emp-tool version to build and publish (e.g. 0.2.2)"
+        required: true
+        type: string
+      os:
+        description: "Which os to use. Currently only supports ubuntu"
+        required: false
+        type: str
+        default: "ubuntu"
+      os_release: "The os version to use (e.g. 20.04 for ubuntu)"
+        required: false
+        type: str
+        default: "20.04"
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  permissions:
+    contents: read
+    packages: write
+
+  ubuntu:
+    runs-on: [self-hosted, e2e_test_runner]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Log into registry ${{ env.REGISTRY }}
+      uses: docker/login-action@v1
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build image
+      run: |
+        docker build \
+        --build-arg os_release=${{ github.event.inputs.os_release }} \
+        --build-arg emp_tool_release=${{ github.event.inputs.emp_tool_release }} \
+        --build-arg emp_release=${{ github.event.inputs.emp_release }} \
+        -t "fbpcf/${{ github.event.inputs.os }}-emp:${{ github.event.inputs.emp_tool_release }}" \
+        -f "docker/${DOCKER_DIR}/Dockerfile.${{ github.event.inputs.os }}" .
+
+    - name: Tag image
+    - run: |
+      docker tag fbpcf/${{ github.event.inputs.os }}-emp:${{ github.event.inputs.emp_tool_release }} \
+      ${{ env.REGISTRY }}/${{ github.repository }}/${{ github.event.inputs.os }}-emp:${{ github.event.inputs.emp_tool_release }}
+
+    - name: Publish image
+    run: |
+      docker push --all-tags ${{ env.REGISTRY }}/${{ github.repository }}/${{ github.event.inputs.os }}-emp

--- a/.github/workflows/folly-publish.yml
+++ b/.github/workflows/folly-publish.yml
@@ -1,0 +1,64 @@
+name: Build and publish folly dependency
+
+on:
+  workflow_dispatch:
+    inputs:
+      name:
+        description: 'Build and publish an fbpcf/folly image for a particular version'
+        default: "Run"
+      folly_release:
+        description: "The folly version to build and publish (e.g. 2021.03.29.00)"
+        required: true
+        type: string
+      fmt_release:
+        description: "The fmt version to build and publish (e.g. 7.1.3)"
+        required: true
+        type: string
+      os:
+        description: "Which os to use. Currently only supports ubuntu"
+        required: false
+        type: str
+        default: "ubuntu"
+      os_release: "The os version to use (e.g. 20.04 for ubuntu)"
+        required: false
+        type: str
+        default: "20.04"
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  permissions:
+    contents: read
+    packages: write
+
+  ubuntu:
+    runs-on: [self-hosted, e2e_test_runner]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Log into registry ${{ env.REGISTRY }}
+      uses: docker/login-action@v1
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build image
+      run: |
+        docker build \
+        --build-arg os_release=${{ github.event.inputs.os_release }} \
+        --build-arg folly_release=${{ github.event.inputs.folly_release }} \
+        --build-arg fmt_release=${{ github.event.inputs.fmt_release }} \
+        -t "fbpcf/${{ github.event.inputs.os }}-folly:${{ github.event.inputs.folly_release }}" \
+        -f "docker/${DOCKER_DIR}/Dockerfile.${{ github.event.inputs.os }}" .
+
+    - name: Tag image
+    - run: |
+      docker tag fbpcf/${{ github.event.inputs.os }}-folly:${{ github.event.inputs.folly_release }} \
+      ${{ env.REGISTRY }}/${{ github.repository }}/${{ github.event.inputs.os }}-folly:${{ github.event.inputs.folly_release }}
+
+    - name: Publish image
+    run: |
+      docker push --all-tags ${{ env.REGISTRY }}/${{ github.repository }}/${{ github.event.inputs.os }}-folly

--- a/.github/workflows/gcp-publish.yml
+++ b/.github/workflows/gcp-publish.yml
@@ -1,0 +1,59 @@
+name: Build and publish google cloud dependency
+
+on:
+  workflow_dispatch:
+    inputs:
+      name:
+        description: 'Build and publish an fbpcf/google-cloud-cpp image for a particular version'
+        default: "Run"
+      gcp_release:
+        description: "The gcp version to build and publish (e.g. 1.32.1)"
+        required: true
+        type: string
+      os:
+        description: "Which os to use. Currently only supports ubuntu"
+        required: false
+        type: str
+        default: "ubuntu"
+      os_release: "The os version to use (e.g. 20.04 for ubuntu)"
+        required: false
+        type: str
+        default: "20.04"
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  permissions:
+    contents: read
+    packages: write
+
+  ubuntu:
+    runs-on: [self-hosted, e2e_test_runner]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Log into registry ${{ env.REGISTRY }}
+      uses: docker/login-action@v1
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build image
+      run: |
+        docker build \
+        --build-arg os_release=${{ github.event.inputs.os_release }} \
+        --build-arg gcp_release=${{ github.event.inputs.gcp_release }} \
+        -t "fbpcf/${{ github.event.inputs.os }}-google-cloud-cpp:${{ github.event.inputs.gcp_release }}" \
+        -f "docker/${DOCKER_DIR}/Dockerfile.${{ github.event.inputs.os }}" .
+
+    - name: Tag image
+    - run: |
+      docker tag fbpcf/${{ github.event.inputs.os }}-google-cloud-cpp:${{ github.event.inputs.gcp_release }} \
+      ${{ env.REGISTRY }}/${{ github.repository }}/${{ github.event.inputs.os }}-google-cloud-cpp:${{ github.event.inputs.gcp_release }}
+
+    - name: Publish image
+    run: |
+      docker push --all-tags ${{ env.REGISTRY }}/${{ github.repository }}/${{ github.event.inputs.os }}-google-cloud-cpp


### PR DESCRIPTION
Summary:
# Context
FBPCF builds have a caching mechanism. When we build our docker image, we have cached the images for emp, aws, gcp, and folly (https://github.com/orgs/facebookresearch/packages?repo_name=fbpcf) so that we don't have to rebuild them every time. However, when we upgrade a dependency (like we did with emp a few months ago), this image is stale and gets rebuilt every time we build fbpcf. So, we need to create a process to rebuild the cached image.

The solution here, IMO, is to create 4 workflows, one for each dependency, that accepts a version number as an argument and will build and publish a dependent image for that version. It will only be called on `workflow_dispatch` (i.e. manually), not at `push` or `pull_request` time.

Each diff sets up a workflow for the respective based on the code here: https://fburl.com/code/zyma3fzr

# This Diff
Workflow for gcp

# This Stack
1. Workflow for emp
2. Workflow for aws
3. Workflow for gcp
4. **Workflow for folly**

Differential Revision: D36285593

