### PR TITLE
Address a potential `heap use after free` bug

### DIFF
--- a/fbpcf/scheduler/EagerScheduler.cpp
+++ b/fbpcf/scheduler/EagerScheduler.cpp
@@ -374,7 +374,7 @@ IScheduler::WireId<IScheduler::Boolean> EagerScheduler::batchingUp(
 std::vector<IScheduler::WireId<IScheduler::Boolean>> EagerScheduler::unbatching(
     WireId<Boolean> src,
     std::shared_ptr<std::vector<uint32_t>> unbatchingStrategy) {
-  auto& batch = wireKeeper_->getBatchBooleanValue(src);
+  auto batch = wireKeeper_->getBatchBooleanValue(src);
   size_t index = 0;
   std::vector<IScheduler::WireId<IScheduler::Boolean>> rst(
       unbatchingStrategy->size());


### PR DESCRIPTION
Summary:
Recently a bug in the eager scheduler was uncovered. The root cause was an improper use of reference. A reference to a stored wire's value may become invalid when more wires are allocated. This is because allocating more wires may cause the system to move the underlying value storage to a new place, thus invalidate the reference.

This diff will use value instead of a reference to address the concern.

Detailed dynamic of the bug:

on line 377, a reference to a vector is created;
on line 390, a new wire is allocated, this might use up all the free slots in the underlying wirekeeper, so the wire keeper has to allocate more memory and potentially move existing data there, pretty much invalidate the reference obtained previously on line 377.
In next for loop, the invalid reference was used on line 383 again.

Reviewed By: chualynn

Differential Revision: D37839467

