### PR TITLE
Explicitly call out the reuse of global M.

### DIFF
--- a/fbpcf/engine/tuple_generator/oblivious_transfer/NpBaseObliviousTransfer.cpp
+++ b/fbpcf/engine/tuple_generator/oblivious_transfer/NpBaseObliviousTransfer.cpp
@@ -200,6 +200,8 @@ __m128i NpBaseObliviousTransfer::hashPoint(
 
 std::pair<std::vector<__m128i>, std::vector<__m128i>>
 NpBaseObliviousTransfer::send(size_t size) {
+  // This global M is only used for all the OT instances in this function.
+  // Obviously this batch of OTs are between the same pair of parties.
   auto globalM = generateRandomPoint();
   sendPoint(*globalM);
 

--- a/fbpcf/engine/tuple_generator/oblivious_transfer/NpBaseObliviousTransfer.h
+++ b/fbpcf/engine/tuple_generator/oblivious_transfer/NpBaseObliviousTransfer.h
@@ -63,7 +63,7 @@ class NpBaseObliviousTransfer : public IBaseObliviousTransfer {
 
   PointPointer generateRandomPoint() const;
 
-  __m128i hashPoint(const EC_POINT& point) const;
+  __m128i hashPoint(const EC_POINT& point, uint64_t nonce) const;
 
   std::unique_ptr<communication::IPartyCommunicationAgent> agent_;
 

--- a/fbpcf/engine/tuple_generator/oblivious_transfer/test/BaseObliviousTransferTest.cpp
+++ b/fbpcf/engine/tuple_generator/oblivious_transfer/test/BaseObliviousTransferTest.cpp
@@ -118,8 +118,8 @@ TEST(BaseObliviousTransferTest, TestNpBaseOTSendAndReceivePoints) {
         EC_POINT_cmp(
             ot1.group_.get(), pointToSend.get(), point.get(), ctx.get()),
         0);
-    auto hash0 = ot0.hashPoint(*pointToSend);
-    auto hash1 = ot1.hashPoint(*point);
+    auto hash0 = ot0.hashPoint(*pointToSend, 0);
+    auto hash1 = ot1.hashPoint(*point, 0);
     EXPECT_TRUE(compareM128i(hash0, hash1));
   }
 }


### PR DESCRIPTION
Summary: The global M shouldn't be used with different receivers. This is exactly our use case. Explicitly calling this out to avoid potential misuse. The doc is updated accordingly as well.

Reviewed By: chualynn

Differential Revision: D36427314

