### PR TITLE
Stop relying on continuous port numbers

### DIFF
--- a/fbpcf/engine/communication/SocketPartyCommunicationAgent.h
+++ b/fbpcf/engine/communication/SocketPartyCommunicationAgent.h
@@ -25,6 +25,7 @@ class SocketPartyCommunicationAgent final : public IPartyCommunicationAgent {
    * Create as socket server, optionally with TLS.
    */
   explicit SocketPartyCommunicationAgent(
+      int sockFd,
       int portNo,
       bool useTls,
       std::string tlsDir);
@@ -62,10 +63,10 @@ class SocketPartyCommunicationAgent final : public IPartyCommunicationAgent {
   void sendImpl(const void* data, int nBytes) override;
 
  private:
-  void openServerPort(int portNo);
+  void openServerPort(int sockFd, int portNo);
   void openClientPort(const std::string& serverAddress, int portNo);
 
-  void openServerPortWithTls(int portNo, std::string tlsDir);
+  void openServerPortWithTls(int sockFd, int portNo, std::string tlsDir);
   void openClientPortWithTls(
       const std::string& serverAddress,
       int portNo,

--- a/fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.cpp
+++ b/fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.cpp
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h"
+#include <stdexcept>
+
+#include "folly/logging/xlog.h"
+
+namespace fbpcf::engine::communication {
+
+std::unique_ptr<IPartyCommunicationAgent>
+SocketPartyCommunicationAgentFactory::create(int id) {
+  if (id == myId_) {
+    throw std::runtime_error("No need to talk to myself!");
+  } else {
+    auto iter = initialConnections_.find(id);
+    if (iter == initialConnections_.end()) {
+      throw std::runtime_error("Don't know how to connect to this party!");
+    }
+
+    if (id > myId_) {
+      // We first try to bind on the assigned port number (and its nexts). If
+      // that failed, we will try to bind to a free port instead. In either
+      // case, we will tell the client which port to use.
+      auto assignedPortNo = ++iter->second.first.portNo;
+      auto [socket, portNo] = createSocketFromMaybeFreePort(assignedPortNo);
+      iter->second.second->sendSingleT<int>(portNo);
+      return std::make_unique<SocketPartyCommunicationAgent>(
+          socket, portNo, useTls_, tlsDir_);
+    } else {
+      auto portNo = iter->second.second->receiveSingleT<int>();
+      return std::make_unique<SocketPartyCommunicationAgent>(
+          iter->second.first.address, portNo, useTls_, tlsDir_);
+    }
+  }
+}
+
+std::pair<int, int>
+SocketPartyCommunicationAgentFactory::createSocketFromMaybeFreePort(
+    int portNo) {
+  auto sockfd = socket(AF_INET, SOCK_STREAM, 0);
+  if (sockfd < 0) {
+    throw std::runtime_error("error opening socket");
+  }
+  int enable = 1;
+
+  if (setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(int)) < 0) {
+    XLOG(INFO) << "setsockopt(SO_REUSEADDR) failed";
+  }
+
+  struct sockaddr_in servAddr;
+
+  memset((char*)&servAddr, 0, sizeof(servAddr));
+  servAddr.sin_family = AF_INET;
+  servAddr.sin_addr.s_addr = INADDR_ANY;
+  servAddr.sin_port = htons(portNo);
+
+  // if binding to the original port number fails, try to grab a free port
+  // instead
+  if (::bind(sockfd, (struct sockaddr*)&servAddr, sizeof(struct sockaddr_in)) <
+      0) {
+    XLOG(INFO)
+        << "Failed to bind on the assigned port, binding to a free one instead.";
+    portNo = 0;
+    servAddr.sin_port = htons(portNo);
+    if (::bind(
+            sockfd, (struct sockaddr*)&servAddr, sizeof(struct sockaddr_in)) <
+        0) {
+      // throw when failed to bind to a random free port.
+      throw std::runtime_error("error on binding to a free port");
+    }
+  }
+  // only expect 1 client to connect
+  listen(sockfd, 1);
+
+  // port number is known.
+  if (portNo != 0) {
+    return {sockfd, portNo};
+  }
+
+  struct sockaddr_in actualAddr;
+
+  socklen_t len = sizeof(actualAddr);
+  if (::getsockname(sockfd, (struct sockaddr*)&actualAddr, &len) != 0) {
+    throw std::runtime_error("error on getting socket name.");
+  }
+  if (ntohs(actualAddr.sin_port) == 0) {
+    throw std::runtime_error("port number shouldn't be 0.");
+  }
+  return {sockfd, ntohs(actualAddr.sin_port)};
+}
+
+void SocketPartyCommunicationAgentFactory::setupInitialConnection(
+    const std::map<int, PartyInfo>& partyInfos) {
+  for (auto& item : partyInfos) {
+    if (myId_ < item.first) {
+      auto [socket, _] = createSocketFromMaybeFreePort(item.second.portNo);
+      initialConnections_.insert(
+          {item.first,
+           std::make_pair(
+               item.second,
+               std::make_unique<SocketPartyCommunicationAgent>(
+                   socket, item.second.portNo, useTls_, tlsDir_))});
+
+    } else if (myId_ > item.first) {
+      initialConnections_.insert(
+          {item.first,
+           std::make_pair(
+               item.second,
+               std::make_unique<SocketPartyCommunicationAgent>(
+                   item.second.address,
+                   item.second.portNo,
+                   useTls_,
+                   tlsDir_))});
+    }
+  }
+}
+
+} // namespace fbpcf::engine::communication

--- a/fbpcf/engine/communication/test/PartyCommunicationAgentTest.cpp
+++ b/fbpcf/engine/communication/test/PartyCommunicationAgentTest.cpp
@@ -9,6 +9,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <filesystem>
+#include <future>
 #include <memory>
 #include <mutex>
 #include <random>
@@ -47,15 +48,18 @@ void testAgentFactory(
     int totalParty,
     int size,
     std::unique_ptr<IPartyCommunicationAgentFactory> factory) {
-  for (int i = 0; i < totalParty; i++) {
-    std::vector<std::thread> testThreads;
-    if (i != myId) {
-      auto agent = factory->create(i);
-      testThreads.push_back(
-          std::thread(sendAndReceive, std::move(agent), size));
-    }
-    for (auto& t : testThreads) {
-      t.join();
+  // repeat the process multiple times
+  for (int t = 0; t < 3; t++) {
+    for (int i = 0; i < totalParty; i++) {
+      std::vector<std::thread> testThreads(0);
+      if (i != myId) {
+        auto agent = factory->create(i);
+        testThreads.push_back(
+            std::thread(sendAndReceive, std::move(agent), size));
+      }
+      for (auto& thread : testThreads) {
+        thread.join();
+      }
     }
   }
 }
@@ -96,17 +100,23 @@ TEST(SocketPartyCommunicationAgentTest, testSendAndReceiveWithTls) {
   std::map<int, SocketPartyCommunicationAgentFactory::PartyInfo> partyInfo2 = {
       {0, {"127.0.0.1", port02}}, {1, {"127.0.0.1", port12}}};
 
+  auto factory1 = std::async([&partyInfo1, &createdDir]() {
+    return std::make_unique<SocketPartyCommunicationAgentFactory>(
+        1, partyInfo1, true, createdDir);
+  });
+
+  auto factory2 = std::async([&partyInfo2, &createdDir]() {
+    return std::make_unique<SocketPartyCommunicationAgentFactory>(
+        2, partyInfo2, true, createdDir);
+  });
+
   auto factory0 = std::make_unique<SocketPartyCommunicationAgentFactory>(
       0, partyInfo0, true, createdDir);
-  auto factory1 = std::make_unique<SocketPartyCommunicationAgentFactory>(
-      1, partyInfo1, true, createdDir);
-  auto factory2 = std::make_unique<SocketPartyCommunicationAgentFactory>(
-      2, partyInfo2, true, createdDir);
 
   int size = 1048576; // 1024 ^ 2
   auto thread0 = std::thread(testAgentFactory, 0, 3, size, std::move(factory0));
-  auto thread1 = std::thread(testAgentFactory, 1, 3, size, std::move(factory1));
-  auto thread2 = std::thread(testAgentFactory, 2, 3, size, std::move(factory2));
+  auto thread1 = std::thread(testAgentFactory, 1, 3, size, factory1.get());
+  auto thread2 = std::thread(testAgentFactory, 2, 3, size, factory2.get());
 
   thread2.join();
   thread1.join();
@@ -121,8 +131,8 @@ TEST(SocketPartyCommunicationAgentTest, testSendAndReceiveWithoutTls) {
   std::uniform_int_distribution<int> intDistro(10000, 25000);
 
   auto port01 = intDistro(defEngine);
-  auto port02 = intDistro(defEngine);
-  auto port12 = intDistro(defEngine);
+  auto port02 = port01 + 4;
+  auto port12 = port01 + 8;
 
   std::map<int, SocketPartyCommunicationAgentFactory::PartyInfo> partyInfo0 = {
       {1, {"127.0.0.1", port01}}, {2, {"127.0.0.1", port02}}};
@@ -131,20 +141,88 @@ TEST(SocketPartyCommunicationAgentTest, testSendAndReceiveWithoutTls) {
   std::map<int, SocketPartyCommunicationAgentFactory::PartyInfo> partyInfo2 = {
       {0, {"127.0.0.1", port02}}, {1, {"127.0.0.1", port12}}};
 
+  auto factory1 = std::async([&partyInfo1]() {
+    return std::make_unique<SocketPartyCommunicationAgentFactory>(
+        1, partyInfo1);
+  });
+
+  auto factory2 = std::async([&partyInfo2]() {
+    return std::make_unique<SocketPartyCommunicationAgentFactory>(
+        2, partyInfo2);
+  });
+
   auto factory0 =
       std::make_unique<SocketPartyCommunicationAgentFactory>(0, partyInfo0);
-  auto factory1 =
-      std::make_unique<SocketPartyCommunicationAgentFactory>(1, partyInfo1);
-  auto factory2 =
-      std::make_unique<SocketPartyCommunicationAgentFactory>(2, partyInfo2);
 
   int size = 1048576; // 1024 ^ 2
+
   auto thread0 = std::thread(testAgentFactory, 0, 3, size, std::move(factory0));
-  auto thread1 = std::thread(testAgentFactory, 1, 3, size, std::move(factory1));
-  auto thread2 = std::thread(testAgentFactory, 2, 3, size, std::move(factory2));
+  auto thread1 = std::thread(testAgentFactory, 1, 3, size, factory1.get());
+  auto thread2 = std::thread(testAgentFactory, 2, 3, size, factory2.get());
 
   thread2.join();
   thread1.join();
   thread0.join();
 }
+
+TEST(SocketPartyCommunicationAgentTest, testSendAndReceiveWithJammedPort) {
+  std::random_device rd;
+  std::default_random_engine defEngine(rd());
+  std::uniform_int_distribution<int> intDistro(10000, 25000);
+
+  auto port01 = intDistro(defEngine);
+  auto port02 = port01 + 4;
+  auto port12 = port01 + 8;
+
+  std::map<int, SocketPartyCommunicationAgentFactory::PartyInfo> partyInfo0 = {
+      {1, {"127.0.0.1", port01}}, {2, {"127.0.0.1", port02}}};
+  std::map<int, SocketPartyCommunicationAgentFactory::PartyInfo> partyInfo1 = {
+      {0, {"127.0.0.1", port01}}, {2, {"127.0.0.1", port12}}};
+  std::map<int, SocketPartyCommunicationAgentFactory::PartyInfo> partyInfo2 = {
+      {0, {"127.0.0.1", port02}}, {1, {"127.0.0.1", port12}}};
+
+  {
+    // jam the ports here
+    struct sockaddr_in servAddr;
+
+    memset((char*)&servAddr, 0, sizeof(servAddr));
+    servAddr.sin_family = AF_INET;
+    servAddr.sin_addr.s_addr = INADDR_ANY;
+
+    servAddr.sin_port = htons(port01 + 1);
+    auto sockfd1 = socket(AF_INET, SOCK_STREAM, 0);
+    ::bind(sockfd1, (struct sockaddr*)&servAddr, sizeof(struct sockaddr_in));
+
+    servAddr.sin_port = htons(port02 + 1);
+    auto sockfd2 = socket(AF_INET, SOCK_STREAM, 0);
+    ::bind(sockfd2, (struct sockaddr*)&servAddr, sizeof(struct sockaddr_in));
+
+    servAddr.sin_port = htons(port12 + 1);
+    auto sockfd3 = socket(AF_INET, SOCK_STREAM, 0);
+    ::bind(sockfd3, (struct sockaddr*)&servAddr, sizeof(struct sockaddr_in));
+  }
+
+  auto factory1 = std::async([&partyInfo1]() {
+    return std::make_unique<SocketPartyCommunicationAgentFactory>(
+        1, partyInfo1);
+  });
+
+  auto factory2 = std::async([&partyInfo2]() {
+    return std::make_unique<SocketPartyCommunicationAgentFactory>(
+        2, partyInfo2);
+  });
+
+  auto factory0 =
+      std::make_unique<SocketPartyCommunicationAgentFactory>(0, partyInfo0);
+
+  int size = 1048576; // 1024 ^ 2
+  auto thread0 = std::thread(testAgentFactory, 0, 3, size, std::move(factory0));
+  auto thread1 = std::thread(testAgentFactory, 1, 3, size, factory1.get());
+  auto thread2 = std::thread(testAgentFactory, 2, 3, size, factory2.get());
+
+  thread2.join();
+  thread1.join();
+  thread0.join();
+}
+
 } // namespace fbpcf::engine::communication

--- a/fbpcf/engine/util/test/benchmarks/BenchmarkHelper.h
+++ b/fbpcf/engine/util/test/benchmarks/BenchmarkHelper.h
@@ -54,12 +54,14 @@ getSocketAgents() {
           communication::SocketPartyCommunicationAgentFactory::PartyInfo>
           partyInfo1 = {{0, {"127.0.0.1", port}}};
 
+      auto factory1Future = std::async([&partyInfo1]() {
+        return std::make_unique<
+            communication::SocketPartyCommunicationAgentFactory>(1, partyInfo1);
+      });
       auto factory0 =
           std::make_unique<communication::SocketPartyCommunicationAgentFactory>(
               0, partyInfo0);
-      auto factory1 =
-          std::make_unique<communication::SocketPartyCommunicationAgentFactory>(
-              1, partyInfo1);
+      auto factory1 = factory1Future.get();
 
       auto task =
           [](std::unique_ptr<communication::IPartyCommunicationAgentFactory>


### PR DESCRIPTION
Summary:
We used to use continuous port numbers when creating connections. E.g. when port 30000 is provided, we will use port 30000, 30001, 30002,... to establish connections. One motivation behind that is the limited range of ports that are not blocked by firewall (https://www.internalfb.com/code/fbsource/[897a4c792d85b834cf4a200a4843234b43dc1d23]/fbcode/fbpcs/infra/pce/aws_terraform_template/common/pce/networking.tf?lines=74-75), PCF needs to be instructed how to choose ports.

This is not a big deal in production as MPC is the only running binary. However this will become an issue in continuous tests when our test binary is share a container with a large number of other stranger binaries who has no agreement with us on how to allocate the port numbers. Last time when encountering this issue, our fix was to pass a guaranteed-to-be-free port number to PCF from application layer. This was merely a temp patch. This approach can work under the following assumptions: the following several port numbers after the given free port are also free, which can be totally untrue.

This time, we will address this issue for good. This diff will make PCF rely on only one provided free port and it will be able to find more on its own.

Here is our high-level algorithm:
1.  each pair of parties will establish a dedicated connection on the provided free port. This connection's only purpose is to communicate which port to use to establish next connection.
2. Each time a connection request comes in, the server will first try to bind to the assigned port. If failed, the server will find a new free port on its end instead.
3. In either case, the server tells the client to which port to use for connection.

See more details on the comments below and embedded in code.

We use bind() function to get a new free port. According to its man page(https://man7.org/linux/man-pages/man2/bind.2.html). This function will find a free port if a port number 0 is provided.  We use getsockname() to get the port number of this new free port(https://man7.org/linux/man-pages/man2/getsockname.2.html).

Differential Revision: D37131828

