### PR TITLE
Create workflow to publish new dependency for gcp when we upgrade

### DIFF
--- a/.github/workflows/aws-s3-publish.yml
+++ b/.github/workflows/aws-s3-publish.yml
@@ -1,0 +1,59 @@
+name: Build and publish aws s3 dependency
+
+on:
+  workflow_dispatch:
+    inputs:
+      name:
+        description: 'Build and publish an fbpcf/aws-s3-core image for a particular version'
+        default: "Run"
+      aws_release:
+        description: "The aws s3 version to build and publish (e.g. 1.8.177)"
+        required: true
+        type: string
+      os:
+        description: "Which os to use. Currently only supports ubuntu"
+        required: false
+        type: str
+        default: "ubuntu"
+      os_release: "The os version to use (e.g. 20.04 for ubuntu)"
+        required: false
+        type: str
+        default: "20.04"
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  permissions:
+    contents: read
+    packages: write
+
+  ubuntu:
+    runs-on: [self-hosted, e2e_test_runner]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Log into registry ${{ env.REGISTRY }}
+      uses: docker/login-action@v1
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build image
+      run: |
+        docker build \
+        --build-arg os_release=${{ github.event.inputs.os_release }} \
+        --build-arg aws_release=${{ github.event.inputs.aws_release }} \
+        -t "fbpcf/${{ github.event.inputs.os }}-aws-s3-core:${{ github.event.inputs.aws_release }}" \
+        -f "docker/${DOCKER_DIR}/Dockerfile.${{ github.event.inputs.os }}" .
+
+    - name: Tag image
+    - run: |
+      docker tag fbpcf/${{ github.event.inputs.os }}-aws-s3-core:${{ github.event.inputs.aws_release }} \
+      ${{ env.REGISTRY }}/${{ github.repository }}/${{ github.event.inputs.os }}-aws-s3-core:${{ github.event.inputs.aws_release }}
+
+    - name: Publish image
+    run: |
+      docker push --all-tags ${{ env.REGISTRY }}/${{ github.repository }}/${{ github.event.inputs.os }}-aws-s3-core

--- a/.github/workflows/emp-publish.yml
+++ b/.github/workflows/emp-publish.yml
@@ -1,0 +1,64 @@
+name: Build and publish emp dependency
+
+on:
+  workflow_dispatch:
+    inputs:
+      name:
+        description: 'Build and publish an fbpcf/emp image for a particular version'
+        default: "Run"
+      emp_release:
+        description: "The emp version to build and publish (e.g. 0.2.3)"
+        required: true
+        type: string
+      emp_tool_release:
+        description: "The emp-tool version to build and publish (e.g. 0.2.2)"
+        required: true
+        type: string
+      os:
+        description: "Which os to use. Currently only supports ubuntu"
+        required: false
+        type: str
+        default: "ubuntu"
+      os_release: "The os version to use (e.g. 20.04 for ubuntu)"
+        required: false
+        type: str
+        default: "20.04"
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  permissions:
+    contents: read
+    packages: write
+
+  ubuntu:
+    runs-on: [self-hosted, e2e_test_runner]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Log into registry ${{ env.REGISTRY }}
+      uses: docker/login-action@v1
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build image
+      run: |
+        docker build \
+        --build-arg os_release=${{ github.event.inputs.os_release }} \
+        --build-arg emp_tool_release=${{ github.event.inputs.emp_tool_release }} \
+        --build-arg emp_release=${{ github.event.inputs.emp_release }} \
+        -t "fbpcf/${{ github.event.inputs.os }}-emp:${{ github.event.inputs.emp_tool_release }}" \
+        -f "docker/${DOCKER_DIR}/Dockerfile.${{ github.event.inputs.os }}" .
+
+    - name: Tag image
+    - run: |
+      docker tag fbpcf/${{ github.event.inputs.os }}-emp:${{ github.event.inputs.emp_tool_release }} \
+      ${{ env.REGISTRY }}/${{ github.repository }}/${{ github.event.inputs.os }}-emp:${{ github.event.inputs.emp_tool_release }}
+
+    - name: Publish image
+    run: |
+      docker push --all-tags ${{ env.REGISTRY }}/${{ github.repository }}/${{ github.event.inputs.os }}-emp

--- a/.github/workflows/gcp-publish.yml
+++ b/.github/workflows/gcp-publish.yml
@@ -1,0 +1,59 @@
+name: Build and publish google cloud dependency
+
+on:
+  workflow_dispatch:
+    inputs:
+      name:
+        description: 'Build and publish an fbpcf/google-cloud-cpp image for a particular version'
+        default: "Run"
+      gcp_release:
+        description: "The gcp version to build and publish (e.g. 1.32.1)"
+        required: true
+        type: string
+      os:
+        description: "Which os to use. Currently only supports ubuntu"
+        required: false
+        type: str
+        default: "ubuntu"
+      os_release: "The os version to use (e.g. 20.04 for ubuntu)"
+        required: false
+        type: str
+        default: "20.04"
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  permissions:
+    contents: read
+    packages: write
+
+  ubuntu:
+    runs-on: [self-hosted, e2e_test_runner]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Log into registry ${{ env.REGISTRY }}
+      uses: docker/login-action@v1
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build image
+      run: |
+        docker build \
+        --build-arg os_release=${{ github.event.inputs.os_release }} \
+        --build-arg gcp_release=${{ github.event.inputs.gcp_release }} \
+        -t "fbpcf/${{ github.event.inputs.os }}-google-cloud-cpp:${{ github.event.inputs.gcp_release }}" \
+        -f "docker/${DOCKER_DIR}/Dockerfile.${{ github.event.inputs.os }}" .
+
+    - name: Tag image
+    - run: |
+      docker tag fbpcf/${{ github.event.inputs.os }}-google-cloud-cpp:${{ github.event.inputs.gcp_release }} \
+      ${{ env.REGISTRY }}/${{ github.repository }}/${{ github.event.inputs.os }}-google-cloud-cpp:${{ github.event.inputs.gcp_release }}
+
+    - name: Publish image
+    run: |
+      docker push --all-tags ${{ env.REGISTRY }}/${{ github.repository }}/${{ github.event.inputs.os }}-google-cloud-cpp

