### PR TITLE
Update the cloud file writer to use shared S3Client

### DIFF
--- a/fbpcf/io/cloud_util/CloudFileUtil.cpp
+++ b/fbpcf/io/cloud_util/CloudFileUtil.cpp
@@ -9,6 +9,7 @@
 #include <re2/re2.h>
 #include "fbpcf/aws/S3Util.h"
 #include "fbpcf/exception/PcfException.h"
+#include "fbpcf/io/cloud_util/S3Client.h"
 #include "fbpcf/io/cloud_util/S3FileReader.h"
 #include "fbpcf/io/cloud_util/S3FileUploader.h"
 
@@ -59,8 +60,9 @@ std::unique_ptr<IFileUploader> getCloudFileUploader(
   if (fileType == CloudFileType::S3) {
     const auto& ref = fbpcf::aws::uriToObjectReference(filePath);
     return std::make_unique<S3FileUploader>(
-        fbpcf::aws::createS3Client(
-            fbpcf::aws::S3ClientOption{.region = ref.region}),
+        fbpcf::cloudio::S3Client::getInstance(
+            fbpcf::aws::S3ClientOption{.region = ref.region})
+            .getS3Client(),
         filePath);
   } else {
     throw fbpcf::PcfException("Not supported yet.");

--- a/fbpcf/io/cloud_util/S3Client.cpp
+++ b/fbpcf/io/cloud_util/S3Client.cpp
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "fbpcf/io/cloud_util/S3Client.h"
+
+#include <aws/core/Aws.h>
+#include <aws/s3/S3Client.h>
+
+namespace fbpcf::cloudio {
+S3Client& S3Client::getInstance(const fbpcf::aws::S3ClientOption& option) {
+  static S3Client s3Client(option);
+  return s3Client;
+}
+} // namespace fbpcf::cloudio

--- a/fbpcf/io/cloud_util/S3Client.h
+++ b/fbpcf/io/cloud_util/S3Client.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <memory>
+
+#include <aws/core/Aws.h>
+#include <aws/s3/S3Client.h>
+#include "fbpcf/aws/S3Util.h"
+
+namespace fbpcf::cloudio {
+
+class S3Client {
+ private:
+  explicit S3Client(const fbpcf::aws::S3ClientOption& option) {
+    awsS3Client_ = fbpcf::aws::createS3Client(option);
+  }
+
+ public:
+  static S3Client& getInstance(const fbpcf::aws::S3ClientOption& option);
+
+  std::shared_ptr<Aws::S3::S3Client> getS3Client() {
+    return awsS3Client_;
+  }
+
+ private:
+  std::shared_ptr<Aws::S3::S3Client> awsS3Client_;
+};
+
+} // namespace fbpcf::cloudio

--- a/fbpcf/io/cloud_util/S3FileUploader.h
+++ b/fbpcf/io/cloud_util/S3FileUploader.h
@@ -17,7 +17,7 @@ namespace fbpcf::cloudio {
 class S3FileUploader : public IFileUploader {
  public:
   explicit S3FileUploader(
-      std::unique_ptr<Aws::S3::S3Client> s3Client,
+      std::shared_ptr<Aws::S3::S3Client> s3Client,
       const std::string& filePath)
       : s3Client_{std::move(s3Client)}, filePath_{filePath} {
     init();
@@ -28,7 +28,7 @@ class S3FileUploader : public IFileUploader {
  private:
   void init() override;
   void abortUpload();
-  std::unique_ptr<Aws::S3::S3Client> s3Client_;
+  std::shared_ptr<Aws::S3::S3Client> s3Client_;
   const std::string filePath_;
   std::string bucket_;
   std::string key_;


### PR DESCRIPTION
Summary: Aditya recently found an issue that when we have 169 shards for uploading files, it will fail at 169 shards. Similar to this issue https://github.com/aws/aws-sdk-cpp/issues/1920. After Aditya talking with AWS team, the current solution is to use a shared S3Clinet instead of creating one per each request. In the meanwhile, AWS is working on finding the root cause. This diff is to make the S3Client a singleton and use the same client among all requests.

Differential Revision: D36727729

