### PR TITLE
Reimplement AES benchmarks derived from a new LocalBenchmark class

### DIFF
--- a/fbpcf/engine/util/test/benchmarks/LocalBenchmark.h
+++ b/fbpcf/engine/util/test/benchmarks/LocalBenchmark.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/Benchmark.h>
+
+namespace fbpcf::engine::util {
+
+/**
+ * A parent class for local benchmarks that don't need to measure network use.
+ */
+class LocalBenchmark {
+ public:
+  virtual ~LocalBenchmark() = default;
+
+  void runBenchmark(unsigned int n) {
+    BENCHMARK_SUSPEND {
+      setup();
+    }
+
+    run(n);
+
+    BENCHMARK_SUSPEND {
+      teardown();
+    }
+  }
+
+ protected:
+  virtual void setup() {}
+  virtual void teardown() {}
+  virtual void run(unsigned int n) = 0;
+};
+
+} // namespace fbpcf::engine::util


### PR DESCRIPTION
Summary:
Adds a LocalBenchmark class as a base for benchmarks that do not involve
network traffic, then re-implements the existing AES benchmarks using this
class to reduce setup code duplication.

Reviewed By: RuiyuZhu

Differential Revision: D37082978

