### PR TITLE
ShiftRow function in AesCircuit

### DIFF
--- a/fbpcf/mpc_std_lib/aes_circuit/AesCircuit.h
+++ b/fbpcf/mpc_std_lib/aes_circuit/AesCircuit.h
@@ -48,3 +48,5 @@ class AesCircuit : public IAesCircuit<BitType> {
 };
 
 } // namespace fbpcf::mpc_std_lib::aes_circuit
+
+#include "fbpcf/mpc_std_lib/aes_circuit/AesCircuit_impl.h"

--- a/fbpcf/mpc_std_lib/aes_circuit/AesCircuit_impl.h
+++ b/fbpcf/mpc_std_lib/aes_circuit/AesCircuit_impl.h
@@ -7,8 +7,8 @@
 
 #pragma once
 
+#include <algorithm>
 #include <vector>
-#include "fbpcf/mpc_std_lib/aes_circuit/AesCircuit.h"
 
 namespace fbpcf::mpc_std_lib::aes_circuit {
 
@@ -60,7 +60,18 @@ void AesCircuit<BitType>::inverseMixColumnsInPlace(WordType& src) const {
 
 template <typename BitType>
 void AesCircuit<BitType>::shiftRowInPlace(WordType& src, int8_t offset) {
-  throw std::runtime_error("Not implemented!");
+  if (offset == 1) {
+    std::swap(src[0], src[1]);
+    std::swap(src[1], src[2]);
+    std::swap(src[2], src[3]);
+  } else if (offset == 2) {
+    std::swap(src[0], src[2]);
+    std::swap(src[1], src[3]);
+  } else if (offset == 3) {
+    std::swap(src[3], src[2]);
+    std::swap(src[2], src[1]);
+    std::swap(src[1], src[0]);
+  }
 }
 
 } // namespace fbpcf::mpc_std_lib::aes_circuit


### PR DESCRIPTION
Summary:
Implemented shift row as part of the AES circuit.

The function takes in a WordType (which is an array of bytes) and shifts every byte to the left by offset bytes.

The variable "offset" should take a value in {0,1,2,3}.

Differential Revision: D37806096

