### PR TITLE
Minor fixes to IO APIs

### DIFF
--- a/fbpcf/io/api/BufferedReader.cpp
+++ b/fbpcf/io/api/BufferedReader.cpp
@@ -67,9 +67,7 @@ bool BufferedReader::eof() {
   return baseReader_.eof() && (currentPosition_ == lastPosition_);
 }
 
-BufferedReader::~BufferedReader() {
-  close();
-}
+BufferedReader::~BufferedReader() {}
 
 std::string BufferedReader::readLine() {
   if (eof()) {

--- a/fbpcf/io/api/BufferedReader.h
+++ b/fbpcf/io/api/BufferedReader.h
@@ -21,13 +21,13 @@ provides a readLine function as well as the ability
 to specify a chunk size.
 */
 
-constexpr size_t defaultChunkSize = 4096;
+constexpr size_t defaultReaderChunkSize = 4096;
 
 class BufferedReader : public IReaderCloser {
  public:
   explicit BufferedReader(
       IReaderCloser& baseReader,
-      const size_t chunkSize = defaultChunkSize)
+      const size_t chunkSize = defaultReaderChunkSize)
       : buffer_{std::vector<char>(chunkSize)},
         currentPosition_{0},
         baseReader_{baseReader},

--- a/fbpcf/io/api/BufferedWriter.cpp
+++ b/fbpcf/io/api/BufferedWriter.cpp
@@ -15,7 +15,7 @@ namespace fbpcf::io {
 
 int BufferedWriter::close() {
   flush();
-  return baseWriter_.close();
+  return baseWriter_->close();
 }
 
 size_t BufferedWriter::write(std::vector<char>& buf) {
@@ -45,9 +45,14 @@ size_t BufferedWriter::write(std::vector<char>& buf) {
   return written;
 }
 
-BufferedWriter::~BufferedWriter() {
-  close();
+size_t BufferedWriter::writeString(std::string& line) {
+  auto vec = std::vector<char>(line.size());
+  std::copy(line.begin(), line.end(), vec.begin());
+
+  return write(vec);
 }
+
+BufferedWriter::~BufferedWriter() {}
 
 void BufferedWriter::flush() {
   if (currentPosition_ == 0) {
@@ -63,7 +68,7 @@ void BufferedWriter::flush() {
     toWrite = buffer_;
   }
   currentPosition_ = 0;
-  if (baseWriter_.write(toWrite) != toWrite.size()) {
+  if (baseWriter_->write(toWrite) != toWrite.size()) {
     throw std::runtime_error(
         "Failed to flush contents of buffer. Terminating.");
   }

--- a/fbpcf/io/api/BufferedWriter.h
+++ b/fbpcf/io/api/BufferedWriter.h
@@ -20,19 +20,20 @@ This class is the API for buffered writer, which
 provides the ability to specify a chunk size.
 */
 
-constexpr size_t defaultChunkSize = 4096;
+constexpr size_t defaultWriterChunkSize = 4096;
 
 class BufferedWriter : public IWriterCloser {
  public:
   explicit BufferedWriter(
-      IWriterCloser& baseWriter,
-      const size_t chunkSize = defaultChunkSize)
+      std::unique_ptr<IWriterCloser> baseWriter,
+      const size_t chunkSize = defaultWriterChunkSize)
       : buffer_{std::vector<char>(chunkSize)},
         currentPosition_{0},
-        baseWriter_{baseWriter} {}
+        baseWriter_{std::move(baseWriter)} {}
 
   int close() override;
   size_t write(std::vector<char>& buf) override;
+  size_t writeString(std::string& line);
   ~BufferedWriter() override;
 
   void flush();
@@ -40,7 +41,7 @@ class BufferedWriter : public IWriterCloser {
  private:
   std::vector<char> buffer_;
   size_t currentPosition_;
-  IWriterCloser& baseWriter_;
+  std::unique_ptr<IWriterCloser> baseWriter_;
 };
 
 } // namespace fbpcf::io

--- a/fbpcf/io/api/FileReader.cpp
+++ b/fbpcf/io/api/FileReader.cpp
@@ -24,9 +24,7 @@ FileReader::FileReader(std::string filePath) {
   }
 }
 
-FileReader::~FileReader() {
-  close();
-}
+FileReader::~FileReader() {}
 
 size_t FileReader::read(std::vector<char>& buf) {
   return childReader_->read(buf);

--- a/fbpcf/io/api/FileWriter.cpp
+++ b/fbpcf/io/api/FileWriter.cpp
@@ -23,9 +23,7 @@ FileWriter::FileWriter(std::string filePath) {
   }
 }
 
-FileWriter::~FileWriter() {
-  close();
-}
+FileWriter::~FileWriter() {}
 
 size_t FileWriter::write(std::vector<char>& buf) {
   return childWriter_->write(buf);

--- a/fbpcf/io/api/LocalFileReader.cpp
+++ b/fbpcf/io/api/LocalFileReader.cpp
@@ -41,7 +41,5 @@ bool LocalFileReader::eof() {
   return inputStream_->eof();
 }
 
-LocalFileReader::~LocalFileReader() {
-  close();
-}
+LocalFileReader::~LocalFileReader() {}
 } // namespace fbpcf::io

--- a/fbpcf/io/api/LocalFileWriter.cpp
+++ b/fbpcf/io/api/LocalFileWriter.cpp
@@ -33,7 +33,5 @@ size_t LocalFileWriter::write(std::vector<char>& buf) {
   return buf.size();
 }
 
-LocalFileWriter::~LocalFileWriter() {
-  close();
-}
+LocalFileWriter::~LocalFileWriter() {}
 } // namespace fbpcf::io

--- a/fbpcf/io/api/test/BufferedWriterTest.cpp
+++ b/fbpcf/io/api/test/BufferedWriterTest.cpp
@@ -26,8 +26,9 @@ inline void runBufferedWriterTest(size_t chunkSize) {
   auto randint = intDistro(defEngine);
   std::string fileToWriteTo = baseDir + "data/local_file_writer_test_file" +
       std::to_string(randint) + ".txt";
-  auto writer = fbpcf::io::LocalFileWriter(fileToWriteTo);
-  auto bufferedWriter = std::make_unique<BufferedWriter>(writer, chunkSize);
+  auto writer = std::make_unique<fbpcf::io::LocalFileWriter>(fileToWriteTo);
+  auto bufferedWriter =
+      std::make_unique<BufferedWriter>(std::move(writer), chunkSize);
 
   std::string to_write = "this file tests the buffered writer\n";
   auto buf =
@@ -58,6 +59,15 @@ inline void runBufferedWriterTest(size_t chunkSize) {
   auto buf4 =
       std::vector<char>(to_write.c_str(), to_write.c_str() + to_write.size());
   nBytes = bufferedWriter->write(buf4);
+  EXPECT_EQ(nBytes, to_write.size());
+
+  to_write = "writing a small string\n";
+  nBytes = bufferedWriter->writeString(to_write);
+  EXPECT_EQ(nBytes, to_write.size());
+
+  to_write =
+      "writing a big string that will also take multiple iterations to write everything in the file so that we have comprehensive tests\n";
+  nBytes = bufferedWriter->writeString(to_write);
   EXPECT_EQ(nBytes, to_write.size());
 
   bufferedWriter->close();

--- a/fbpcf/io/api/test/data/expected_buffered_writer_test_file.txt
+++ b/fbpcf/io/api/test/data/expected_buffered_writer_test_file.txt
@@ -2,3 +2,5 @@ this file tests the buffered writer
 these two lines fit in one chunk
 but this next line is going to be much longer and will require multiple iterations of the loop to fit everything in the file
 this is tiny
+writing a small string
+writing a big string that will also take multiple iterations to write everything in the file so that we have comprehensive tests

--- a/fbpcf/io/cloud_util/S3FileUploader.cpp
+++ b/fbpcf/io/cloud_util/S3FileUploader.cpp
@@ -30,6 +30,8 @@ void S3FileUploader::init() {
   request.SetKey(key_);
   request.SetContentType(FILE_TYPE);
 
+  XLOG(INFO) << "Bucket: " << bucket_ << ", Key: " << key_;
+
   auto createMultipartUploadOutcome = s3Client_->CreateMultipartUpload(request);
 
   if (createMultipartUploadOutcome.IsSuccess()) {
@@ -37,6 +39,7 @@ void S3FileUploader::init() {
     XLOG(INFO) << "Multipart upload initialization succeed. Upload id is: "
                << uploadId_;
   } else {
+    XLOG(ERR) << createMultipartUploadOutcome.GetError();
     throw AwsException{
         "Multipart upload initialization failed: " +
         createMultipartUploadOutcome.GetError().GetMessage()};


### PR DESCRIPTION
Summary:
- Change a reference to a unique ptr
- Rename variables to avoid conflicts
- Add a simple writeString function
- Don't call `close` in destructor to avoid double close
- Bit more logging in S3FileUploader

Differential Revision: D36875840

