### PR TITLE
Add helper functions for a pair type

### DIFF
--- a/fbpcf/mpc_std_lib/permuter/AsWaksmanPermuter_impl.h
+++ b/fbpcf/mpc_std_lib/permuter/AsWaksmanPermuter_impl.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <fbpcf/mpc_std_lib/util/util.h>
 namespace fbpcf::mpc_std_lib::permuter {
 
 template <typename T, int schedulerId>
@@ -97,7 +98,8 @@ AsWaksmanPermuter<T, schedulerId>::preSubPermutationSwap(
   if ((size & 1) == 1) {
     (*unbatchSize)[2] = 1;
   }
-  auto batches = src.unbatching(unbatchSize);
+  auto batches =
+      util::MpcAdapters<T, schedulerId>::unbatching(src, unbatchSize);
   if ((size & 1) == 0) {
     return util::MpcAdapters<T, schedulerId>::obliviousSwap(
         std::move(batches[0]),
@@ -108,7 +110,8 @@ AsWaksmanPermuter<T, schedulerId>::preSubPermutationSwap(
         std::move(batches[0]),
         std::move(batches[1]),
         std::move(firstSwapConditions));
-    auto fullSecond = std::move(second).batchingWith({std::move(batches[2])});
+    auto fullSecond = util::MpcAdapters<T, schedulerId>::batchingWith(
+        std::move(second), {std::move(batches[2])});
     return {first, fullSecond};
   }
 }
@@ -123,14 +126,17 @@ AsWaksmanPermuter<T, schedulerId>::postSubPermutationSwap(
   auto unbatchSize = std::make_shared<std::vector<uint32_t>>(2);
   (*unbatchSize)[0] = (size - 1) / 2;
   (*unbatchSize)[1] = 1;
-  auto secondBatches = src1.unbatching(unbatchSize);
+  auto secondBatches =
+      util::MpcAdapters<T, schedulerId>::unbatching(src1, unbatchSize);
   if ((size & 1) == 0) {
-    auto firstBatches = src0.unbatching(unbatchSize);
+    auto firstBatches =
+        util::MpcAdapters<T, schedulerId>::unbatching(src0, unbatchSize);
     auto [first, second] = util::MpcAdapters<T, schedulerId>::obliviousSwap(
         std::move(firstBatches[0]),
         std::move(secondBatches[0]),
         std::move(secondSwapConditions));
-    return first.batchingWith(
+    return util::MpcAdapters<T, schedulerId>::batchingWith(
+        first,
         {std::move(firstBatches[1]),
          std::move(second),
          std::move(secondBatches[1])});
@@ -139,7 +145,8 @@ AsWaksmanPermuter<T, schedulerId>::postSubPermutationSwap(
         std::move(src0),
         std::move(secondBatches[0]),
         std::move(secondSwapConditions));
-    return first.batchingWith({std::move(second), std::move(secondBatches[1])});
+    return util::MpcAdapters<T, schedulerId>::batchingWith(
+        first, {std::move(second), std::move(secondBatches[1])});
   }
 }
 
@@ -151,12 +158,13 @@ AsWaksmanPermuter<T, schedulerId>::processTwoElements(
   auto unbatchSize = std::make_shared<std::vector<uint32_t>>(2);
   (*unbatchSize)[0] = 1;
   (*unbatchSize)[1] = 1;
-  auto batches = src.unbatching(unbatchSize);
-
+  auto batches =
+      util::MpcAdapters<T, schedulerId>::unbatching(src, unbatchSize);
   auto [first, second] = util::MpcAdapters<T, schedulerId>::obliviousSwap(
       std::move(batches[0]), std::move(batches[1]), swapConditions);
 
-  return first.batchingWith({std::move(second)});
+  return util::MpcAdapters<T, schedulerId>::batchingWith(
+      first, {std::move(second)});
 }
 
 } // namespace fbpcf::mpc_std_lib::permuter

--- a/fbpcf/mpc_std_lib/shuffler/test/ShufflerTestPair.cpp
+++ b/fbpcf/mpc_std_lib/shuffler/test/ShufflerTestPair.cpp
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <cmath>
+#include <future>
+#include <memory>
+#include <random>
+#include <unordered_map>
+
+#include "fbpcf/engine/communication/test/AgentFactoryCreationHelper.h"
+#include "fbpcf/engine/util/AesPrgFactory.h"
+#include "fbpcf/mpc_std_lib/permuter/AsWaksmanPermuterFactory.h"
+#include "fbpcf/mpc_std_lib/permuter/DummyPermuterFactory.h"
+#include "fbpcf/mpc_std_lib/shuffler/NonShufflerFactory.h"
+#include "fbpcf/mpc_std_lib/shuffler/PermuteBasedShufflerFactory.h"
+#include "fbpcf/mpc_std_lib/util/test/util.h"
+#include "fbpcf/mpc_std_lib/util/util.h"
+#include "fbpcf/scheduler/SchedulerHelper.h"
+#include "fbpcf/test/TestHelper.h"
+
+namespace fbpcf::mpc_std_lib::shuffler {
+
+/*
+ * We run unit tests on a pair type of std::pair<uint32_t, bool>.
+ */
+
+/*
+ * Generate a vector of pairs, where each pair is composed of an id-value
+ * (uint32_t) and its true/false label. The i-th pair has an id value of i. This
+ * is used as a running example to test shuffler on a specific input type of
+ * std::pair<uint32_t, bool> .
+ */
+std::vector<std::pair<uint32_t, bool>> generateTestData(size_t size) {
+  std::vector<uint32_t> uint32Vec(size);
+  std::iota(
+      uint32Vec.begin(),
+      uint32Vec.end(),
+      0); // generate unique values starting from 0.
+  auto binaryVec = util::generateRandomBinary(size);
+
+  std::vector<std::pair<uint32_t, bool>> rst(size);
+  for (size_t i = 0; i < size; i++) {
+    rst[i] = {uint32Vec.at(i), binaryVec.at(i)};
+  }
+  return rst;
+}
+
+template <int schedulerId>
+std::vector<std::pair<uint32_t, bool>> task(
+    std::unique_ptr<IShuffler<std::pair<
+        frontend::Int<false, 32, true, schedulerId, true>,
+        frontend::Bit<true, schedulerId, true>>>> shuffler,
+    const std::vector<std::pair<uint32_t, bool>>& data) {
+  auto secretData = util::MpcAdapters<std::pair<uint32_t, bool>, schedulerId>::
+      processSecretInputs(data, 0);
+  auto shuffled = shuffler->shuffle(secretData, data.size());
+  auto rst =
+      util::MpcAdapters<std::pair<uint32_t, bool>, schedulerId>::openToParty(
+          shuffled, 0);
+  return rst;
+}
+
+void shufflerTest(
+    IShufflerFactory<std::pair<
+        frontend::Int<false, 32, true, 0, true>,
+        frontend::Bit<true, 0, true>>>& shufflerFactory0,
+    IShufflerFactory<std::pair<
+        frontend::Int<false, 32, true, 1, true>,
+        frontend::Bit<true, 1, true>>>& shufflerFactory1) {
+  auto agentFactories = engine::communication::getInMemoryAgentFactory(2);
+  setupRealBackend<0, 1>(*agentFactories[0], *agentFactories[1]);
+  auto shuffler0 = shufflerFactory0.create();
+  auto shuffler1 = shufflerFactory1.create();
+  size_t size = 16;
+  auto data = generateTestData(size);
+
+  auto future0 = std::async(task<0>, std::move(shuffler0), data);
+  auto future1 = std::async(task<1>, std::move(shuffler1), data);
+  auto rst = future0.get();
+  future1.get();
+
+  ASSERT_EQ(rst.size(), size);
+  for (size_t i = 0; i < data.size(); i++) {
+    auto index = rst.at(i).first;
+    // check consistency of each pair
+    ASSERT_EQ(rst.at(i).first, data.at(index).first);
+    ASSERT_EQ(rst.at(i).second, data.at(index).second);
+  }
+}
+
+TEST(shufflerTestPair, testNonShuffler) {
+  insecure::NonShufflerFactory<std::pair<
+      frontend::Int<false, 32, true, 0, true>,
+      frontend::Bit<true, 0, true>>>
+      factory0;
+  insecure::NonShufflerFactory<std::pair<
+      frontend::Int<false, 32, true, 1, true>,
+      frontend::Bit<true, 1, true>>>
+      factory1;
+
+  shufflerTest(factory0, factory1);
+}
+
+TEST(shufflerTestPair, testPermuteBasedShufflerWithDummyPermuter) {
+  PermuteBasedShufflerFactory<std::pair<
+      frontend::Int<false, 32, true, 0, true>,
+      frontend::Bit<true, 0, true>>>
+      factory0(
+          0,
+          1,
+          std::make_unique<permuter::insecure::DummyPermuterFactory<
+              std::pair<uint32_t, bool>,
+              0>>(0, 1),
+          std::make_unique<engine::util::AesPrgFactory>());
+  PermuteBasedShufflerFactory<std::pair<
+      frontend::Int<false, 32, true, 1, true>,
+      frontend::Bit<true, 1, true>>>
+      factory1(
+          1,
+          0,
+          std::make_unique<permuter::insecure::DummyPermuterFactory<
+              std::pair<uint32_t, bool>,
+              1>>(1, 0),
+          std::make_unique<engine::util::AesPrgFactory>());
+
+  shufflerTest(factory0, factory1);
+}
+
+TEST(shufflerTestPair, testPermuteBasedShufflerWithAsWaksmanPermuter) {
+  PermuteBasedShufflerFactory<std::pair<
+      frontend::Int<false, 32, true, 0, true>,
+      frontend::Bit<true, 0, true>>>
+      factory0(
+          0,
+          1,
+          std::make_unique<
+              permuter::AsWaksmanPermuterFactory<std::pair<uint32_t, bool>, 0>>(
+              0, 1),
+          std::make_unique<engine::util::AesPrgFactory>());
+  PermuteBasedShufflerFactory<std::pair<
+      frontend::Int<false, 32, true, 1, true>,
+      frontend::Bit<true, 1, true>>>
+      factory1(
+          1,
+          0,
+          std::make_unique<
+              permuter::AsWaksmanPermuterFactory<std::pair<uint32_t, bool>, 1>>(
+              1, 0),
+          std::make_unique<engine::util::AesPrgFactory>());
+
+  shufflerTest(factory0, factory1);
+}
+
+} // namespace fbpcf::mpc_std_lib::shuffler

--- a/fbpcf/mpc_std_lib/util/bit_impl.h
+++ b/fbpcf/mpc_std_lib/util/bit_impl.h
@@ -40,6 +40,17 @@ class MpcAdapters<bool, schedulerId> {
   static std::vector<bool> openToParty(const SecBatchType& src, int partyId) {
     return src.openToParty(partyId).getValue();
   }
+  static SecBatchType batchingWith(
+      const SecBatchType& src,
+      const std::vector<SecBatchType>& others) {
+    return src.batchingWith(others);
+  }
+
+  static std::vector<SecBatchType> unbatching(
+      const SecBatchType& src,
+      std::shared_ptr<std::vector<uint32_t>> unbatchingStrategy) {
+    return src.unbatching(unbatchingStrategy);
+  }
 };
 
 } // namespace fbpcf::mpc_std_lib::util

--- a/fbpcf/mpc_std_lib/util/bitstring_impl.h
+++ b/fbpcf/mpc_std_lib/util/bitstring_impl.h
@@ -47,6 +47,17 @@ class MpcAdapters<std::vector<bool>, schedulerId> {
       int partyId) {
     return src.openToParty(partyId).getValue();
   }
+  static SecBatchType batchingWith(
+      const SecBatchType& src,
+      const std::vector<SecBatchType>& others) {
+    return src.batchingWith(others);
+  }
+
+  static std::vector<SecBatchType> unbatching(
+      const SecBatchType& src,
+      std::shared_ptr<std::vector<uint32_t>> unbatchingStrategy) {
+    return src.unbatching(unbatchingStrategy);
+  }
 };
 
 } // namespace fbpcf::mpc_std_lib::util

