### PR TITLE
Add an adapter for boolean type

### DIFF
--- a/fbpcf/mpc_std_lib/permuter/test/PermuterTestBit.cpp
+++ b/fbpcf/mpc_std_lib/permuter/test/PermuterTestBit.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <cmath>
+#include <future>
+#include <memory>
+#include <random>
+#include <unordered_map>
+
+#include "fbpcf/engine/communication/test/AgentFactoryCreationHelper.h"
+#include "fbpcf/mpc_std_lib/permuter/AsWaksmanPermuter.h"
+#include "fbpcf/mpc_std_lib/permuter/AsWaksmanPermuterFactory.h"
+#include "fbpcf/mpc_std_lib/permuter/DummyPermuterFactory.h"
+#include "fbpcf/mpc_std_lib/util/test/util.h"
+#include "fbpcf/mpc_std_lib/util/util.h"
+#include "fbpcf/scheduler/SchedulerHelper.h"
+#include "fbpcf/test/TestHelper.h"
+
+namespace fbpcf::mpc_std_lib::permuter {
+
+std::tuple<std::vector<bool>, std::vector<uint32_t>, std::vector<bool>>
+getPermuterTestDataBinary(size_t size) {
+  auto originalData = util::generateRandomBinary(size);
+  auto order = util::generateRandomPermutation(size);
+  std::vector<bool> expectedResult(size);
+  for (size_t i = 0; i < size; i++) {
+    expectedResult[i] = originalData.at(order.at(i));
+  }
+  return {originalData, order, expectedResult};
+}
+
+std::pair<std::vector<bool>, std::vector<bool>> party0Task(
+    std::unique_ptr<IPermuter<frontend::Bit<true, 0, true>>> permuter,
+    const std::vector<bool>& data,
+    const std::vector<uint32_t>& order) {
+  frontend::Bit<true, 0, true> bits(data, 0);
+  auto permuted0 = permuter->permute(bits, data.size(), order);
+  auto permuted1 = permuter->permute(bits, data.size());
+  auto rst0 = permuted0.openToParty(0).getValue();
+  auto rst1 = permuted1.openToParty(0).getValue();
+  return {rst0, rst1};
+}
+
+void party1Task(
+    std::unique_ptr<IPermuter<frontend::Bit<true, 1, true>>> permuter,
+    const std::vector<bool>& data,
+    const std::vector<uint32_t>& order) {
+  frontend::Bit<true, 1, true> bits(data, 0);
+  auto permuted0 = permuter->permute(bits, data.size());
+  auto permuted1 = permuter->permute(bits, data.size(), order);
+  permuted0.openToParty(0);
+  permuted1.openToParty(0);
+}
+
+void permuterTest(
+    IPermuterFactory<frontend::Bit<true, 0, true>>& permuterFactory0,
+    IPermuterFactory<frontend::Bit<true, 1, true>>& permuterFactory1) {
+  auto agentFactories = engine::communication::getInMemoryAgentFactory(2);
+  setupRealBackend<0, 1>(*agentFactories[0], *agentFactories[1]);
+  auto permuter0 = permuterFactory0.create();
+  auto permuter1 = permuterFactory1.create();
+  size_t size = 17;
+  auto [originalData, order, expectedOutput] = getPermuterTestDataBinary(size);
+  auto future0 =
+      std::async(party0Task, std::move(permuter0), originalData, order);
+  auto future1 =
+      std::async(party1Task, std::move(permuter1), originalData, order);
+  auto [rst0, rst1] = future0.get();
+  future1.get();
+  testVectorEq(rst0, expectedOutput);
+  testVectorEq(rst1, expectedOutput);
+}
+
+TEST(permuterTestBit, testDummyPermuter) {
+  insecure::DummyPermuterFactory<frontend::Bit<true, 0, true>> factory0(0, 1);
+  insecure::DummyPermuterFactory<frontend::Bit<true, 1, true>> factory1(1, 0);
+
+  permuterTest(factory0, factory1);
+}
+
+TEST(permuterTestBit, testAsWaksmanPermuter) {
+  AsWaksmanPermuterFactory<bool, 0> factory0(0, 1);
+  AsWaksmanPermuterFactory<bool, 1> factory1(1, 0);
+
+  permuterTest(factory0, factory1);
+}
+
+} // namespace fbpcf::mpc_std_lib::permuter

