### PR TITLE
Fix small bug on unbatching adapter

### DIFF
--- a/fbpcf/mpc_std_lib/util/pair_impl.h
+++ b/fbpcf/mpc_std_lib/util/pair_impl.h
@@ -91,7 +91,7 @@ class MpcAdapters<std::pair<T, bool>, schedulerId> {
 
   static std::vector<SecBatchType> unbatching(
       const SecBatchType& src,
-      std::shared_ptr<std::vector<T>> unbatchingStrategy) {
+      std::shared_ptr<std::vector<uint32_t>> unbatchingStrategy) {
     auto rst1 =
         MpcAdapters<T, schedulerId>::unbatching(src.first, unbatchingStrategy);
     auto rst2 = MpcAdapters<bool, schedulerId>::unbatching(


### PR DESCRIPTION
Summary: The unbatching strategy type should be uint32_t.

Reviewed By: chualynn

Differential Revision: D37822826

