### PR TITLE
Change from reference to unique_ptr, and make the change push safe- Step 1

### DIFF
--- a/fbpcf/io/api/BufferedReaderCopy.cpp
+++ b/fbpcf/io/api/BufferedReaderCopy.cpp
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <cstddef>
+#include <exception>
+#include <stdexcept>
+#include <vector>
+
+#include "fbpcf/io/api/BufferedReaderCopy.h"
+
+namespace fbpcf::io {
+
+int BufferedReaderCopy::close() {
+  return baseReader_.close();
+}
+
+size_t BufferedReaderCopy::read(std::vector<char>& buf) {
+  if (eof()) {
+    throw std::runtime_error("There is no more data in this file.");
+  }
+
+  size_t filledUp = 0;
+  size_t remaining = buf.size();
+  while (filledUp < buf.size() && !eof()) {
+    if ((lastPosition_ - currentPosition_) >= remaining) {
+      // we already have enough data loaded
+      std::copy(
+          buffer_.begin() + currentPosition_,
+          buffer_.begin() + currentPosition_ + remaining,
+          buf.begin() + filledUp);
+      currentPosition_ += remaining;
+      filledUp += remaining;
+      break;
+    }
+
+    // need to load more data
+
+    // first, copy what we currently have
+    std::copy(
+        buffer_.begin() + currentPosition_,
+        buffer_.begin() + lastPosition_,
+        buf.begin() + filledUp);
+    filledUp += (lastPosition_ - currentPosition_);
+    remaining = buf.size() - filledUp;
+    currentPosition_ = lastPosition_;
+
+    if (baseReader_.eof()) {
+      // that's all the data that exists in the file
+      return filledUp;
+    }
+
+    // load next chunk and the repeat
+    // loadNextChunk appropriately sets
+    // currentPosition, lastPosition_, and eof_
+    loadNextChunk();
+  }
+
+  return filledUp;
+}
+
+bool BufferedReaderCopy::eof() {
+  // The base file is exhausted and the buffer is exhausted
+  return baseReader_.eof() && (currentPosition_ == lastPosition_);
+}
+
+BufferedReaderCopy::~BufferedReaderCopy() {}
+
+std::string BufferedReaderCopy::readLine() {
+  if (eof()) {
+    throw std::runtime_error("There are no more lines in this file.");
+  }
+
+  if (currentPosition_ == lastPosition_) {
+    loadNextChunk();
+  }
+
+  auto c = buffer_.at(currentPosition_++);
+  std::string output = "";
+  while (c != '\n') {
+    output += c;
+
+    if (currentPosition_ == lastPosition_) {
+      // we've run out of data, try to get the next chunk
+      if (baseReader_.eof()) {
+        // no more data in the file, return what we have
+        break;
+      }
+
+      loadNextChunk();
+    }
+
+    c = buffer_.at(currentPosition_++);
+  }
+
+  if (currentPosition_ == lastPosition_ && !eof()) {
+    // if we are at the end of the buffer and there is more data
+    // to be loaded, we should load the next chunk.
+    // otherwise we risk the next invocation of readLine()
+    // to not return any data (in case the most recent \n was the
+    // final character of the file)
+    loadNextChunk();
+  }
+
+  return output;
+}
+
+void BufferedReaderCopy::loadNextChunk() {
+  auto bytesRead = baseReader_.read(buffer_);
+
+  lastPosition_ = bytesRead;
+  currentPosition_ = 0;
+}
+
+} // namespace fbpcf::io

--- a/fbpcf/io/api/BufferedReaderCopy.h
+++ b/fbpcf/io/api/BufferedReaderCopy.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+#include "fbpcf/io/api/IReaderCloser.h"
+
+namespace fbpcf::io {
+
+/*
+This class is the API for buffered reading, which
+provides a readLine function as well as the ability
+to specify a chunk size.
+*/
+
+constexpr size_t defaultReaderChunkSize = 4096;
+
+class BufferedReaderCopy : public IReaderCloser {
+ public:
+  explicit BufferedReaderCopy(
+      IReaderCloser& baseReader,
+      const size_t chunkSize = defaultReaderChunkSize)
+      : buffer_{std::vector<char>(chunkSize)},
+        currentPosition_{0},
+        baseReader_{baseReader},
+        lastPosition_{0} {}
+
+  int close() override;
+  size_t read(std::vector<char>& buf) override;
+  bool eof() override;
+  ~BufferedReaderCopy() override;
+
+  std::string readLine();
+
+ private:
+  void loadNextChunk();
+
+  std::vector<char> buffer_;
+  size_t currentPosition_;
+  IReaderCloser& baseReader_;
+  size_t lastPosition_;
+};
+
+} // namespace fbpcf::io

