### PR TITLE
Change FileIOWrappers parameter to const

### DIFF
--- a/fbpcf/io/api/BufferedWriter.cpp
+++ b/fbpcf/io/api/BufferedWriter.cpp
@@ -45,7 +45,7 @@ size_t BufferedWriter::write(std::vector<char>& buf) {
   return written;
 }
 
-size_t BufferedWriter::writeString(std::string& line) {
+size_t BufferedWriter::writeString(const std::string& line) {
   auto vec = std::vector<char>(line.size());
   std::copy(line.begin(), line.end(), vec.begin());
 

--- a/fbpcf/io/api/BufferedWriter.h
+++ b/fbpcf/io/api/BufferedWriter.h
@@ -33,7 +33,7 @@ class BufferedWriter : public IWriterCloser {
 
   int close() override;
   size_t write(std::vector<char>& buf) override;
-  size_t writeString(std::string& line);
+  size_t writeString(const std::string& line);
   ~BufferedWriter() override;
 
   void flush();

--- a/fbpcf/io/api/FileIOWrappers.cpp
+++ b/fbpcf/io/api/FileIOWrappers.cpp
@@ -32,7 +32,7 @@ std::string FileIOWrappers::readFile(const std::string& srcPath) {
 
 void FileIOWrappers::writeFile(
     const std::string& destPath,
-    std::string& content) {
+    const std::string& content) {
   auto fileWriter = std::make_unique<fbpcf::io::FileWriter>(destPath);
   auto bufferedWriter = std::make_unique<fbpcf::io::BufferedWriter>(
       std::move(fileWriter), kBufferedWriterChunkSize);

--- a/fbpcf/io/api/FileIOWrappers.h
+++ b/fbpcf/io/api/FileIOWrappers.h
@@ -31,7 +31,9 @@ constexpr size_t kBufferedWriterChunkSize = 5'242'880;
 class FileIOWrappers {
  public:
   static std::string readFile(const std::string& srcPath);
-  static void writeFile(const std::string& destPath, std::string& content);
+  static void writeFile(
+      const std::string& destPath,
+      const std::string& content);
   static void transferFileInParts(
       const std::string& srcPath,
       const std::string& destPath);


### PR DESCRIPTION
Summary:
Make

`FileIOWrappers::writeFile(const std::string& destPath, std::string& content)`
 to
`FileIOWrappers::writeFile(const std::string& destPath, const std::string& content)`

which make more sense and avoid const casting for most usecase.

Differential Revision: D37251086

