### PR TITLE
Back out "Log in applications"

### DIFF
--- a/example/billionaire_problem/main.cpp
+++ b/example/billionaire_problem/main.cpp
@@ -5,14 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <folly/json.h>
 #include <gflags/gflags.h>
-
-#include "./BillionaireProblemGame.h"
-#include "fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h"
 #include "fbpcf/scheduler/SchedulerHelper.h"
 #include "folly/init/Init.h"
 #include "folly/logging/xlog.h"
+
+#include "./BillionaireProblemGame.h"
+#include "fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h"
 
 DEFINE_int32(party, 0, "my party ID");
 DEFINE_string(server_ip, "127.0.0.1", "server's ip address");
@@ -35,7 +34,7 @@ int main(int argc, char* argv[]) {
            {1, {FLAGS_server_ip, FLAGS_port}}});
   auto factory = std::make_unique<
       fbpcf::engine::communication::SocketPartyCommunicationAgentFactory>(
-      FLAGS_party, partyInfos, "billionaire_problem_traffic");
+      FLAGS_party, partyInfos);
 
   auto game = std::make_unique<
       fbpcf::billionaire_problem::BillionaireProblemGame<0, true>>(
@@ -80,7 +79,4 @@ int main(int argc, char* argv[]) {
     XLOG(FATAL, "Failed to execute the game!");
   }
   XLOG(INFO, "Game executed successfully!");
-  XLOG(
-      INFO,
-      folly::toPrettyJson(factory->getMetricsCollector()->collectMetrics()));
 }

--- a/fbpcf/engine/communication/IPartyCommunicationAgentFactory.h
+++ b/fbpcf/engine/communication/IPartyCommunicationAgentFactory.h
@@ -19,7 +19,7 @@ namespace fbpcf::engine::communication {
  */
 class IPartyCommunicationAgentFactory {
  public:
-  explicit IPartyCommunicationAgentFactory(std::string name)
+  IPartyCommunicationAgentFactory(std::string name = "unnamed_traffic")
       : metricCollector_(std::make_shared<fbpcf::util::MetricCollector>(name)) {
   }
 

--- a/fbpcf/engine/communication/InMemoryPartyCommunicationAgentFactory.h
+++ b/fbpcf/engine/communication/InMemoryPartyCommunicationAgentFactory.h
@@ -33,9 +33,7 @@ class InMemoryPartyCommunicationAgentFactory final
   InMemoryPartyCommunicationAgentFactory(
       int myId,
       std::map<int, std::shared_ptr<HostInfo>>&& sharedHosts)
-      : IPartyCommunicationAgentFactory("in_memory_traffic"),
-        myId_(myId),
-        sharedHosts_(sharedHosts) {
+      : myId_(myId), sharedHosts_(sharedHosts) {
     for (auto& item : sharedHosts_) {
       createdAgentCount_.emplace(item.first, 0);
     }

--- a/fbpcf/engine/util/test/benchmarks/BenchmarkHelper.h
+++ b/fbpcf/engine/util/test/benchmarks/BenchmarkHelper.h
@@ -102,9 +102,7 @@ class BenchmarkSocketAgentFactory final
   BenchmarkSocketAgentFactory(
       int myId,
       std::shared_ptr<AgentsByParty> agentsByParty)
-      : communication::IPartyCommunicationAgentFactory("benchmark_traffic"),
-        myId_(myId),
-        agentsByParty_(agentsByParty) {}
+      : myId_(myId), agentsByParty_(agentsByParty) {}
 
   // The socket agents are stored in a queue.
   // If a party calls create() and the queue is empty, create a new pair of


### PR DESCRIPTION
Summary: generated via `hg backout D37323715 (https://github.com/facebookresearch/fbpcf/commit/9fd60f8e04a50976833913560e2a993b00a28482)` to fix an e2e test failure.

Differential Revision: D37529257