--- a/fbpcf/io/api/test/BufferedReaderCopyTest.cpp
+++ b/fbpcf/io/api/test/BufferedReaderCopyTest.cpp
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include <memory>
+
+#include "fbpcf/io/api/BufferedReaderCopy.h"
+#include "fbpcf/io/api/FileReader.h"
+#include "fbpcf/io/api/test/utils/IOTestHelper.h"
+
+namespace fbpcf::io {
+
+inline void runBufferedReaderTestForReadLineOnly(size_t chunkSize) {
+  // this more accurately resembles a production style usage
+  auto fileReader = fbpcf::io::FileReader(
+      IOTestHelper::getBaseDirFromPath(__FILE__) +
+      "data/buffered_reader_test_file.txt");
+  auto bufferedReader =
+      std::make_unique<fbpcf::io::BufferedReaderCopy>(fileReader, chunkSize);
+
+  auto expectedLines = std::vector<std::string>{
+      "this is a simple first line",
+      "this is a second line that is intended to be longer than a line that can fit in a single buffer",
+      "this is a third line that should take at least three iterations of the buffer so that we can properly check the iterative functionality",
+      "",
+      "we also test a blank line and",
+      "a line that will include a newline",
+      "",
+      "finally, we want to test a really long block of",
+      "text, that will take 3 or 4 chunks, but this time",
+      "using the read API instead of the readLine API to",
+      "make sure that we have adequate test coverage. the",
+      "total size of this paragraph is 242 bytes."};
+
+  auto i = 0;
+  while (!bufferedReader->eof()) {
+    auto line = bufferedReader->readLine();
+    EXPECT_EQ(line, expectedLines.at(i)) << "Strings don't match at row " << i;
+    i++;
+
+    if (i == expectedLines.size()) {
+      EXPECT_TRUE(bufferedReader->eof()) << "Failed to assert eof at row " << i;
+    } else {
+      EXPECT_FALSE(bufferedReader->eof()) << "Unexpected eof at row " << i;
+    }
+  }
+}
+
+inline void runBufferedReaderTestForReadAndReadLine(size_t chunkSize) {
+  auto fileReader = fbpcf::io::FileReader(
+      IOTestHelper::getBaseDirFromPath(__FILE__) +
+      "data/buffered_reader_test_file.txt");
+  auto bufferedReader =
+      std::make_unique<fbpcf::io::BufferedReaderCopy>(fileReader, chunkSize);
+
+  auto firstLine = bufferedReader->readLine();
+
+  EXPECT_EQ(firstLine, "this is a simple first line");
+  EXPECT_FALSE(bufferedReader->eof());
+
+  auto secondLine = bufferedReader->readLine();
+
+  EXPECT_EQ(
+      secondLine,
+      "this is a second line that is intended to be longer than a line that can fit in a single buffer");
+  EXPECT_FALSE(bufferedReader->eof());
+
+  auto thirdLine = bufferedReader->readLine();
+  std::string expectedLongString =
+      "this is a third line that should take at least three iterations of the buffer so that we can properly check the iterative functionality";
+  EXPECT_EQ(thirdLine, expectedLongString);
+  EXPECT_FALSE(bufferedReader->eof());
+
+  auto fourthLine = bufferedReader->readLine();
+  EXPECT_EQ(fourthLine, "");
+  EXPECT_FALSE(bufferedReader->eof());
+
+  auto blurb = std::vector<char>(65);
+  auto nBytes = bufferedReader->read(blurb);
+  EXPECT_EQ(nBytes, 65);
+  IOTestHelper::expectBufferToEqualString(
+      blurb,
+      "we also test a blank line and\na line that will include a newline\n",
+      65);
+  EXPECT_FALSE(bufferedReader->eof());
+
+  auto blankLine = bufferedReader->readLine();
+  EXPECT_EQ(blankLine, "");
+  EXPECT_FALSE(bufferedReader->eof());
+
+  auto remainingBytes = std::vector<char>(300);
+  nBytes = bufferedReader->read(remainingBytes);
+  EXPECT_EQ(nBytes, 242);
+  std::string expectedLongParagraph =
+      "finally, we want to test a really long block of\ntext, that will take 3 or 4 chunks, but this time\nusing the read API instead of the readLine API to\nmake sure that we have adequate test coverage. the\ntotal size of this paragraph is 242 bytes.\n";
+  IOTestHelper::expectBufferToEqualString(
+      remainingBytes, expectedLongParagraph, nBytes);
+  EXPECT_TRUE(bufferedReader->eof());
+
+  bufferedReader->close();
+}
+
+class BufferedReaderCopyTest
+    : public ::testing::TestWithParam<size_t> { // the only parameter is the
+                                                // chunk size
+ protected:
+  void SetUp() override {}
+
+  void TearDown() override {}
+};
+
+TEST_P(BufferedReaderCopyTest, testBufferedReaderWithReadLineOnly) {
+  auto chunkSize = GetParam();
+
+  runBufferedReaderTestForReadLineOnly(chunkSize);
+}
+
+TEST_P(BufferedReaderCopyTest, testBufferedReaderWithReadAndReadLine) {
+  auto chunkSize = GetParam();
+
+  runBufferedReaderTestForReadAndReadLine(chunkSize);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    BufferedReaderCopyTest,
+    BufferedReaderCopyTest,
+    ::testing::Values(1, 10, 40, 100, 200, 500, 1000, 4096),
+    [](const testing::TestParamInfo<BufferedReaderCopyTest::ParamType>& info) {
+      auto chunkSize = std::to_string(info.param);
+      std::string name = "Chunk_size_" + chunkSize;
+      return name;
+    });
+
+} // namespace fbpcf::io


### PR DESCRIPTION
Summary: Create a duplicate version of the BufferedReader called BufferedReaderCopy. It can have exactly the same code, just copy pasted. Let's also duplicate the BufferedReaderTest just as a sanity check. Get that diff accepted, and land it. You will need to modify the TARGETS file to include the .h file(s) in headers and the .cpp file(s) in srcs.

Reviewed By: adshastri

Differential Revision: D37145220

