### PR TITLE
Add a batch size as an additional parameter to compactor API

### DIFF
--- a/fbpcf/mpc_std_lib/compactor/DummyCompactor.h
+++ b/fbpcf/mpc_std_lib/compactor/DummyCompactor.h
@@ -30,6 +30,7 @@ class DummyCompactor final : public ICompactor<T, LabelT> {
   std::pair<T, LabelT> compaction(
       const T& src,
       const LabelT& label,
+      size_t size,
       bool /*shouldRevealSize*/) const override {
     auto party0 =
         (myId_ < partnerId_) ? myId_ : partnerId_; // a party with a smaller id
@@ -50,9 +51,8 @@ class DummyCompactor final : public ICompactor<T, LabelT> {
     // select items whose labels are 1.
     auto compactifiedSrc = plaintextSrc;
     auto compactifiedLabel = plaintextLabel;
-    size_t inputSize = plaintextLabel.size();
     size_t outputSize = 0;
-    for (size_t j = 0; j < inputSize; j++) {
+    for (size_t j = 0; j < size; j++) {
       if (plaintextLabel[j]) {
         compactifiedSrc[outputSize] = std::move(compactifiedSrc.at(j));
         compactifiedLabel[outputSize] = std::move(plaintextLabel.at(j));

--- a/fbpcf/mpc_std_lib/compactor/ICompactor.h
+++ b/fbpcf/mpc_std_lib/compactor/ICompactor.h
@@ -35,6 +35,7 @@ class ICompactor {
    * @param label: a set of n binary labels, where 1 indicates the
    * corresponding items in the src are considered as necessary data;
    * otherwise they are considered as unimportant data
+   * @param size: the size of the batch
    * @param shouldRevealSize: whether it is okay to reveal the size of 1s items
    * @return the resulting compactified src and label
    */
@@ -42,6 +43,7 @@ class ICompactor {
   virtual std::pair<T, LabelT> compaction(
       const T& src,
       const LabelT& label,
+      size_t size,
       bool shouldRevealSize) const = 0;
 };
 

--- a/fbpcf/mpc_std_lib/compactor/test/CompactorTest.cpp
+++ b/fbpcf/mpc_std_lib/compactor/test/CompactorTest.cpp
@@ -84,6 +84,7 @@ std::tuple<std::vector<T>, std::vector<bool>> task(
         compactor,
     const std::vector<T>& src,
     const std::vector<bool>& label,
+    size_t size,
     bool shouldRevealSize) {
   // generate secret values
   auto secSrc = SecUnsignedIntBatch<schedulerId>(src, 0);
@@ -91,7 +92,7 @@ std::tuple<std::vector<T>, std::vector<bool>> task(
 
   // run a compaction algorithm
   auto [compactifiedSrc, compactifiedLabel] =
-      compactor->compaction(secSrc, secLabel, shouldRevealSize);
+      compactor->compaction(secSrc, secLabel, size, shouldRevealSize);
 
   // get plaintext results
   auto rstSrc = compactifiedSrc.openToParty(0).getValue();
@@ -123,12 +124,14 @@ TEST(compactorTest, testDummyCompactor) {
       std::move(compactor0),
       testData,
       testLabel,
+      batchSize,
       shouldRevealSize);
   auto future1 = std::async(
       task<1, uint64_t>,
       std::move(compactor1),
       testData,
       testLabel,
+      batchSize,
       shouldRevealSize);
   auto [rstData0, rstLabel0] = future0.get();
   future1.get();

--- a/fbpcf/mpc_std_lib/shuffler/test/ShufflerTestAttribution.cpp
+++ b/fbpcf/mpc_std_lib/shuffler/test/ShufflerTestAttribution.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <cmath>
+#include <future>
+#include <memory>
+#include <random>
+#include <unordered_map>
+
+#include "fbpcf/engine/communication/test/AgentFactoryCreationHelper.h"
+#include "fbpcf/engine/util/AesPrgFactory.h"
+#include "fbpcf/mpc_std_lib/permuter/AsWaksmanPermuterFactory.h"
+#include "fbpcf/mpc_std_lib/permuter/DummyPermuterFactory.h"
+#include "fbpcf/mpc_std_lib/shuffler/NonShufflerFactory.h"
+#include "fbpcf/mpc_std_lib/shuffler/PermuteBasedShufflerFactory.h"
+#include "fbpcf/mpc_std_lib/util/test/util.h"
+#include "fbpcf/mpc_std_lib/util/util.h"
+#include "fbpcf/scheduler/SchedulerHelper.h"
+#include "fbpcf/test/TestHelper.h"
+
+namespace fbpcf::mpc_std_lib::shuffler {
+
+template <int schedulerId>
+std::vector<util::AttributionData> task(
+    std::unique_ptr<IShuffler<util::SecretAttributionData<schedulerId>>>
+        shuffler,
+    const std::vector<util::AttributionData>& data) {
+  auto secData = util::MpcAdapters<util::AttributionData, schedulerId>::
+      processSecretInputs(data, 0);
+  auto shuffled = shuffler->shuffle(secData, data.size());
+  auto rst = util::MpcAdapters<util::AttributionData, schedulerId>::openToParty(
+      shuffled, 0);
+  return rst;
+}
+
+void shufflerTest(
+    IShufflerFactory<util::SecretAttributionData<0>>& shufflerFactory0,
+    IShufflerFactory<util::SecretAttributionData<1>>& shufflerFactory1) {
+  auto agentFactories = engine::communication::getInMemoryAgentFactory(2);
+  setupRealBackend<0, 1>(*agentFactories[0], *agentFactories[1]);
+  auto shuffler0 = shufflerFactory0.create();
+  auto shuffler1 = shufflerFactory1.create();
+
+  /* Generate test data for AttributionData type. */
+  size_t size = 10;
+  std::vector<uint64_t> adId(size);
+  std::iota(adId.begin(), adId.end(), 0); // assign unique ids starting from 0.
+  std::vector<uint64_t> conversionValue(size);
+  std::iota(conversionValue.begin(), conversionValue.end(), 100);
+  auto label = util::generateRandomBinary(size);
+
+  std::vector<util::AttributionData> data(size);
+  for (size_t i = 0; i < size; i++) {
+    data[i] = util::AttributionData(
+        util::AttributionValue(adId.at(i), conversionValue.at(i)), label.at(i));
+  }
+
+  auto future0 = std::async(task<0>, std::move(shuffler0), data);
+  auto future1 = std::async(task<1>, std::move(shuffler1), data);
+  auto rst = future0.get();
+  future1.get();
+
+  ASSERT_EQ(rst.size(), size);
+  for (size_t i = 0; i < size; i++) {
+    /* check consistensiy of each record */
+    auto index = rst.at(i).value.adId; // ad id corresponds to the index
+                                       // position of original data.
+    ASSERT_EQ(rst.at(i).value.adId, data.at(index).value.adId);
+    ASSERT_EQ(
+        rst.at(i).value.conversionValue, data.at(index).value.conversionValue);
+    ASSERT_EQ(rst.at(i).label, data.at(index).label);
+  }
+}
+
+TEST(shufflerTestAttributionValue, testNonShuffler) {
+  insecure::NonShufflerFactory<util::SecretAttributionData<0>> factory0;
+  insecure::NonShufflerFactory<util::SecretAttributionData<1>> factory1;
+
+  shufflerTest(factory0, factory1);
+}
+
+TEST(
+    shufflerTestAttributionValue,
+    testPermuteBasedShufflerWithAsWaksmanPermuter) {
+  PermuteBasedShufflerFactory<util::SecretAttributionData<0>> factory0(
+      0,
+      1,
+      std::make_unique<
+          permuter::AsWaksmanPermuterFactory<util::AttributionData, 0>>(0, 1),
+      std::make_unique<engine::util::AesPrgFactory>());
+  PermuteBasedShufflerFactory<util::SecretAttributionData<1>> factory1(
+      1,
+      0,
+      std::make_unique<
+          permuter::AsWaksmanPermuterFactory<util::AttributionData, 1>>(1, 0),
+      std::make_unique<engine::util::AesPrgFactory>());
+
+  shufflerTest(factory0, factory1);
+}
+
+} // namespace fbpcf::mpc_std_lib::shuffler

--- a/fbpcf/mpc_std_lib/util/attributionValue_impl.h
+++ b/fbpcf/mpc_std_lib/util/attributionValue_impl.h
@@ -1,0 +1,282 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <emmintrin.h>
+#include <smmintrin.h>
+#include <functional>
+#include <random>
+#include <stdexcept>
+
+namespace fbpcf::mpc_std_lib::util {
+
+/**
+ * functions added here are helpers to support shuffler and permuter for
+ * AttributionData type. They are partial specializations for function
+ * templates listed in mpc_std_lib/util/util.h file.
+ */
+
+/*
+ * AttributionValue is composed of 64 bits unsinged integer type of ad id
+ * and 32 bits unsinged integer type of conversion value.
+ */
+struct AttributionValue {
+  uint64_t adId;
+  uint32_t conversionValue;
+  AttributionValue() {}
+  AttributionValue(uint64_t id, uint32_t value)
+      : adId{id}, conversionValue(value) {}
+};
+
+template <>
+class Adapters<AttributionValue> {
+ public:
+  static const int8_t adIdWidth = 64; // 64 bits unsinged integer
+  static const int8_t valueWidth = 32; // 32 bits unsigned integer
+};
+
+/*
+ * SecretAttributionValue is a secret batch of AttributionValue type. Namely, it
+ * is composed of secret batches of ad ids and conversion values, each with an
+ * appropriate batched Int type. This type supports
+ * unbatching and batchingWith functions, similar to those implemented for Bit,
+ * BitString and Int types.
+ */
+template <int schedulerId>
+struct SecretAttributionValue {
+  SecretAttributionValue() = default;
+  SecretAttributionValue(
+      const frontend::Int<
+          false,
+          Adapters<AttributionValue>::adIdWidth,
+          true,
+          schedulerId,
+          true>& id,
+      const frontend::Int<
+          false,
+          Adapters<AttributionValue>::valueWidth,
+          true,
+          schedulerId,
+          true>& value)
+      : adId(id), conversionValue(value) {}
+  SecretAttributionValue(
+      const std::vector<AttributionValue>& src,
+      int partyId) {
+    std::vector<uint64_t> id(src.size());
+    std::vector<uint32_t> value(src.size());
+    std::transform(
+        src.begin(), src.end(), id.begin(), [](const AttributionValue& src) {
+          return src.adId;
+        });
+    std::transform(
+        src.begin(), src.end(), value.begin(), [](const AttributionValue& src) {
+          return src.conversionValue;
+        });
+    adId = frontend::Int<
+        false,
+        Adapters<AttributionValue>::adIdWidth,
+        true,
+        schedulerId,
+        true>(id, partyId);
+    conversionValue = frontend::Int<
+        false,
+        Adapters<AttributionValue>::valueWidth,
+        true,
+        schedulerId,
+        true>(value, partyId);
+  }
+  std::vector<SecretAttributionValue<schedulerId>> unbatching(
+      std::shared_ptr<std::vector<uint32_t>> unbatchingStrategy) const {
+    auto unbatchedAdId = adId.unbatching(unbatchingStrategy);
+    auto unbatchedConversionValue =
+        conversionValue.unbatching(unbatchingStrategy);
+    std::vector<SecretAttributionValue<schedulerId>> rst(
+        unbatchingStrategy->size());
+    for (size_t i = 0; i < unbatchingStrategy->size(); i++) {
+      rst[i].adId = unbatchedAdId.at(i);
+      rst[i].conversionValue = unbatchedConversionValue.at(i);
+    }
+
+    return rst;
+  }
+  SecretAttributionValue<schedulerId> batchingWith(
+      const std::vector<SecretAttributionValue<schedulerId>>& others) const {
+    std::vector<frontend::Int<
+        false,
+        Adapters<AttributionValue>::adIdWidth,
+        true,
+        schedulerId,
+        true>>
+        otherIds(others.size());
+    std::vector<frontend::Int<
+        false,
+        Adapters<AttributionValue>::valueWidth,
+        true,
+        schedulerId,
+        true>>
+        otherValues(others.size());
+    std::transform(
+        others.begin(),
+        others.end(),
+        otherIds.begin(),
+        [](const SecretAttributionValue<schedulerId>& other) {
+          return other.adId;
+        });
+    std::transform(
+        others.begin(),
+        others.end(),
+        otherValues.begin(),
+        [](const SecretAttributionValue<schedulerId>& other) {
+          return other.conversionValue;
+        });
+    SecretAttributionValue<schedulerId> rst(
+        adId.batchingWith(otherIds), conversionValue.batchingWith(otherValues));
+    return rst;
+  }
+  frontend::
+      Int<false, Adapters<AttributionValue>::adIdWidth, true, schedulerId, true>
+          adId;
+  frontend::Int<
+      false,
+      Adapters<AttributionValue>::valueWidth,
+      true,
+      schedulerId,
+      true>
+      conversionValue;
+};
+
+/*
+ * AttributionData is composed of AsstributionValue type value and boolean type
+ * label.
+ */
+struct AttributionData {
+  AttributionValue value;
+  bool label;
+  AttributionData() {}
+  AttributionData(AttributionValue value, bool label)
+      : value{std::move(value)}, label{label} {}
+};
+
+/*
+ * SecretAttributionData is a secret batch of AttributionData type. Namely, it
+ * is composed of secret batches of AttributionValue type values and boolean
+ * type labels This type supports unbatching and batchingWith functions, similar
+ * to those implemented for Bit, BitString and Int types.
+ */
+template <int schedulerId>
+struct SecretAttributionData {
+  SecretAttributionData() = default;
+  SecretAttributionData(
+      const SecretAttributionValue<schedulerId>& value,
+      const frontend::Bit<true, schedulerId, true>& label)
+      : value{std::move(value)}, label{std::move(label)} {}
+  SecretAttributionData(const std::vector<AttributionData>& src, int partyId) {
+    std::vector<AttributionValue> attValue(src.size());
+    std::vector<bool> attLabel(src.size());
+    for (size_t i = 0; i < src.size(); i++) {
+      attValue[i] = src[i].value;
+      attLabel[i] = src[i].label;
+    }
+    value = SecretAttributionValue<schedulerId>(attValue, partyId);
+    label = frontend::Bit<true, schedulerId, true>(attLabel, partyId);
+  }
+
+  std::vector<SecretAttributionData> unbatching(
+      std::shared_ptr<std::vector<uint32_t>> unbatchingStrategy) const {
+    auto unbatchedValue = value.unbatching(unbatchingStrategy);
+    auto unbatchedLabel = label.unbatching(unbatchingStrategy);
+
+    std::vector<SecretAttributionData<schedulerId>> rst(
+        unbatchingStrategy->size());
+    for (size_t i = 0; i < unbatchingStrategy->size(); i++) {
+      rst[i] = SecretAttributionData<schedulerId>(
+          unbatchedValue.at(i), unbatchedLabel.at(i));
+    }
+
+    return rst;
+  }
+  SecretAttributionData<schedulerId> batchingWith(
+      const std::vector<SecretAttributionData<schedulerId>>& others) const {
+    std::vector<SecretAttributionValue<schedulerId>> otherValues(others.size());
+    std::vector<frontend::Bit<true, schedulerId, true>> otherLabels(
+        others.size());
+    for (size_t i = 0; i < others.size(); i++) {
+      otherValues[i] = others.at(i).value;
+      otherLabels[i] = others.at(i).label;
+    }
+    SecretAttributionData<schedulerId> rst(
+        value.batchingWith(otherValues), label.batchingWith(otherLabels));
+
+    return rst;
+  }
+  SecretAttributionValue<schedulerId> value;
+  frontend::Bit<true, schedulerId, true> label;
+};
+
+template <int schedulerId>
+struct SecBatchType<AttributionData, schedulerId> {
+  using type = SecretAttributionData<schedulerId>;
+};
+
+/*
+ * Helpers for AttributionData type in MPC.
+ */
+template <int schedulerId>
+class MpcAdapters<AttributionData, schedulerId> {
+ public:
+  using SecBatchType =
+      typename SecBatchType<AttributionData, schedulerId>::type;
+  static SecBatchType processSecretInputs(
+      const std::vector<AttributionData>& secrets,
+      int secretOwnerPartyId) {
+    return SecretAttributionData<schedulerId>(secrets, secretOwnerPartyId);
+  }
+  static std::pair<SecBatchType, SecBatchType> obliviousSwap(
+      const SecBatchType& src1,
+      const SecBatchType& src2,
+      frontend::Bit<true, schedulerId, true> indicator) {
+    auto [rstLabel1, rstLabel2] = MpcAdapters<bool, schedulerId>::obliviousSwap(
+        src1.label, src2.label, indicator);
+
+    auto [rstId1, rstId2] =
+        MpcAdapters<Intp<false, 64>, schedulerId>::obliviousSwap(
+            src1.value.adId, src2.value.adId, indicator);
+    auto [rstConversionValue1, rstConversionValue2] =
+        MpcAdapters<uint32_t, schedulerId>::obliviousSwap(
+            src1.value.conversionValue, src2.value.conversionValue, indicator);
+
+    auto rst1 = SecretAttributionData<schedulerId>(
+        SecretAttributionValue<schedulerId>(rstId1, rstConversionValue1),
+        rstLabel1);
+    auto rst2 = SecretAttributionData<schedulerId>(
+        SecretAttributionValue<schedulerId>(rstId2, rstConversionValue2),
+        rstLabel2);
+
+    return {rst1, rst2};
+  }
+  static std::vector<AttributionData> openToParty(
+      const SecBatchType& src,
+      int partyId) {
+    auto id = src.value.adId.openToParty(partyId).getValue();
+    auto value = src.value.conversionValue.openToParty(partyId).getValue();
+    auto label = src.label.openToParty(partyId).getValue();
+
+    if (label.size() != id.size() || label.size() != value.size()) {
+      throw std::runtime_error("Unexpected size.");
+    }
+
+    std::vector<AttributionData> rst(label.size());
+    for (size_t i = 0; i < rst.size(); i++) {
+      rst[i] =
+          AttributionData(AttributionValue(id.at(i), value.at(i)), label.at(i));
+    }
+    return rst;
+  }
+};
+
+} // namespace fbpcf::mpc_std_lib::util

--- a/fbpcf/mpc_std_lib/util/util.h
+++ b/fbpcf/mpc_std_lib/util/util.h
@@ -70,4 +70,5 @@ std::vector<__m128i> convertFromBits(const std::vector<std::vector<bool>>& src);
 
 #include "fbpcf/mpc_std_lib/util/bitstring_impl.h"
 
+#include "fbpcf/mpc_std_lib/util/attributionValue_impl.h"
 #include "fbpcf/mpc_std_lib/util/bit_impl.h"


### PR DESCRIPTION
Summary:
Add a batch size as an additional input parameter to the compactor API.

Details:  an input data that the compactor API takes is assumed to be a batch type and we need to explicitly tell the program its size.

Reviewed By: chualynn

Differential Revision: D37582603