--- a/docker/google-cloud-cpp/Dockerfile.ubuntu
+++ b/docker/google-cloud-cpp/Dockerfile.ubuntu
@@ -4,8 +4,8 @@
 # LICENSE file in the root directory of this source tree.
 ARG os_release="latest"
 FROM ubuntu:${os_release} AS builder
-ARG gcp_cpp_release="1.8.177"
-# Required Packages for google-cloud-cpp 
+ARG gcp_cpp_release="1.32.1"
+# Required Packages for google-cloud-cpp
 # Instructions modified from https://github.com/googleapis/google-cloud-cpp/blob/main/doc/packaging.md
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get -y update && apt-get install --no-install-recommends -y \
@@ -39,7 +39,7 @@ RUN wget -q https://github.com/googleapis/google-cloud-cpp/archive/${gcp_cpp_rel
     tar -xf ${gcp_cpp_release}.tar.gz -C ${HOME}/google-cloud-cpp --strip=1
 
 # Install Abseil
-RUN mkdir -p ${HOME}/Downloads/abseil-cpp 
+RUN mkdir -p ${HOME}/Downloads/abseil-cpp
 WORKDIR ${HOME}/Downloads/abseil-cpp
 RUN curl -sSL https://github.com/abseil/abseil-cpp/archive/20210324.2.tar.gz | \
     tar -xzf - --strip-components=1 && \
@@ -55,7 +55,7 @@ RUN curl -sSL https://github.com/abseil/abseil-cpp/archive/20210324.2.tar.gz | \
     ldconfig
 
 # Install Protobuf
-RUN mkdir -p ${HOME}/Downloads/protobuf 
+RUN mkdir -p ${HOME}/Downloads/protobuf
 WORKDIR ${HOME}/Downloads/protobuf
 RUN curl -sSL https://github.com/protocolbuffers/protobuf/archive/v3.19.0.tar.gz | \
     tar -xzf - --strip-components=1 && \
@@ -69,7 +69,7 @@ RUN curl -sSL https://github.com/protocolbuffers/protobuf/archive/v3.19.0.tar.gz
     ldconfig
 
 # Install gRPC
-RUN mkdir -p ${HOME}/Downloads/grpc 
+RUN mkdir -p ${HOME}/Downloads/grpc
 WORKDIR ${HOME}/Downloads/grpc
 RUN curl -sSL https://github.com/grpc/grpc/archive/v1.41.1.tar.gz | \
     tar -xzf - --strip-components=1 && \
@@ -89,7 +89,7 @@ RUN curl -sSL https://github.com/grpc/grpc/archive/v1.41.1.tar.gz | \
     ldconfig
 
 # Install crc32c
-RUN mkdir -p ${HOME}/Downloads/crc32c 
+RUN mkdir -p ${HOME}/Downloads/crc32c
 WORKDIR ${HOME}/Downloads/crc32c
 RUN curl -sSL https://github.com/google/crc32c/archive/1.1.2.tar.gz | \
     tar -xzf - --strip-components=1 && \
@@ -105,7 +105,7 @@ RUN curl -sSL https://github.com/google/crc32c/archive/1.1.2.tar.gz | \
     ldconfig
 
 # Install nlohmann_json
-RUN mkdir -p ${HOME}/Downloads/json 
+RUN mkdir -p ${HOME}/Downloads/json
 WORKDIR ${HOME}/Downloads/json
 RUN curl -sSL https://github.com/nlohmann/json/archive/v3.10.4.tar.gz | \
     tar -xzf - --strip-components=1 && \
@@ -119,7 +119,7 @@ RUN curl -sSL https://github.com/nlohmann/json/archive/v3.10.4.tar.gz | \
 
 # Build google-cloud-cpp
 WORKDIR ${HOME}/google-cloud-cpp
-RUN cmake \ 
+RUN cmake \
         -DBUILD_TESTING=OFF \
         -DGOOGLE_CLOUD_CPP_ENABLE_BIGTABLE=OFF \
         -DGOOGLE_CLOUD_CPP_ENABLE_BIGQUERY=OFF \


### PR DESCRIPTION
Summary:
# Context
FBPCF builds have a caching mechanism. When we build our docker image, we have cached the images for emp, aws, gcp, and folly (https://github.com/orgs/facebookresearch/packages?repo_name=fbpcf) so that we don't have to rebuild them every time. However, when we upgrade a dependency (like we did with emp a few months ago), this image is stale and gets rebuilt every time we build fbpcf. So, we need to create a process to rebuild the cached image.

The solution here, IMO, is to create 4 workflows, one for each dependency, that accepts a version number as an argument and will build and publish a dependent image for that version. It will only be called on `workflow_dispatch` (i.e. manually), not at `push` or `pull_request` time.

Each diff sets up a workflow for the respective based on the code here: https://fburl.com/code/zyma3fzr

# This Diff
Workflow for gcp

# This Stack
1. Workflow for emp
2. Workflow for aws
3. **Workflow for gcp**
4. Workflow for folly

Differential Revision: D36285479

