### PR TITLE
((MINOR)) [PCF][BE] Mandatory name requirement for socket connection factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change log
 All notable changes to this project will be documented in this file.
 
+## [2.1.0] - 2022-06-30
+- Each socket connection and socket connection factory now need a dedicated name.
+- The traffic on each socket connection will be monitored separately.
+
+
 ## [2.0.0] - 2022-05-05
 - New features and APIs are explained in the README
 - Removed dependence on EMP-toolkit

--- a/fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h
+++ b/fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h
@@ -48,7 +48,7 @@ establishing multiple connections (>3) between each party pair.
   SocketPartyCommunicationAgentFactory(
       int myId,
       std::map<int, PartyInfo> partyInfos,
-      std::string myname = "unnamed_traffic_factory")
+      std::string myname)
       : IPartyCommunicationAgentFactory(myname),
         myId_(myId),
         useTls_(false),
@@ -61,7 +61,7 @@ establishing multiple connections (>3) between each party pair.
       std::map<int, PartyInfo> partyInfos,
       bool useTls,
       std::string tlsDir,
-      std::string myname = "unnamed_traffic_factory")
+      std::string myname)
       : IPartyCommunicationAgentFactory(myname),
         myId_(myId),
         useTls_(useTls),


### PR DESCRIPTION
Summary:
((MINOR))
As title.
Giving a name for each socket connection factory is a mandatory now.

Reviewed By: adshastri

Differential Revision: D37537260

