### PR TITLE
Fix prompt in emp-publish workflow

### DIFF
--- a/.github/workflows/emp-publish.yml
+++ b/.github/workflows/emp-publish.yml
@@ -7,11 +7,11 @@ on:
         description: "Build and publish an fbpcf/emp image for a particular version"
         default: "Run"
       emp_release:
-        description: "The emp version to build and publish (e.g. 0.2.3)"
+        description: "The emp version to build and publish (e.g. 0.2.2)"
         required: true
         type: string
       emp_tool_release:
-        description: "The emp-tool version to build and publish (e.g. 0.2.2)"
+        description: "The emp-tool version to build and publish (e.g. 0.2.3)"
         required: true
         type: string
       os:

--- a/.github/workflows/gcp-publish.yml
+++ b/.github/workflows/gcp-publish.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           docker build \
           --build-arg os_release=${{ github.event.inputs.os_release }} \
-          --build-arg gcp_release=${{ github.event.inputs.gcp_release }} \
+          --build-arg gcp_cpp_release=${{ github.event.inputs.gcp_release }} \
           -t "fbpcf/${{ github.event.inputs.os }}-google-cloud-cpp:${{ github.event.inputs.gcp_release }}" \
           -f "docker/google-cloud-cpp/Dockerfile.${{ github.event.inputs.os }}" .
 


### PR DESCRIPTION
Summary: The versions in the message prompt are switched. See https://fburl.com/code/md42ntyz. emp-tool should be 0.2.3, and emp should be 0.2.2

Differential Revision: D36943203

