### PR TITLE
Adding APIs to expand keys for encryption and decryption.

### DIFF
--- a/fbpcf/engine/util/aes.h
+++ b/fbpcf/engine/util/aes.h
@@ -61,6 +61,10 @@ class Aes {
 
   static __m128i getFixedKey();
 
+  static std::array<__m128i, 11> expandEncryptionKey(__m128i key);
+
+  static std::array<__m128i, 11> expandDecryptionKey(__m128i key);
+
  protected:
   static const uint8_t kRound = 10;
   std::array<__m128i, 11> roundKey_;

--- a/fbpcf/engine/util/test/aesTestHelper.cpp
+++ b/fbpcf/engine/util/test/aesTestHelper.cpp
@@ -12,16 +12,7 @@ namespace fbpcf::engine::util {
 
 void AesTestHelper::switchToDecrypt() {
   // convert the encryption key to the decryption key
-  int8_t j = 0;
-  int8_t i = kRound;
-  std::array<__m128i, 11> decryptionKey;
-  decryptionKey[i--] = roundKey_[j++];
-  while (i > 0) {
-    decryptionKey[i--] = _mm_aesimc_si128(roundKey_[j++]);
-  }
-  decryptionKey[i] = roundKey_[j];
-
-  roundKey_ = decryptionKey;
+  roundKey_ = Aes::expandDecryptionKey(key_);
 }
 
 void AesTestHelper::decryptInPlace(std::vector<__m128i>& ciphertext) const {

--- a/fbpcf/engine/util/test/aesTestHelper.h
+++ b/fbpcf/engine/util/test/aesTestHelper.h
@@ -6,13 +6,14 @@
  */
 
 #pragma once
+#include <emmintrin.h>
 #include "fbpcf/engine/util/aes.h"
 
 namespace fbpcf::engine::util {
 
 class AesTestHelper final : public Aes {
  public:
-  explicit AesTestHelper(__m128i key) : Aes(key) {}
+  explicit AesTestHelper(__m128i key) : Aes(key), key_(key) {}
 
   /**
    * Switch the cipher to decryption mode
@@ -20,6 +21,9 @@ class AesTestHelper final : public Aes {
   void switchToDecrypt();
 
   void decryptInPlace(std::vector<__m128i>& ciphertext) const;
+
+ private:
+  __m128i key_;
 };
 
 } // namespace fbpcf::engine::util


### PR DESCRIPTION
Summary: In UDP project we need *expanded* AES keys for encryption and decryption. We already have the key-expanding code. This diff is merely exposing them for public use.

Differential Revision: D36987381

