### PR TITLE
Add a nonce in point hashing

### DIFF
--- a/fbpcf/engine/tuple_generator/oblivious_transfer/NpBaseObliviousTransfer.h
+++ b/fbpcf/engine/tuple_generator/oblivious_transfer/NpBaseObliviousTransfer.h
@@ -63,7 +63,7 @@ class NpBaseObliviousTransfer : public IBaseObliviousTransfer {
 
   PointPointer generateRandomPoint() const;
 
-  __m128i hashPoint(const EC_POINT& point) const;
+  __m128i hashPoint(const EC_POINT& point, uint64_t nonce) const;
 
   std::unique_ptr<communication::IPartyCommunicationAgent> agent_;
 

--- a/fbpcf/engine/tuple_generator/oblivious_transfer/test/BaseObliviousTransferTest.cpp
+++ b/fbpcf/engine/tuple_generator/oblivious_transfer/test/BaseObliviousTransferTest.cpp
@@ -118,8 +118,8 @@ TEST(BaseObliviousTransferTest, TestNpBaseOTSendAndReceivePoints) {
         EC_POINT_cmp(
             ot1.group_.get(), pointToSend.get(), point.get(), ctx.get()),
         0);
-    auto hash0 = ot0.hashPoint(*pointToSend);
-    auto hash1 = ot1.hashPoint(*point);
+    auto hash0 = ot0.hashPoint(*pointToSend, 0);
+    auto hash1 = ot1.hashPoint(*point, 0);
     EXPECT_TRUE(compareM128i(hash0, hash1));
   }
 }


### PR DESCRIPTION
Summary:
NCC finds out that we forgot to include a nonce when hashing a point and opened a hole for potential attack. This diff is adding a nonce when hashing a point on EC.

Doc is updated accordingly: https://docs.google.com/document/d/1vQ06j-_NjjWCcru5VMAFHZZXU_LpibCQeSxz5YWG8zM/edit#

Reviewed By: chualynn

Differential Revision: D36426991