--- a/fbpcf/mpc_std_lib/util/pairUtil.h
+++ b/fbpcf/mpc_std_lib/util/pairUtil.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace fbpcf::mpc_std_lib::util {
+
+/*
+ * The adapters here are partial template specializations for function
+ * templates listed in mpc_std_lib/util/util.h file to support a pair template
+ * type std::pair<T, U>.
+ */
+
+template <typename T, typename U, int schedulerId>
+struct SecBatchType<std::pair<T, U>, schedulerId> {
+  using type = std::pair<
+      typename SecBatchType<T, schedulerId>::type,
+      typename SecBatchType<U, schedulerId>::type>;
+};
+
+template <typename T, typename U, int schedulerId>
+class MpcAdapters<std::pair<T, U>, schedulerId> {
+ public:
+  using SecBatchType =
+      typename SecBatchType<std::pair<T, U>, schedulerId>::type;
+  static SecBatchType processSecretInputs(
+      const std::vector<std::pair<T, U>>& secrets,
+      int secretOwnerPartyId);
+
+  static std::pair<SecBatchType, SecBatchType> obliviousSwap(
+      const SecBatchType& src1,
+      const SecBatchType& src2,
+      frontend::Bit<true, schedulerId, true> indicator);
+
+  static std::vector<std::pair<T, U>> openToParty(
+      const SecBatchType& src,
+      int partyId);
+
+  static SecBatchType batchingWith(
+      const SecBatchType& src,
+      const std::vector<SecBatchType>& others);
+
+  static std::vector<SecBatchType> unbatching(
+      const SecBatchType& src,
+      std::shared_ptr<std::vector<uint32_t>> unbatchingStrategy);
+};
+
+} // namespace fbpcf::mpc_std_lib::util
+
+#include "fbpcf/mpc_std_lib/util/pair_impl.h"

