### PR TITLE
Use singleton S3Client for reads

### DIFF
--- a/fbpcf/io/cloud_util/CloudFileUtil.cpp
+++ b/fbpcf/io/cloud_util/CloudFileUtil.cpp
@@ -47,8 +47,10 @@ std::unique_ptr<IFileReader> getCloudFileReader(const std::string& filePath) {
   auto fileType = getCloudFileType(filePath);
   if (fileType == CloudFileType::S3) {
     const auto& ref = fbpcf::aws::uriToObjectReference(filePath);
-    return std::make_unique<S3FileReader>(fbpcf::aws::createS3Client(
-        fbpcf::aws::S3ClientOption{.region = ref.region}));
+    return std::make_unique<S3FileReader>(
+        fbpcf::cloudio::S3Client::getInstance(
+            fbpcf::aws::S3ClientOption{.region = ref.region})
+            .getS3Client());
   } else {
     return nullptr;
   }

--- a/fbpcf/io/cloud_util/S3FileReader.h
+++ b/fbpcf/io/cloud_util/S3FileReader.h
@@ -16,8 +16,8 @@ namespace fbpcf::cloudio {
 
 class S3FileReader : public IFileReader {
  public:
-  explicit S3FileReader(std::unique_ptr<Aws::S3::S3Client> client)
-      : s3Client_{std::move(client)} {}
+  explicit S3FileReader(std::shared_ptr<Aws::S3::S3Client> client)
+      : s3Client_{client} {}
 
   std::string readBytes(
       const std::string& filePath,
@@ -27,7 +27,7 @@ class S3FileReader : public IFileReader {
   size_t getFileContentLength(const std::string& filePath) override;
 
  private:
-  std::unique_ptr<Aws::S3::S3Client> s3Client_;
+  std::shared_ptr<Aws::S3::S3Client> s3Client_;
 };
 
 } // namespace fbpcf::cloudio


### PR DESCRIPTION
Summary:
# What
Previously, we noticed a bug during multipart uploads that multiple concurrent S3Clients would result in failed writes. So, we created a singleton S3Client to share between all write operations. This diff does it for reads.

# Why
It is a better architecture, since we do not need multiple S3Client objects.

Reviewed By: wenhaizhu

Differential Revision: D37557580

