### PR TITLE
Add name when creating a new connection

### DIFF
--- a/fbpcf/engine/communication/AgentMapHelper.h
+++ b/fbpcf/engine/communication/AgentMapHelper.h
@@ -27,7 +27,10 @@ inline std::map<int, std::unique_ptr<IPartyCommunicationAgent>> getAgentMap(
       agentMap;
   for (int i = 0; i < numberOfParties; i++) {
     if (i != myId) {
-      agentMap.emplace(i, agentFactory.create(i));
+      agentMap.emplace(
+          i,
+          agentFactory.create(
+              i, "Secret_Share_Engine_Traffic_to_Party " + std::to_string(i)));
     }
   }
   return agentMap;

--- a/fbpcf/engine/communication/IPartyCommunicationAgentFactory.h
+++ b/fbpcf/engine/communication/IPartyCommunicationAgentFactory.h
@@ -8,7 +8,9 @@
 #pragma once
 #include <memory>
 
+#include <folly/dynamic.h>
 #include "fbpcf/engine/communication/IPartyCommunicationAgent.h"
+#include "fbpcf/util/MetricCollector.h"
 
 namespace fbpcf::engine::communication {
 
@@ -17,12 +19,25 @@ namespace fbpcf::engine::communication {
  */
 class IPartyCommunicationAgentFactory {
  public:
+  IPartyCommunicationAgentFactory(std::string name = "unnamed_traffic")
+      : metricCollector_(std::make_shared<fbpcf::util::MetricCollector>(name)) {
+  }
+
   virtual ~IPartyCommunicationAgentFactory() = default;
 
   /**
    * create an agent that talks to a certain party.
    */
-  virtual std::unique_ptr<IPartyCommunicationAgent> create(int id) = 0;
+  virtual std::unique_ptr<IPartyCommunicationAgent> create(
+      int id,
+      std::string name = "unnamed_traffic") = 0;
+
+  std::shared_ptr<fbpcf::util::MetricCollector> getMetricsCollector() const {
+    return metricCollector_;
+  }
+
+ protected:
+  std::shared_ptr<fbpcf::util::MetricCollector> metricCollector_;
 };
 
 } // namespace fbpcf::engine::communication

--- a/fbpcf/engine/communication/IPartyCommunicationAgentFactory.h
+++ b/fbpcf/engine/communication/IPartyCommunicationAgentFactory.h
@@ -30,7 +30,7 @@ class IPartyCommunicationAgentFactory {
    */
   virtual std::unique_ptr<IPartyCommunicationAgent> create(
       int id,
-      std::string name = "unnamed_traffic") = 0;
+      std::string name) = 0;
 
   std::shared_ptr<fbpcf::util::MetricCollector> getMetricsCollector() const {
     return metricCollector_;

--- a/fbpcf/engine/communication/InMemoryPartyCommunicationAgentFactory.h
+++ b/fbpcf/engine/communication/InMemoryPartyCommunicationAgentFactory.h
@@ -42,7 +42,8 @@ class InMemoryPartyCommunicationAgentFactory final
   /**
    * @inherit doc
    */
-  std::unique_ptr<IPartyCommunicationAgent> create(int id) override {
+  std::unique_ptr<IPartyCommunicationAgent> create(int id, std::string)
+      override {
     if (sharedHosts_.find(id) == sharedHosts_.end() ||
         createdAgentCount_.find(id) == createdAgentCount_.end()) {
       throw std::runtime_error(" can't connect to this party!");

--- a/fbpcf/engine/communication/SocketPartyCommunicationAgent.h
+++ b/fbpcf/engine/communication/SocketPartyCommunicationAgent.h
@@ -28,7 +28,8 @@ class SocketPartyCommunicationAgent final : public IPartyCommunicationAgent {
       int sockFd,
       int portNo,
       bool useTls,
-      std::string tlsDir);
+      std::string tlsDir,
+      std::shared_ptr<PartyCommunicationAgentTrafficRecorder> recorder);
 
   /**
    * Created as socket client, optionally with TLS.
@@ -37,7 +38,8 @@ class SocketPartyCommunicationAgent final : public IPartyCommunicationAgent {
       const std::string& serverAddress,
       int portNo,
       bool useTls,
-      std::string tlsDir);
+      std::string tlsDir,
+      std::shared_ptr<PartyCommunicationAgentTrafficRecorder> recorder);
 
   ~SocketPartyCommunicationAgent() override;
 
@@ -55,7 +57,7 @@ class SocketPartyCommunicationAgent final : public IPartyCommunicationAgent {
    * @inherit doc
    */
   std::pair<uint64_t, uint64_t> getTrafficStatistics() const override {
-    return {sentData_, receivedData_};
+    return recorder_->getTrafficStatistics();
   }
 
   void recvImpl(void* data, int nBytes) override;
@@ -80,8 +82,7 @@ class SocketPartyCommunicationAgent final : public IPartyCommunicationAgent {
   FILE* incomingPort_;
   FILE* outgoingPort_;
 
-  uint64_t sentData_;
-  uint64_t receivedData_;
+  std::shared_ptr<PartyCommunicationAgentTrafficRecorder> recorder_;
 
   SSL* ssl_;
 };

--- a/fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h
+++ b/fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h
@@ -16,7 +16,9 @@
 #include <unistd.h>
 #include <cerrno>
 #include <stdexcept>
+#include <string>
 
+#include <fbpcf/util/MetricCollector.h>
 #include "fbpcf/engine/communication/IPartyCommunicationAgentFactory.h"
 #include "fbpcf/engine/communication/SocketPartyCommunicationAgent.h"
 
@@ -45,8 +47,12 @@ establishing multiple connections (>3) between each party pair.
   */
   SocketPartyCommunicationAgentFactory(
       int myId,
-      std::map<int, PartyInfo> partyInfos)
-      : myId_(myId), useTls_(false), tlsDir_("") {
+      std::map<int, PartyInfo> partyInfos,
+      std::string myname = "unnamed_traffic_factory")
+      : IPartyCommunicationAgentFactory(myname),
+        myId_(myId),
+        useTls_(false),
+        tlsDir_("") {
     setupInitialConnection(partyInfos);
   }
 
@@ -54,15 +60,20 @@ establishing multiple connections (>3) between each party pair.
       int myId,
       std::map<int, PartyInfo> partyInfos,
       bool useTls,
-      std::string tlsDir)
-      : myId_(myId), useTls_(useTls), tlsDir_(tlsDir) {
+      std::string tlsDir,
+      std::string myname = "unnamed_traffic_factory")
+      : IPartyCommunicationAgentFactory(myname),
+        myId_(myId),
+        useTls_(useTls),
+        tlsDir_(tlsDir) {
     setupInitialConnection(partyInfos);
   }
 
   /**
    * create an agent that talks to a certain party
    */
-  std::unique_ptr<IPartyCommunicationAgent> create(int id) override;
+  std::unique_ptr<IPartyCommunicationAgent> create(int id, std::string name)
+      override;
 
  private:
   /**

--- a/fbpcf/engine/tuple_generator/DummyProductShareGeneratorFactory.h
+++ b/fbpcf/engine/tuple_generator/DummyProductShareGeneratorFactory.h
@@ -25,7 +25,8 @@ class DummyProductShareGeneratorFactory final
       : factory_(factory) {}
 
   std::unique_ptr<IProductShareGenerator> create(int id) override {
-    return std::make_unique<DummyProductShareGenerator>(factory_.create(id));
+    return std::make_unique<DummyProductShareGenerator>(
+        factory_.create(id, "Dummy_Product_Generator_Traffic"));
   }
 
  private:

--- a/fbpcf/engine/tuple_generator/TwoPartyTupleGeneratorFactory.h
+++ b/fbpcf/engine/tuple_generator/TwoPartyTupleGeneratorFactory.h
@@ -46,11 +46,19 @@ class TwoPartyTupleGeneratorFactory final : public ITupleGeneratorFactory {
     auto otherId = 1 - myId_;
 
     if (myId_ == 0) {
-      senderRcot = rcotFactory_->create(delta, agentFactory_.create(otherId));
-      receiverRcot = rcotFactory_->create(agentFactory_.create(otherId));
+      senderRcot = rcotFactory_->create(
+          delta,
+          agentFactory_.create(
+              otherId, "Two_party_Tuple_Generator_Traffic_as_OT_sender"));
+      receiverRcot = rcotFactory_->create(agentFactory_.create(
+          otherId, "Two_party_Tuple_Generator_Traffic_as_OT_receiver"));
     } else {
-      receiverRcot = rcotFactory_->create(agentFactory_.create(otherId));
-      senderRcot = rcotFactory_->create(delta, agentFactory_.create(otherId));
+      receiverRcot = rcotFactory_->create(agentFactory_.create(
+          otherId, "Two_party_Tuple_Generator_Traffic_as_OT_receiver"));
+      senderRcot = rcotFactory_->create(
+          delta,
+          agentFactory_.create(
+              otherId, "Two_party_Tuple_Generator_Traffic_as_OT_sender"));
     }
 
     return std::make_unique<TwoPartyTupleGenerator>(

--- a/fbpcf/engine/tuple_generator/oblivious_transfer/DummyBidirectionObliviousTransferFactory.h
+++ b/fbpcf/engine/tuple_generator/oblivious_transfer/DummyBidirectionObliviousTransferFactory.h
@@ -24,7 +24,7 @@ class DummyBidirectionObliviousTransferFactory final
 
   std::unique_ptr<IBidirectionObliviousTransfer<T>> create(int id) override {
     return std::make_unique<DummyBidirectionObliviousTransfer<T>>(
-        factory_.create(id));
+        factory_.create(id, "Dummy_Bidirection_OT_traffic"));
   }
 
  private:

--- a/fbpcf/engine/tuple_generator/oblivious_transfer/RcotBasedBidirectionObliviousTransferFactory.h
+++ b/fbpcf/engine/tuple_generator/oblivious_transfer/RcotBasedBidirectionObliviousTransferFactory.h
@@ -38,15 +38,19 @@ class RcotBasedBidirectionObliviousTransferFactory final
     std::unique_ptr<IRandomCorrelatedObliviousTransfer> receiverRcot;
 
     if (id < myid_) {
-      senderRcot = rcotFactory_->create(delta, agentFactory_.create(id));
-      receiverRcot = rcotFactory_->create(agentFactory_.create(id));
+      senderRcot = rcotFactory_->create(
+          delta, agentFactory_.create(id, "RCOT_sender_traffic"));
+      receiverRcot = rcotFactory_->create(
+          agentFactory_.create(id, "RCOT_receiver_traffic"));
     } else {
-      receiverRcot = rcotFactory_->create(agentFactory_.create(id));
-      senderRcot = rcotFactory_->create(delta, agentFactory_.create(id));
+      receiverRcot = rcotFactory_->create(
+          agentFactory_.create(id, "RCOT_receiver_traffic"));
+      senderRcot = rcotFactory_->create(
+          delta, agentFactory_.create(id, "RCOT_sender_traffic"));
     }
 
     return std::make_unique<RcotBasedBidirectionObliviousTransfer<T>>(
-        agentFactory_.create(id),
+        agentFactory_.create(id, "BiDirection_OT_traffic"),
         delta,
         std::move(senderRcot),
         std::move(receiverRcot));

--- a/fbpcf/engine/util/test/benchmarks/BenchmarkHelper.h
+++ b/fbpcf/engine/util/test/benchmarks/BenchmarkHelper.h
@@ -110,7 +110,8 @@ class BenchmarkSocketAgentFactory final
   // NOTE: This API is not thread-safe if one party is creating new agents in
   // multiple threads.
   std::unique_ptr<communication::IPartyCommunicationAgent> create(
-      int id) override {
+      int id,
+      std::string) override {
     std::lock_guard<std::mutex> lock(*agentsByParty_->mutex);
 
     if (agentsByParty_->agents.at(myId_).empty()) {

--- a/fbpcf/engine/util/test/benchmarks/BenchmarkHelper.h
+++ b/fbpcf/engine/util/test/benchmarks/BenchmarkHelper.h
@@ -66,7 +66,9 @@ getSocketAgents() {
       auto task =
           [](std::unique_ptr<communication::IPartyCommunicationAgentFactory>
                  factory,
-             int myId) { return factory->create(1 - myId); };
+             int myId) {
+            return factory->create(1 - myId, "benchmark_traffic");
+          };
 
       auto createSocketAgent0 = std::async(task, std::move(factory0), 0);
       auto createSocketAgent1 = std::async(task, std::move(factory1), 1);

--- a/fbpcf/mpc_std_lib/oram/DummyDifferenceCalculatorFactory.h
+++ b/fbpcf/mpc_std_lib/oram/DummyDifferenceCalculatorFactory.h
@@ -28,7 +28,8 @@ class DummyDifferenceCalculatorFactory final
 
   std::unique_ptr<IDifferenceCalculator<T>> create() override {
     return std::make_unique<DummyDifferenceCalculator<T, indicatorSumWidth>>(
-        thisPartyToSetDifference_, factory_.create(peerId_));
+        thisPartyToSetDifference_,
+        factory_.create(peerId_, "Dummy_Difference_Calculator_Traffic"));
   }
 
  private:

--- a/fbpcf/mpc_std_lib/oram/DummyObliviousDeltaCalculatorFactory.h
+++ b/fbpcf/mpc_std_lib/oram/DummyObliviousDeltaCalculatorFactory.h
@@ -24,7 +24,7 @@ class DummyObliviousDeltaCalculatorFactory final
 
   std::unique_ptr<IObliviousDeltaCalculator> create() override {
     return std::make_unique<DummyObliviousDeltaCalculator>(
-        factory_.create(peerId_));
+        factory_.create(peerId_, "Dummy_Oblivious_Delta_Calculator_Traffic"));
   }
 
  private:

--- a/fbpcf/mpc_std_lib/oram/DummySinglePointArrayGeneratorFactory.h
+++ b/fbpcf/mpc_std_lib/oram/DummySinglePointArrayGeneratorFactory.h
@@ -27,7 +27,8 @@ class DummySinglePointArrayGeneratorFactory final
 
   std::unique_ptr<ISinglePointArrayGenerator> create() override {
     return std::make_unique<DummySinglePointArrayGenerator>(
-        thisPartyToSetIndicator_, factory_.create(peerId_));
+        thisPartyToSetIndicator_,
+        factory_.create(peerId_, "Dummy_Single_Point_Array_Generator_Traffic"));
   }
 
  private:

--- a/fbpcf/mpc_std_lib/oram/LinearOramFactory.h
+++ b/fbpcf/mpc_std_lib/oram/LinearOramFactory.h
@@ -41,7 +41,7 @@ class LinearOramFactory final : public IWriteOnlyOramFactory<T> {
         myRole_,
         party0Id_,
         party1Id_,
-        agentFactory_.create(peerId_),
+        agentFactory_.create(peerId_, "Linear_ORAM_Traffic"),
         prgFactory_->create(engine::util::getRandomM128iFromSystemNoise()));
   }
 

--- a/fbpcf/mpc_std_lib/oram/WriteOnlyOramFactory.h
+++ b/fbpcf/mpc_std_lib/oram/WriteOnlyOramFactory.h
@@ -40,7 +40,7 @@ class WriteOnlyOramFactory final : public IWriteOnlyOramFactory<T> {
     return std::make_unique<WriteOnlyOram<T>>(
         myRole_,
         size,
-        factory_.create(peerId_),
+        factory_.create(peerId_, "Write_only_ORAM_traffic"),
         singlePointArrayFactory_->create(),
         differenceCalculatorFactory_->create());
   }

--- a/fbpcf/util/IMetricRecorder.h
+++ b/fbpcf/util/IMetricRecorder.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/dynamic.h>
+
+namespace fbpcf::util {
+/**
+ * Different components could have different implementation of this recorder.
+ * The only function of this interface is to allow metric collector to pull
+ * metrics regardless of the actual implementation. The implementation of
+ * this object needs to be thread-safe.
+ */
+
+class IMetricRecorder {
+ public:
+  virtual ~IMetricRecorder() = default;
+  // return a map of metric name and values.
+  virtual folly::dynamic getMetrics() const = 0;
+};
+
+} // namespace fbpcf::util

--- a/fbpcf/util/MetricCollector.h
+++ b/fbpcf/util/MetricCollector.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/dynamic.h>
+#include <string>
+#include <unordered_map>
+#include "fbpcf/util/IMetricRecorder.h"
+
+namespace fbpcf::util {
+
+class MetricCollector {
+ public:
+  explicit MetricCollector(std::string prefix) : prefix_(prefix) {}
+
+  void addNewRecorder(
+      std::string name,
+      std::shared_ptr<IMetricRecorder> recorder) {
+    recorders_.emplace(name, recorder);
+  }
+
+  folly::dynamic collectMetrics() const {
+    folly::dynamic result = folly::dynamic::object;
+    for (const auto& [key, recorder] : recorders_) {
+      result.insert(prefix_ + "." + key, recorder->getMetrics());
+    }
+    return result;
+  }
+
+ private:
+  std::unordered_map<std::string, std::shared_ptr<IMetricRecorder>> recorders_;
+  std::string prefix_;
+};
+
+} // namespace fbpcf::util

--- a/fbpcf/util/test/MetricCollectorTest.cpp
+++ b/fbpcf/util/test/MetricCollectorTest.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "fbpcf/util/MetricCollector.h"
+#include <folly/dynamic.h>
+#include <gtest/gtest.h>
+
+namespace fbpcf::util {
+
+using namespace ::testing;
+
+class TestMetricRecorder final : public IMetricRecorder {
+ public:
+  explicit TestMetricRecorder(folly::dynamic output) : output_(output) {}
+  folly::dynamic getMetrics() const override {
+    return output_;
+  }
+
+ private:
+  folly::dynamic output_;
+};
+
+TEST(MetricCollectorTest, testMetricCollector) {
+  MetricCollector collector("test");
+
+  folly::dynamic metric1 = folly::dynamic::object("time", 3)("speed", 2);
+  folly::dynamic metric2 =
+      folly::dynamic::object("volume", "high")("price", 99.3);
+  folly::dynamic expectedOutcome =
+      folly::dynamic::object("test.traffic", metric1)("test.liquid", metric2);
+  {
+    std::shared_ptr<IMetricRecorder> r1 =
+        std::make_shared<TestMetricRecorder>(metric1);
+    std::shared_ptr<IMetricRecorder> r2 =
+        std::make_shared<TestMetricRecorder>(metric2);
+
+    collector.addNewRecorder("traffic", r1);
+    collector.addNewRecorder("liquid", r2);
+    // the recorders are going out of scope.
+  }
+  auto outcome = collector.collectMetrics();
+  EXPECT_EQ(expectedOutcome, outcome);
+}
+
+} // namespace fbpcf::util


### PR DESCRIPTION
Summary: In this diff, we give each connection a name such that we know how to interpret the metrics.

Reviewed By: adshastri

Differential Revision: D37305211