--- a/fbpcf/mpc_std_lib/shuffler/test/ShufflerTestBit.cpp
+++ b/fbpcf/mpc_std_lib/shuffler/test/ShufflerTestBit.cpp
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <cmath>
+#include <future>
+#include <memory>
+#include <random>
+#include <unordered_map>
+
+#include "fbpcf/engine/communication/test/AgentFactoryCreationHelper.h"
+#include "fbpcf/engine/util/AesPrgFactory.h"
+#include "fbpcf/mpc_std_lib/permuter/AsWaksmanPermuterFactory.h"
+#include "fbpcf/mpc_std_lib/permuter/DummyPermuterFactory.h"
+#include "fbpcf/mpc_std_lib/shuffler/NonShufflerFactory.h"
+#include "fbpcf/mpc_std_lib/shuffler/PermuteBasedShufflerFactory.h"
+#include "fbpcf/mpc_std_lib/util/test/util.h"
+#include "fbpcf/mpc_std_lib/util/util.h"
+#include "fbpcf/scheduler/SchedulerHelper.h"
+#include "fbpcf/test/TestHelper.h"
+
+namespace fbpcf::mpc_std_lib::shuffler {
+
+template <int schedulerId>
+std::vector<bool> task(
+    std::unique_ptr<IShuffler<frontend::Bit<true, schedulerId, true>>> shuffler,
+    const std::vector<bool>& data) {
+  frontend::Bit<true, schedulerId, true> bits(data, 0);
+  auto shuffled = shuffler->shuffle(bits, data.size());
+  auto rst = shuffled.openToParty(0).getValue();
+  return rst;
+}
+
+void shufflerTest(
+    IShufflerFactory<frontend::Bit<true, 0, true>>& shufflerFactory0,
+    IShufflerFactory<frontend::Bit<true, 1, true>>& shufflerFactory1) {
+  auto agentFactories = engine::communication::getInMemoryAgentFactory(2);
+  setupRealBackend<0, 1>(*agentFactories[0], *agentFactories[1]);
+  auto shuffler0 = shufflerFactory0.create();
+  auto shuffler1 = shufflerFactory1.create();
+  size_t size = 16;
+  auto data = util::generateRandomBinary(size);
+
+  auto future0 = std::async(task<0>, std::move(shuffler0), data);
+  auto future1 = std::async(task<1>, std::move(shuffler1), data);
+  auto rst = future0.get();
+  future1.get();
+  ASSERT_EQ(data.size(), rst.size());
+  size_t numZeros = 0;
+  size_t numOnes = 0;
+  size_t expectedNumZeros = 0;
+  size_t expectedNumOnes = 0;
+  for (size_t i = 0; i < data.size(); i++) {
+    if (rst.at(i)) {
+      numOnes++;
+    } else {
+      numZeros++;
+    }
+    if (data.at(i)) {
+      expectedNumOnes++;
+    } else {
+      expectedNumZeros++;
+    }
+  }
+  ASSERT_EQ(numOnes, expectedNumOnes);
+  ASSERT_EQ(numZeros, expectedNumZeros);
+}
+
+TEST(shufflerTestBit, testNonShuffler) {
+  insecure::NonShufflerFactory<frontend::Bit<true, 0, true>> factory0;
+  insecure::NonShufflerFactory<frontend::Bit<true, 1, true>> factory1;
+
+  shufflerTest(factory0, factory1);
+}
+
+TEST(shufflerTestBit, testPermuteBasedShufflerWithDummyPermuter) {
+  PermuteBasedShufflerFactory<frontend::Bit<true, 0, true>> factory0(
+      0,
+      1,
+      std::make_unique<permuter::insecure::DummyPermuterFactory<
+          frontend::Bit<true, 0, true>>>(0, 1),
+      std::make_unique<engine::util::AesPrgFactory>());
+  PermuteBasedShufflerFactory<frontend::Bit<true, 1, true>> factory1(
+      1,
+      0,
+      std::make_unique<permuter::insecure::DummyPermuterFactory<
+          frontend::Bit<true, 1, true>>>(1, 0),
+      std::make_unique<engine::util::AesPrgFactory>());
+
+  shufflerTest(factory0, factory1);
+}
+
+TEST(shufflerTestBit, testPermuteBasedShufflerWithAsWaksmanPermuter) {
+  PermuteBasedShufflerFactory<frontend::Bit<true, 0, true>> factory0(
+      0,
+      1,
+      std::make_unique<permuter::AsWaksmanPermuterFactory<bool, 0>>(0, 1),
+      std::make_unique<engine::util::AesPrgFactory>());
+  PermuteBasedShufflerFactory<frontend::Bit<true, 1, true>> factory1(
+      1,
+      0,
+      std::make_unique<permuter::AsWaksmanPermuterFactory<bool, 1>>(1, 0),
+      std::make_unique<engine::util::AesPrgFactory>());
+
+  shufflerTest(factory0, factory1);
+}
+
+} // namespace fbpcf::mpc_std_lib::shuffler