--- a/fbpcf/mpc_std_lib/util/pair_impl.h
+++ b/fbpcf/mpc_std_lib/util/pair_impl.h
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace fbpcf::mpc_std_lib::util {
+
+/*
+ * The adapters here are partial specializations for function
+ * templates listed in mpc_std_lib/util/pairUtil.h file. The helper functions
+ * support a template type of std::pair<T, bool>.
+ */
+
+template <typename T, int schedulerId>
+struct SecBatchType<std::pair<T, bool>, schedulerId> {
+  using typeT = typename SecBatchType<T, schedulerId>::type;
+  using type = std::pair<typeT, typename SecBatchType<bool, schedulerId>::type>;
+};
+
+template <typename T, int schedulerId>
+class MpcAdapters<std::pair<T, bool>, schedulerId> {
+ public:
+  using SecBatchTypeT =
+      typename SecBatchType<std::pair<T, bool>, schedulerId>::typeT;
+  using SecBatchType =
+      typename SecBatchType<std::pair<T, bool>, schedulerId>::type;
+
+  static SecBatchType processSecretInputs(
+      const std::vector<std::pair<T, bool>>& secrets,
+      int secretOwnerPartyId) {
+    auto size = secrets.size();
+    std::vector<T> secrets1(size);
+    std::vector<bool> secrets2(size);
+    for (size_t i = 0; i < size; i++) {
+      secrets1[i] = secrets.at(i).first;
+      secrets2[i] = secrets.at(i).second;
+    }
+    auto rst1 = MpcAdapters<T, schedulerId>::processSecretInputs(
+        secrets1, secretOwnerPartyId);
+    auto rst2 = MpcAdapters<bool, schedulerId>::processSecretInputs(
+        secrets2, secretOwnerPartyId);
+    return {rst1, rst2};
+  }
+
+  static std::pair<SecBatchType, SecBatchType> obliviousSwap(
+      const SecBatchType& src1,
+      const SecBatchType& src2,
+      frontend::Bit<true, schedulerId, true> indicator) {
+    auto [rst11, rst12] = MpcAdapters<T, schedulerId>::obliviousSwap(
+        src1.first, src2.first, indicator);
+    auto [rst21, rst22] = MpcAdapters<bool, schedulerId>::obliviousSwap(
+        src1.second, src2.second, indicator);
+    return {{rst11, rst21}, {rst12, rst22}};
+  }
+
+  static std::vector<std::pair<T, bool>> openToParty(
+      const SecBatchType& src,
+      int partyId) {
+    auto rst1 = MpcAdapters<T, schedulerId>::openToParty(src.first, partyId);
+    auto rst2 =
+        MpcAdapters<bool, schedulerId>::openToParty(src.second, partyId);
+    if (rst1.size() != rst2.size()) {
+      throw std::runtime_error("data size does not match");
+    }
+
+    auto size = rst1.size();
+    std::vector<std::pair<T, bool>> rst(size);
+    for (size_t i = 0; i < size; i++) {
+      rst[i] = {rst1.at(i), rst2.at(i)};
+    }
+    return rst;
+  }
+  static SecBatchType batchingWith(
+      const SecBatchType& src,
+      const std::vector<SecBatchType>& others) {
+    std::vector<SecBatchTypeT> others1(others.size());
+    std::vector<frontend::Bit<true, schedulerId, true>> others2(others.size());
+    for (size_t i = 0; i < others.size(); i++) {
+      others1[i] = others.at(i).first;
+      others2[i] = others.at(i).second;
+    }
+    auto rst1 = MpcAdapters<T, schedulerId>::batchingWith(src.first, others1);
+    auto rst2 =
+        MpcAdapters<bool, schedulerId>::batchingWith(src.second, others2);
+    return {rst1, rst2};
+  }
+
+  static std::vector<SecBatchType> unbatching(
+      const SecBatchType& src,
+      std::shared_ptr<std::vector<T>> unbatchingStrategy) {
+    auto rst1 =
+        MpcAdapters<T, schedulerId>::unbatching(src.first, unbatchingStrategy);
+    auto rst2 = MpcAdapters<bool, schedulerId>::unbatching(
+        src.second, unbatchingStrategy);
+    std::vector<SecBatchType> rst(rst1.size());
+    for (size_t i = 0; i < rst.size(); i++) {
+      rst[i] = {rst1.at(i), rst2.at(i)};
+    }
+    return rst;
+  }
+};
+
+} // namespace fbpcf::mpc_std_lib::util

