### PR TITLE
add a metric collection object (#231)

### DIFF
--- a/fbpcf/util/IMetricRecorder.h
+++ b/fbpcf/util/IMetricRecorder.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/dynamic.h>
+
+namespace fbpcf::util {
+/**
+ * Different components could have different implementation of this recorder.
+ * The only function of this interface is to allow metric collector to pull
+ * metrics regardless of the actual implementation. The implementation of
+ * this object needs to be thread-safe.
+ */
+
+class IMetricRecorder {
+ public:
+  virtual ~IMetricRecorder() = default;
+  // return a map of metric name and values.
+  virtual folly::dynamic getMetrics() const = 0;
+};
+
+} // namespace fbpcf::util

--- a/fbpcf/util/MetricCollector.h
+++ b/fbpcf/util/MetricCollector.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/dynamic.h>
+#include <string>
+#include <unordered_map>
+#include "fbpcf/util/IMetricRecorder.h"
+
+namespace fbpcf::util {
+
+class MetricCollector {
+ public:
+  explicit MetricCollector(std::string prefix) : prefix_(prefix) {}
+
+  void addNewRecorder(
+      std::string name,
+      std::shared_ptr<IMetricRecorder> recorder) {
+    recorders_.emplace(name, recorder);
+  }
+
+  folly::dynamic collectMetrics() const {
+    folly::dynamic result = folly::dynamic::object;
+    for (const auto& [key, recorder] : recorders_) {
+      result.insert(prefix_ + "." + key, recorder->getMetrics());
+    }
+    return result;
+  }
+
+ private:
+  std::unordered_map<std::string, std::shared_ptr<IMetricRecorder>> recorders_;
+  std::string prefix_;
+};
+
+} // namespace fbpcf::util

--- a/fbpcf/util/test/MetricCollectorTest.cpp
+++ b/fbpcf/util/test/MetricCollectorTest.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "fbpcf/util/MetricCollector.h"
+#include <folly/dynamic.h>
+#include <gtest/gtest.h>
+
+namespace fbpcf::util {
+
+using namespace ::testing;
+
+class TestMetricRecorder final : public IMetricRecorder {
+ public:
+  explicit TestMetricRecorder(folly::dynamic output) : output_(output) {}
+  folly::dynamic getMetrics() const override {
+    return output_;
+  }
+
+ private:
+  folly::dynamic output_;
+};
+
+TEST(MetricCollectorTest, testMetricCollector) {
+  MetricCollector collector("test");
+
+  folly::dynamic metric1 = folly::dynamic::object("time", 3)("speed", 2);
+  folly::dynamic metric2 =
+      folly::dynamic::object("volume", "high")("price", 99.3);
+  folly::dynamic expectedOutcome =
+      folly::dynamic::object("test.traffic", metric1)("test.liquid", metric2);
+  {
+    std::shared_ptr<IMetricRecorder> r1 =
+        std::make_shared<TestMetricRecorder>(metric1);
+    std::shared_ptr<IMetricRecorder> r2 =
+        std::make_shared<TestMetricRecorder>(metric2);
+
+    collector.addNewRecorder("traffic", r1);
+    collector.addNewRecorder("liquid", r2);
+    // the recorders are going out of scope.
+  }
+  auto outcome = collector.collectMetrics();
+  EXPECT_EQ(expectedOutcome, outcome);
+}
+
+} // namespace fbpcf::util


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookresearch/fbpcf/pull/231

We are adding a component that allows monitoring our system with more granularity. This diff adds a metric collector and API for metric recorders.

Reviewed By: adshastri

Differential Revision: D37305212

