### PR TITLE
Fix missing file issue for local file reader/writer

### DIFF
--- a/fbpcf/io/api/LocalFileReader.cpp
+++ b/fbpcf/io/api/LocalFileReader.cpp
@@ -6,6 +6,8 @@
  */
 
 #include "fbpcf/io/api/LocalFileReader.h"
+#include <folly/logging/xlog.h>
+#include <cerrno>
 #include <cstddef>
 #include <fstream>
 #include <vector>
@@ -14,6 +16,10 @@ namespace fbpcf::io {
 
 LocalFileReader::LocalFileReader(std::string filePath) {
   inputStream_ = std::make_unique<std::ifstream>(filePath);
+  if (inputStream_->fail()) {
+    XLOGF(ERR, "Error when opening file: {}", strerror(errno));
+    throw std::runtime_error("Couldn't open local file.");
+  }
   isClosed_ = false;
 }
 
@@ -46,5 +52,7 @@ bool LocalFileReader::eof() {
   return inputStream_->eof();
 }
 
-LocalFileReader::~LocalFileReader() {}
+LocalFileReader::~LocalFileReader() {
+  close();
+}
 } // namespace fbpcf::io

--- a/fbpcf/io/api/test/LocalFileReaderTest.cpp
+++ b/fbpcf/io/api/test/LocalFileReaderTest.cpp
@@ -73,4 +73,12 @@ TEST(LocalFileReaderTest, testLocalFileReaderThroughFileReader) {
   runBaseReaderTests(reader);
 }
 
+TEST(LocalFileReaderTest, testLocalFileReaderWithMissingFile) {
+  EXPECT_THROW(
+      fbpcf::io::FileReader(
+          IOTestHelper::getBaseDirFromPath(__FILE__) +
+          "data/nonexistent_file.txt"),
+      std::runtime_error);
+}
+
 } // namespace fbpcf::io

--- a/fbpcf/io/api/test/LocalFileWriterTest.cpp
+++ b/fbpcf/io/api/test/LocalFileWriterTest.cpp
@@ -94,4 +94,21 @@ TEST(LocalFileWriterTest, testLocalFileWriterThroughFileWriter) {
   runBaseWriterTests(writer, fileToWriteTo, expectedFile);
 }
 
+TEST(LocalFileWriterTest, testLocalFileWriterWithMissingDirectory) {
+  std::string baseDir = IOTestHelper::getBaseDirFromPath(__FILE__);
+  std::random_device rd;
+  std::default_random_engine defEngine(rd());
+  std::uniform_int_distribution<int> intDistro(1, 25000);
+  auto randint = intDistro(defEngine);
+  std::string fileToWriteTo = baseDir + "data/" + std::to_string(randint) +
+      "/local_file_writer_test_file" + std::to_string(randint) + ".txt";
+  std::string expectedFile =
+      baseDir + "data/expected_local_file_writer_test_file.txt";
+
+  auto writer = fbpcf::io::FileWriter(fileToWriteTo);
+  EXPECT_NO_THROW(runBaseWriterTests(writer, fileToWriteTo, expectedFile));
+
+  std::filesystem::remove("data/" + std::to_string(randint));
+}
+
 } // namespace fbpcf::io


### PR DESCRIPTION
Summary:
For the LocalFileWriter, if the file path provided contained a directory that doesn't exist, it would fail. This diff creates directories if they are missing

For the LocalFileReader, it also does a check for whether the file exists.

Differential Revision: D37730898