--- a/fbpcf/mpc_std_lib/util/uint32_impl.h
+++ b/fbpcf/mpc_std_lib/util/uint32_impl.h
@@ -81,6 +81,18 @@ class MpcAdapters<uint32_t, schedulerId> {
         buf.begin(), buf.end(), rst.begin(), [](auto v) { return v; });
     return rst;
   }
+
+  static SecBatchType batchingWith(
+      const SecBatchType& src,
+      const std::vector<SecBatchType>& others) {
+    return src.batchingWith(others);
+  }
+
+  static std::vector<SecBatchType> unbatching(
+      const SecBatchType& src,
+      std::shared_ptr<std::vector<uint32_t>> unbatchingStrategy) {
+    return src.unbatching(unbatchingStrategy);
+  }
 };
 
 template <int schedulerId>

--- a/fbpcf/mpc_std_lib/util/util.h
+++ b/fbpcf/mpc_std_lib/util/util.h
@@ -79,3 +79,6 @@ std::vector<__m128i> convertFromBits(const std::vector<std::vector<bool>>& src);
 #include "fbpcf/mpc_std_lib/util/bitstring_impl.h"
 
 #include "fbpcf/mpc_std_lib/util/bit_impl.h"
+
+#include "fbpcf/mpc_std_lib/util/pairUtil.h"
+#include "fbpcf/mpc_std_lib/util/pair_impl.h"

--- a/fbpcf/mpc_std_lib/util/util.h
+++ b/fbpcf/mpc_std_lib/util/util.h
@@ -55,6 +55,14 @@ class MpcAdapters {
       frontend::Bit<true, schedulerId, true> indicator);
 
   static std::vector<T> openToParty(const SecBatchType& src, int partyId);
+
+  static SecBatchType batchingWith(
+      const SecBatchType& src,
+      const std::vector<SecBatchType>& others);
+
+  static std::vector<SecBatchType> unbatching(
+      const SecBatchType& src,
+      std::shared_ptr<std::vector<uint32_t>> unbatchingStrategy);
 };
 
 std::vector<std::vector<bool>> convertToBits(const std::vector<__m128i>& src);


### PR DESCRIPTION
Summary:
Add partially specialized template functions to MPC adapters to support inputs of a pair type.

Details:
The functions we add here are partial specializations of primary template functions listed in mpc_std_lib/util/util.h. These are meant to be designed to support a compactor API.

1.  add a partially specialized template type ```std::pair<T, U>```.
2.  add a partially instantiated type ```std::pair <T, bool>```.

Reviewed By: chualynn

Differential Revision: D37708542

