### PR TITLE
Refactor dummy permuter to use MPC adapters

### DIFF
--- a/fbpcf/mpc_std_lib/permuter/DummyPermuter.h
+++ b/fbpcf/mpc_std_lib/permuter/DummyPermuter.h
@@ -17,24 +17,33 @@ namespace fbpcf::mpc_std_lib::permuter::insecure {
  * This permuter doesn't do anything but simply output the input. It is only
  * meant to be used as a placeholder in tests.
  **/
-template <typename T>
-class DummyPermuter final : public IPermuter<T> {
+template <typename T, int schedulerId>
+class DummyPermuter final
+    : public IPermuter<typename util::SecBatchType<T, schedulerId>::type> {
  public:
+  using SecBatchType = typename util::SecBatchType<T, schedulerId>::type;
   DummyPermuter(int myId, int partnerId) : myId_(myId), partnerId_(partnerId) {}
 
-  T permute(const T& src, size_t /*size*/) const override {
-    auto placeHolder = src.openToParty(partnerId_).getValue();
-    return T(placeHolder, partnerId_);
+  SecBatchType permute(const SecBatchType& src, size_t /*size*/)
+      const override {
+    auto placeHolder =
+        util::MpcAdapters<T, schedulerId>::openToParty(src, partnerId_);
+
+    return util::MpcAdapters<T, schedulerId>::processSecretInputs(
+        placeHolder, partnerId_);
   }
 
-  T permute(const T& src, size_t /*size*/, const std::vector<uint32_t>& order)
-      const override {
-    auto plaintext = src.openToParty(myId_).getValue();
+  SecBatchType permute(
+      const SecBatchType& src,
+      size_t /*size*/,
+      const std::vector<uint32_t>& order) const override {
+    auto plaintext = util::MpcAdapters<T, schedulerId>::openToParty(src, myId_);
     auto permuted = plaintext;
     for (size_t i = 0; i < order.size(); i++) {
       permuted[i] = plaintext.at(order.at(i));
     }
-    return T(permuted, myId_);
+    return util::MpcAdapters<T, schedulerId>::processSecretInputs(
+        permuted, myId_);
   }
 
  private:

--- a/fbpcf/mpc_std_lib/permuter/DummyPermuterFactory.h
+++ b/fbpcf/mpc_std_lib/permuter/DummyPermuterFactory.h
@@ -12,14 +12,17 @@
 
 namespace fbpcf::mpc_std_lib::permuter::insecure {
 
-template <typename T>
-class DummyPermuterFactory final : public IPermuterFactory<T> {
+template <typename T, int schedulerId>
+class DummyPermuterFactory final
+    : public IPermuterFactory<
+          typename util::SecBatchType<T, schedulerId>::type> {
  public:
   DummyPermuterFactory(int myId, int partnerId)
       : myId_(myId), partnerId_(partnerId) {}
 
-  std::unique_ptr<IPermuter<T>> create() override {
-    return std::make_unique<DummyPermuter<T>>(myId_, partnerId_);
+  std::unique_ptr<IPermuter<typename util::SecBatchType<T, schedulerId>::type>>
+  create() override {
+    return std::make_unique<DummyPermuter<T, schedulerId>>(myId_, partnerId_);
   }
 
  private:

--- a/fbpcf/mpc_std_lib/permuter/test/PermuterTest.cpp
+++ b/fbpcf/mpc_std_lib/permuter/test/PermuterTest.cpp
@@ -85,10 +85,8 @@ void permuterTest(
 }
 
 TEST(permuterTest, testDummyPermuter) {
-  insecure::DummyPermuterFactory<frontend::BitString<true, 0, true>> factory0(
-      0, 1);
-  insecure::DummyPermuterFactory<frontend::BitString<true, 1, true>> factory1(
-      1, 0);
+  insecure::DummyPermuterFactory<std::vector<bool>, 0> factory0(0, 1);
+  insecure::DummyPermuterFactory<std::vector<bool>, 1> factory1(1, 0);
 
   permuterTest(factory0, factory1);
 }

--- a/fbpcf/mpc_std_lib/permuter/test/PermuterTestBit.cpp
+++ b/fbpcf/mpc_std_lib/permuter/test/PermuterTestBit.cpp
@@ -78,8 +78,8 @@ void permuterTest(
 }
 
 TEST(permuterTestBit, testDummyPermuter) {
-  insecure::DummyPermuterFactory<frontend::Bit<true, 0, true>> factory0(0, 1);
-  insecure::DummyPermuterFactory<frontend::Bit<true, 1, true>> factory1(1, 0);
+  insecure::DummyPermuterFactory<bool, 0> factory0(0, 1);
+  insecure::DummyPermuterFactory<bool, 1> factory1(1, 0);
 
   permuterTest(factory0, factory1);
 }

--- a/fbpcf/mpc_std_lib/shuffler/test/ShufflerTest.cpp
+++ b/fbpcf/mpc_std_lib/shuffler/test/ShufflerTest.cpp
@@ -78,14 +78,14 @@ TEST(shufflerTest, testPermuteBasedShufflerWithDummyPermuter) {
   PermuteBasedShufflerFactory<frontend::BitString<true, 0, true>> factory0(
       0,
       1,
-      std::make_unique<permuter::insecure::DummyPermuterFactory<
-          frontend::BitString<true, 0, true>>>(0, 1),
+      std::make_unique<
+          permuter::insecure::DummyPermuterFactory<std::vector<bool>, 0>>(0, 1),
       std::make_unique<engine::util::AesPrgFactory>());
   PermuteBasedShufflerFactory<frontend::BitString<true, 1, true>> factory1(
       1,
       0,
-      std::make_unique<permuter::insecure::DummyPermuterFactory<
-          frontend::BitString<true, 1, true>>>(1, 0),
+      std::make_unique<
+          permuter::insecure::DummyPermuterFactory<std::vector<bool>, 1>>(1, 0),
       std::make_unique<engine::util::AesPrgFactory>());
 
   shufflerTest(factory0, factory1);

--- a/fbpcf/mpc_std_lib/shuffler/test/ShufflerTestBit.cpp
+++ b/fbpcf/mpc_std_lib/shuffler/test/ShufflerTestBit.cpp
@@ -82,14 +82,12 @@ TEST(shufflerTestBit, testPermuteBasedShufflerWithDummyPermuter) {
   PermuteBasedShufflerFactory<frontend::Bit<true, 0, true>> factory0(
       0,
       1,
-      std::make_unique<permuter::insecure::DummyPermuterFactory<
-          frontend::Bit<true, 0, true>>>(0, 1),
+      std::make_unique<permuter::insecure::DummyPermuterFactory<bool, 0>>(0, 1),
       std::make_unique<engine::util::AesPrgFactory>());
   PermuteBasedShufflerFactory<frontend::Bit<true, 1, true>> factory1(
       1,
       0,
-      std::make_unique<permuter::insecure::DummyPermuterFactory<
-          frontend::Bit<true, 1, true>>>(1, 0),
+      std::make_unique<permuter::insecure::DummyPermuterFactory<bool, 1>>(1, 0),
       std::make_unique<engine::util::AesPrgFactory>());
 
   shufflerTest(factory0, factory1);

--- a/fbpcf/mpc_std_lib/util/bit_impl.h
+++ b/fbpcf/mpc_std_lib/util/bit_impl.h
@@ -22,7 +22,9 @@ class MpcAdapters<bool, schedulerId> {
   using SecBatchType = typename SecBatchType<bool, schedulerId>::type;
   static SecBatchType processSecretInputs(
       const std::vector<bool>& secrets,
-      int secretOwnerPartyId);
+      int secretOwnerPartyId) {
+    return SecBatchType(secrets, secretOwnerPartyId);
+  }
 
   static SecBatchType recoverBatchSharedSecrets(const std::vector<bool>& src);
 
@@ -35,7 +37,9 @@ class MpcAdapters<bool, schedulerId> {
     return {rst1, rst2};
   }
 
-  static std::vector<bool> openToParty(const SecBatchType& src, int partyId);
+  static std::vector<bool> openToParty(const SecBatchType& src, int partyId) {
+    return src.openToParty(partyId).getValue();
+  }
 };
 
 } // namespace fbpcf::mpc_std_lib::util

--- a/fbpcf/mpc_std_lib/util/bitstring_impl.h
+++ b/fbpcf/mpc_std_lib/util/bitstring_impl.h
@@ -23,7 +23,9 @@ class MpcAdapters<std::vector<bool>, schedulerId> {
       typename SecBatchType<std::vector<bool>, schedulerId>::type;
   static SecBatchType processSecretInputs(
       const std::vector<std::vector<bool>>& secrets,
-      int secretOwnerPartyId);
+      int secretOwnerPartyId) {
+    return SecBatchType(secrets, secretOwnerPartyId);
+  }
 
   static SecBatchType recoverBatchSharedSecrets(
       const std::vector<std::vector<bool>>& src);
@@ -42,7 +44,9 @@ class MpcAdapters<std::vector<bool>, schedulerId> {
 
   static std::vector<std::vector<bool>> openToParty(
       const SecBatchType& src,
-      int partyId);
+      int partyId) {
+    return src.openToParty(partyId).getValue();
+  }
 };
 
 } // namespace fbpcf::mpc_std_lib::util


### PR DESCRIPTION
Summary:
Use MPC adapters when opening and processing secret values in dummy permuter implementation.

Details: In the current implementation of dummy permuter, a template type ```T``` is limited to Bit, Int and BitString as it has a dependency on the method ```OpenToParty``` and the constructor for processing secret inputs. Thus, to make ```T``` more general, we use MPC adapters as proxies to call those functions.

- We make small changes to all existing dependent unit tests to reflect the modifications to the dummy permuter.

Reviewed By: chualynn

Differential Revision: D37687008

