### PR TITLE
add standard exceptions to be used in shard combiner.

### DIFF
--- a/fbpcf/exception/exceptions.h
+++ b/fbpcf/exception/exceptions.h
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <exception>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+
+namespace common {
+
+/**
+ * PCF exceptions
+ * --------------
+ */
+namespace exceptions {
+
+/**
+ * When to use:
+ *   - While parsing text blobs, CSVs, json
+ *    - For example: while parsing CSV if we see more number of columns in a row
+ *          than the header.
+ */
+class ParseError : virtual public std::exception {
+ public:
+  explicit ParseError(std::string msg) : msg_{msg} {}
+
+  const char* what() const throw() override {
+    return msg_.c_str();
+  }
+
+ private:
+  std::string msg_;
+};
+
+/**
+ * When to use:
+ *  - While constructing an object with incorrect/un-supported argument
+ * value/type
+ *    - For example:
+ * class AggMetrics{
+ *   explicit AggMetrics(AggMetricType type) : type_{type} {
+ *     if (type_ == AggMetricType::kDict) {
+ *       val_ = MetricsDict{};
+ *     } else if (type_ == AggMetricType::kList) {
+ *       val_ = MetricsList{};
+ *     } else if (type_ == AggMetricType::kValue) {
+ *       val_ = MetricsValue{0};
+ *     } else {
+ *       XLOG(ERR) << "Construction not supported for:"
+ *                 << \
+ *                static_cast<std::underlying_type<AggMetricType>::type>(type);
+ *       throw common::ConstructionError("Contructor only supports one of kList,
+ *            kDict or kValue");
+ *     }
+ *   }
+ * };
+ */
+class ConstructionError : virtual public std::exception {
+ public:
+  explicit ConstructionError(std::string msg) : msg_{msg} {}
+
+  const char* what() const throw() override {
+    return msg_.c_str();
+  }
+
+ private:
+  std::string msg_;
+};
+
+/**
+ * When to use:
+ *  - When any dynamic obj fails to meet the type requirement.
+ *    - Example: folly::dynamic expects folly::OBJECT but got folly::INT
+ *      instead.
+ */
+class RuntimeTypeError : virtual public std::exception {
+ public:
+  explicit RuntimeTypeError(std::string msg) : msg_{msg} {}
+
+  const char* what() const throw() override {
+    return msg_.c_str();
+  }
+
+ private:
+  std::string msg_;
+};
+
+/**
+ * When to use:
+ *  - While validating if a parsed json object adheres to schema previously
+ * agreed upon
+ *    - Example: ShardValidator<ShardSchemaType::kAdObjFormat> object will
+ *      throw this exception if the AggMetric does not follow this format.
+ */
+class SchemaTraceError : virtual public std::exception {
+ public:
+  explicit SchemaTraceError(std::string msg) : msg_{msg} {}
+
+  const char* what() const throw() override {
+    return msg_.c_str();
+  }
+
+ private:
+  std::string msg_;
+};
+
+/**
+ * When to use:
+ *  - similar situation NotImplementedError in python, raise this exception
+ *    while class is still being developed.
+ */
+class NotImplementedError : virtual public std::exception {
+ public:
+  explicit NotImplementedError(std::string msg) : msg_{msg} {}
+
+  const char* what() const throw() override {
+    return msg_.c_str();
+  }
+
+ private:
+  std::string msg_;
+};
+
+/**
+ * When to use:
+ *  - When we are trying to access an illegal variable.
+ *    - Example: when a AggMetric<AggMetricType::kPlaintext> object tries to
+ *      access getSecValueXor().
+ */
+class InvalidAccessError : virtual public std::exception {
+ public:
+  explicit InvalidAccessError(std::string msg) : msg_{msg} {}
+
+  const char* what() const throw() override {
+    return msg_.c_str();
+  }
+
+ private:
+  std::string msg_;
+};
+
+/**
+ * When to use:
+ *  - When the connections fail to establish between the parties.
+ */
+class ConnectionError : virtual public std::exception {
+ public:
+  explicit ConnectionError(std::string msg) : msg_{msg} {}
+
+  const char* what() const throw() override {
+    return msg_.c_str();
+  }
+
+ private:
+  std::string msg_;
+};
+
+} // namespace exceptions
+} // namespace common


### PR DESCRIPTION
Summary:
# context
This commit adds standard exceptions that we'd like to use for ShardCombiner stage(not restricted to SC).

I feel that it would be easier for while debugging, to filter out the error by exception type instead of just having one runtime_error and scroll through error messages. Also, it'd make certain error handling(and error suppression) easier at runtime, for instance, an InvalidAccessError(thrown while accessing a metric_key that does not exist) could selectively caught and handled without making a fatal exit and let application continue.  This list may not be complete, I have added a few that relates to ShardCombiner. If you could suggest better names I can add them to this file.

# Changes in this diff
1. New exceptions header file, so that we can catch specific errors and handle them better also helps in debuggin. As it could be common to all other applications, I thought of adding it to the `common/` directory.

Reviewed By: ajinkya-ghonge

Differential Revision: D37570687