--- a/fbpcf/mpc_std_lib/util/bit_impl.h
+++ b/fbpcf/mpc_std_lib/util/bit_impl.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "fbpcf/frontend/Bit.h"
+
+namespace fbpcf::mpc_std_lib::util {
+
+template <int schedulerId>
+struct SecBatchType<bool, schedulerId> {
+  using type = frontend::Bit<true, schedulerId, true>;
+};
+
+template <int schedulerId>
+class MpcAdapters<bool, schedulerId> {
+ public:
+  using SecBatchType = typename SecBatchType<bool, schedulerId>::type;
+  static SecBatchType processSecretInputs(
+      const std::vector<bool>& secrets,
+      int secretOwnerPartyId);
+
+  static SecBatchType recoverBatchSharedSecrets(const std::vector<bool>& src);
+
+  static std::pair<SecBatchType, SecBatchType> obliviousSwap(
+      const SecBatchType& src1,
+      const SecBatchType& src2,
+      frontend::Bit<true, schedulerId, true> indicator) {
+    auto rst1 = src1 ^ (indicator & (src2 ^ src1));
+    auto rst2 = rst1 ^ src1 ^ src2;
+    return {rst1, rst2};
+  }
+
+  static std::vector<bool> openToParty(const SecBatchType& src, int partyId);
+};
+
+} // namespace fbpcf::mpc_std_lib::util

--- a/fbpcf/mpc_std_lib/util/test/util.h
+++ b/fbpcf/mpc_std_lib/util/test/util.h
@@ -27,6 +27,18 @@ inline std::vector<uint32_t> generateRandomPermutation(size_t size) {
   return rst;
 }
 
+inline std::vector<bool> generateRandomBinary(size_t size) {
+  std::random_device rd;
+  std::mt19937_64 e(rd());
+  std::uniform_int_distribution<uint32_t> randomBit(0, 1);
+
+  std::vector<bool> rst(size);
+  for (size_t i = 0; i < size; i++) {
+    rst[i] = randomBit(e);
+  }
+  return rst;
+}
+
 // the 3 returned valeus are: true value, first share, second share
 template <typename T>
 std::tuple<T, T, T> getRandomData(std::mt19937_64& e);

--- a/fbpcf/mpc_std_lib/util/util.h
+++ b/fbpcf/mpc_std_lib/util/util.h
@@ -69,3 +69,5 @@ std::vector<__m128i> convertFromBits(const std::vector<std::vector<bool>>& src);
 #include "fbpcf/mpc_std_lib/util/aggregationValue_impl.h"
 
 #include "fbpcf/mpc_std_lib/util/bitstring_impl.h"
+
+#include "fbpcf/mpc_std_lib/util/bit_impl.h"


### PR DESCRIPTION
Summary:
Add a MPC adapter for a boolean type with an implementation of oblivious swap for a batched type `Bit`. The boolean adapter allows us to run the shuffler and permuter for a boolean type of secret values.

It will be used as a building block for a shuffler-based compactor which requires boolean type of values to be shuffled.

Reviewed By: RuiyuZhu

Differential Revision: D37476874

