### PR TITLE
Support more GCS format

### DIFF
--- a/fbpcf/gcp/GCSUtil.cpp
+++ b/fbpcf/gcp/GCSUtil.cpp
@@ -18,7 +18,9 @@
 namespace fbpcf::gcp {
 // Format:
 // 1. https://storage.cloud.google.com/bucket-name/key-name
-// 2. gs://bucket-name/key-name
+// 2. https://bucket-name.storage.googleapis.com/key-name
+// 3. https://storage.googleapis.com/bucket-name/key-name
+// 4. gs://bucket-name/key-name
 GCSObjectReference uriToObjectReference(std::string url) {
   std::string bucket;
   std::string key;
@@ -37,6 +39,8 @@ GCSObjectReference uriToObjectReference(std::string url) {
 
   if (boost::iequals(scheme, "gs")) {
     bucket = host;
+  } else if (host.find(".storage.googleapis.com") != std::string::npos) {
+    bucket = host.substr(0, host.find_first_of("."));
   } else {
     // Remove the first character '/' in path
     path = path.substr(1);

--- a/fbpcf/gcp/test/GCSUtilTest.cpp
+++ b/fbpcf/gcp/test/GCSUtilTest.cpp
@@ -23,6 +23,22 @@ TEST(GCSUtil, uriToObjectReference) {
   EXPECT_EQ("key", ref.key);
 }
 
+TEST(GCSUtil, uriToObjectReference_virtualHostStyle) {
+  auto uri = "https://bucket-name.storage.googleapis.com/key-name";
+  auto ref = fbpcf::gcp::uriToObjectReference(uri);
+
+  EXPECT_EQ("bucket-name", ref.bucket);
+  EXPECT_EQ("key-name", ref.key);
+}
+
+TEST(GCSUtil, uriToObjectReference_pathStyle) {
+  auto uri = "https://storage.googleapis.com/bucket-name/key-name";
+  auto ref = fbpcf::gcp::uriToObjectReference(uri);
+
+  EXPECT_EQ("bucket-name", ref.bucket);
+  EXPECT_EQ("key-name", ref.key);
+}
+
 TEST(GCSUtil, uriToObjectReference_Subfolder) {
   auto uri = "https://storage.cloud.google.com/bucket/folder/key";
   auto ref = fbpcf::gcp::uriToObjectReference(uri);

--- a/fbpcf/io/cloud_util/CloudFileUtil.cpp
+++ b/fbpcf/io/cloud_util/CloudFileUtil.cpp
@@ -17,12 +17,14 @@ namespace fbpcf::cloudio {
 
 CloudFileType getCloudFileType(const std::string& filePath) {
   // S3 file format:
-  // 1. https://bucket-name.s3.Region.amazonaws.com/key-name
-  // 2. https://bucket-name.s3-Region.amazonaws.com/key-name
+  // 1. https://bucket-name.s3.region.amazonaws.com/key-name
+  // 2. https://bucket-name.s3-region.amazonaws.com/key-name
   // 3. s3://bucket-name/key-name
   // GCS file format:
   // 1. https://storage.cloud.google.com/bucket-name/key-name
-  // 2. gs://bucket-name/key-name
+  // 2. https://bucket-name.storage.googleapis.com/key-name
+  // 3. https://storage.googleapis.com/bucket-name/key-name
+  // 4. gs://bucket-name/key-name
   static const re2::RE2 s3Regex1(
       "https://[a-z0-9.-]+.s3.[a-z0-9-]+.amazonaws.com/.+");
   static const re2::RE2 s3Regex2(
@@ -34,9 +36,14 @@ CloudFileType getCloudFileType(const std::string& filePath) {
     return CloudFileType::S3;
   }
 
-  static const re2::RE2 gcsRegex("https://storage.cloud.google.com/.*");
-  bool isGCSFile =
-      re2::RE2::FullMatch(filePath, gcsRegex) || filePath.find("gs://", 0) == 0;
+  static const re2::RE2 gcsRegex1("https://storage.cloud.google.com/.*");
+  static const re2::RE2 gcsRegex2(
+      "https://[a-z0-9.-]+.storage.googleapis.com/.+");
+  static const re2::RE2 gcsRegex3("https://storage.googleapis.com/.*");
+  bool isGCSFile = re2::RE2::FullMatch(filePath, gcsRegex1) ||
+      re2::RE2::FullMatch(filePath, gcsRegex2) ||
+      re2::RE2::FullMatch(filePath, gcsRegex3) ||
+      filePath.find("gs://", 0) == 0;
   if (isGCSFile) {
     return CloudFileType::GCS;
   }

--- a/fbpcf/io/cloud_util/test/CloudFileUtilTest.cpp
+++ b/fbpcf/io/cloud_util/test/CloudFileUtilTest.cpp
@@ -26,8 +26,16 @@ TEST(FileManagerUtilTest, TestGetCloudFileType) {
       getCloudFileType("https://storage.cloud.google.com/bucket-name/key-name");
   EXPECT_EQ(CloudFileType::GCS, gcsType1);
 
-  auto gcsType2 = getCloudFileType("gs://bucket-name/key-name");
+  auto gcsType2 =
+      getCloudFileType("https://bucket-name.storage.googleapis.com/key-name");
   EXPECT_EQ(CloudFileType::GCS, gcsType2);
+
+  auto gcsType3 =
+      getCloudFileType("https://storage.googleapis.com/bucket-name/key-name");
+  EXPECT_EQ(CloudFileType::GCS, gcsType3);
+
+  auto gcsType4 = getCloudFileType("gs://bucket-name/key-name");
+  EXPECT_EQ(CloudFileType::GCS, gcsType4);
 
   auto unkonwnType =
       getCloudFileType("https://storage.test.com/bucket-name/key-name");


### PR DESCRIPTION
Summary: uriToObjectReference() and getCloudFileType() needs to support more GCS uri format.

Differential Revision: D37811001

