### PR TITLE
Implement edit distance business Logic

### DIFF
--- a/example/edit_distance/EditDistanceCalculator.h
+++ b/example/edit_distance/EditDistanceCalculator.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "./InputProcessor.h" // @manual
+#include "./MPCTypes.h" // @manual
+#include "./Util.h" // @manual
+
+#pragma once
+
+namespace fbpcf::edit_distance {
+
+template <int schedulerId>
+class EditDistanceCalculator {
+ public:
+  explicit EditDistanceCalculator(
+      int myRole,
+      InputProcessor<schedulerId>&& inputProcessor)
+      : myRole_{myRole}, inputProcessor_(inputProcessor) {
+    calculateEditDistances();
+    calculateMessages();
+  }
+
+  InputProcessor<schedulerId>& getInputProcessor() {
+    return inputProcessor_;
+  }
+
+  SecString<schedulerId>& getReceiverMessages() {
+    return receiverMessages_;
+  }
+
+  Sec32Int<schedulerId> getEditDistances() {
+    return editDistances_;
+  }
+
+ private:
+  void calculateEditDistances();
+  void calculateMessages();
+
+  int myRole_;
+  InputProcessor<schedulerId> inputProcessor_;
+
+  SecString<schedulerId> receiverMessages_;
+  Sec32Int<schedulerId> editDistances_;
+};
+
+} // namespace fbpcf::edit_distance
+
+#include "./EditDistanceCalculator_impl.h" // @manual

--- a/example/edit_distance/EditDistanceCalculator_impl.h
+++ b/example/edit_distance/EditDistanceCalculator_impl.h
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "./EditDistanceCalculator.h" // @manual
+
+namespace fbpcf::edit_distance {
+
+template <int schedulerId>
+void EditDistanceCalculator<schedulerId>::calculateEditDistances() {
+  const SecString<schedulerId>& words = inputProcessor_.getWords();
+  const SecString<schedulerId>& guesses = inputProcessor_.getGuesses();
+
+  SecUChar<schedulerId> wordsSize = words.template privateSize<charLength>();
+  SecUChar<schedulerId> guessSize = guesses.template privateSize<charLength>();
+
+  size_t batchSize = inputProcessor_.getInputData().getNumRows();
+  Pub32Int<schedulerId> zero =
+      createPublicBatchConstant<Pub32Int<schedulerId>, int64_t>(0, batchSize);
+  const Pub32Int<schedulerId>& insertCost = inputProcessor_.getInsertCost();
+  const Pub32Int<schedulerId>& deleteCost = inputProcessor_.getDeleteCost();
+
+  std::vector<SecBool<schedulerId>> in_bounds_word(maxStringLength);
+  std::vector<SecBool<schedulerId>> in_bounds_guess(maxStringLength);
+  for (size_t i = 0; i < maxStringLength; i++) {
+    PubUChar<schedulerId> index =
+        createPublicBatchConstant<PubUChar<schedulerId>, size_t>(i, batchSize);
+    in_bounds_word[i] = index < wordsSize;
+    in_bounds_guess[i] = index < guessSize;
+  }
+
+  std::vector<std::vector<Sec32Int<schedulerId>>> distances(
+      maxStringLength + 1);
+
+  distances[0] = std::vector<Sec32Int<schedulerId>>(maxStringLength + 1);
+
+  // Not technically a secret value but makes the types work more easily
+  distances[0][0] = createSecretBatchConstant<Sec32Int<schedulerId>, int64_t>(
+      0, batchSize, PLAYER0);
+
+  for (size_t i = 1; i <= maxStringLength; i++) {
+    distances[i] = std::vector<Sec32Int<schedulerId>>(maxStringLength + 1);
+    distances[0][i] =
+        distances[0][i - 1] + zero.mux(in_bounds_guess[i - 1], deleteCost);
+    distances[i][0] =
+        distances[i - 1][0] + zero.mux(in_bounds_word[i - 1], insertCost);
+  }
+
+  for (size_t i = 1; i <= maxStringLength; i++) {
+    for (size_t j = 1; j <= maxStringLength; j++) {
+      // cast signed char to signed 32int
+      SecChar<schedulerId> wordLetter = words[i - 1];
+      SecChar<schedulerId> guessLetter = guesses[j - 1];
+      Sec32Int<schedulerId> asciiDist =
+          (wordLetter - guessLetter)
+              .mux(wordLetter < guessLetter, guessLetter - wordLetter)
+              .template cast<int32Length>();
+      auto replaceSol = distances[i - 1][j - 1] + asciiDist;
+      auto insertSol = distances[i - 1][j] + insertCost;
+      auto deleteSol = distances[i][j - 1] + deleteCost;
+      auto minSol = fbpcf::frontend::min(
+          fbpcf::frontend::min(replaceSol, insertSol), deleteSol);
+      /*
+      Case 1: In Bounds Both Words
+          - Return minSolution
+      Case 2: In Bounds of Guess / Not in bounds of word
+          - Copy solution of wordIndex - 1
+      Case 3: In bounds of Word / Not in bounds of guess
+          - Copy solution of guessIndex - 1
+      Case 4: Not in bounds of either
+          - Copy solution of wordIndex - 1, guessIndex - 1
+      */
+      distances[i][j] =
+          distances[i - 1][j - 1]
+              .mux(in_bounds_word[i - 1], distances[i][j - 1])
+              .mux(
+                  in_bounds_guess[j - 1],
+                  distances[i - 1][j].mux(
+                      in_bounds_word[i - 1] & in_bounds_guess[j - 1], minSol));
+    }
+  }
+
+  editDistances_ = distances[maxStringLength][maxStringLength];
+}
+
+template <int schedulerId>
+void EditDistanceCalculator<schedulerId>::calculateMessages() {
+  const Pub32Int<schedulerId>& threshold = inputProcessor_.getThreshold();
+  SecUChar<schedulerId> messageLength =
+      inputProcessor_.getSenderMessages().template privateSize<charLength>();
+
+  size_t batchSize = inputProcessor_.getInputData().getNumRows();
+  PubString<schedulerId> emptyMessage =
+      createPublicBatchConstant<PubString<schedulerId>, std::string>(
+          "", batchSize);
+  PubChar<schedulerId> nullChar =
+      createPublicBatchConstant<PubChar<schedulerId>, int64_t>(0, batchSize);
+  PubUChar<schedulerId> one =
+      createPublicBatchConstant<PubUChar<schedulerId>, uint64_t>(1, batchSize);
+  const SecString<schedulerId>& senderMessage =
+      inputProcessor_.getSenderMessages();
+  SecString<schedulerId> halfMessage;
+  for (size_t i = 0; i < maxStringLength; i++) {
+    PubUChar<schedulerId> index =
+        createPublicBatchConstant<PubUChar<schedulerId>, uint64_t>(
+            i, batchSize);
+    halfMessage[i] =
+        nullChar.mux((index + index + one) < messageLength, senderMessage[i]);
+  }
+
+  receiverMessages_ =
+      emptyMessage.mux(editDistances_ <= threshold + threshold, halfMessage)
+          .mux(editDistances_ < threshold, senderMessage);
+}
+} // namespace fbpcf::edit_distance

--- a/example/edit_distance/test/EditDistanceCalculatorTest.cpp
+++ b/example/edit_distance/test/EditDistanceCalculatorTest.cpp
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "../EditDistanceCalculator.h" // @manual
+#include <fbpcf/scheduler/SchedulerHelper.h>
+#include <gtest/gtest.h>
+#include "../EditDistanceInputReader.h" // @manual
+#include "../MPCTypes.h" // @manual
+#include "./Constants.h" // @manual
+#include "fbpcf/engine/communication/IPartyCommunicationAgentFactory.h"
+#include "fbpcf/engine/communication/test/AgentFactoryCreationHelper.h"
+#include "fbpcf/test/TestHelper.h"
+#include "tools/cxx/Resources.h"
+
+namespace fbpcf::edit_distance {
+
+template <int schedulerId>
+EditDistanceCalculator<schedulerId> createCalculatorWithScheduler(
+    int myRole,
+    EditDistanceInputReader&& inputData,
+    std::reference_wrapper<
+        fbpcf::engine::communication::IPartyCommunicationAgentFactory> factory,
+    fbpcf::SchedulerCreator schedulerCreator) {
+  auto scheduler = schedulerCreator(myRole, factory);
+  fbpcf::scheduler::SchedulerKeeper<schedulerId>::setScheduler(
+      std::move(scheduler));
+  InputProcessor<schedulerId> inputProcessor(myRole, std::move(inputData));
+  return EditDistanceCalculator<schedulerId>(myRole, std::move(inputProcessor));
+}
+
+template <int schedulerId>
+std::pair<std::vector<int64_t>, std::vector<std::string>> revealOutputs(
+    int myRole,
+    EditDistanceCalculator<schedulerId>& calculator) {
+  if (myRole == 0) {
+    auto distances =
+        calculator.getEditDistances().openToParty(PLAYER0).getValue();
+    auto receiverMessages =
+        calculator.getReceiverMessages().openToParty(PLAYER0).getValue();
+
+    calculator.getEditDistances().openToParty(PLAYER1).getValue();
+    calculator.getReceiverMessages().openToParty(PLAYER1).getValue();
+    return std::pair(distances, receiverMessages);
+  } else {
+    calculator.getEditDistances().openToParty(PLAYER0).getValue();
+    calculator.getReceiverMessages().openToParty(PLAYER0).getValue();
+
+    auto distances =
+        calculator.getEditDistances().openToParty(PLAYER1).getValue();
+    auto receiverMessages =
+        calculator.getReceiverMessages().openToParty(PLAYER1).getValue();
+    return std::pair(distances, receiverMessages);
+  }
+}
+
+TEST(EditDistanceCalculatorTest, testEditDistanceCalculator) {
+  using namespace fbcpf::edit_distance;
+
+  boost::filesystem::path dataFilepath1 =
+      build::getResourcePath(std::getenv("DATA_FILE_PATH_1"));
+
+  boost::filesystem::path dataFilepath2 =
+      build::getResourcePath(std::getenv("DATA_FILE_PATH_2"));
+  boost::filesystem::path paramsFilePath =
+      build::getResourcePath(std::getenv("PARAMS_FILE_PATH"));
+
+  auto player0InputData =
+      EditDistanceInputReader(dataFilepath1.native(), paramsFilePath.native());
+
+  auto player1InputData =
+      EditDistanceInputReader(dataFilepath2.native(), paramsFilePath.native());
+
+  auto schedulerCreator = fbpcf::scheduler::createLazySchedulerWithRealEngine;
+  auto factories = fbpcf::engine::communication::getInMemoryAgentFactory(2);
+
+  auto future0 = std::async(
+      createCalculatorWithScheduler<0>,
+      PLAYER0,
+      std::move(player0InputData),
+      std::reference_wrapper<
+          fbpcf::engine::communication::IPartyCommunicationAgentFactory>(
+          *factories[0]),
+      schedulerCreator);
+
+  auto future1 = std::async(
+      createCalculatorWithScheduler<1>,
+      PLAYER1,
+      std::move(player1InputData),
+      std::reference_wrapper<
+          fbpcf::engine::communication::IPartyCommunicationAgentFactory>(
+          *factories[1]),
+      schedulerCreator);
+
+  EditDistanceCalculator<0> player0Calculator = future0.get();
+  EditDistanceCalculator<1> player1Calculator = future1.get();
+
+  auto future2 = std::async(
+      revealOutputs<0>,
+      PLAYER0,
+      std::reference_wrapper<EditDistanceCalculator<0>>(player0Calculator));
+
+  auto future3 = std::async(
+      revealOutputs<1>,
+      PLAYER1,
+      std::reference_wrapper<EditDistanceCalculator<1>>(player1Calculator));
+
+  auto player0Results = future2.get();
+  auto player1Results = future3.get();
+
+  testVectorEq(std::get<0>(player0Results), kExpectedDistances);
+  testVectorEq(std::get<1>(player0Results), kExpectedReceiverMessages);
+
+  testVectorEq(std::get<0>(player1Results), kExpectedDistances);
+  testVectorEq(std::get<1>(player1Results), kExpectedReceiverMessages);
+}
+} // namespace fbpcf::edit_distance


### PR DESCRIPTION
Summary:
Implements the core logic to calculate the edit distance. The algorithm is slightly complicated by the fact that the size of the strings is unknown, so the solution matrix must account for that.

{F753583602}

I drew the following diagram as an example. The rows direction has the letters of the word, and the columns are the letters of the guess that we are trying to change into the word.

Moving up means we are inserting the letter into the guess at that position of the word. Moving left means we are deleting the letter of the guess at the current position. Moving diagonally means replacement of the letter.

Once we are out of bounds, the logic depends on which quadrant we are in. Assuming the quadrants are numbered
1 2
3 4
quadrant 2 indicates we should copy the value to the left, quadrant 3 is copying the value from above, and quadrant 4 is copying the value diagonally up and left. This guarantees that the correct solution in the position of the last letter of guess and last letter of word will surround quadrant 4, and then be copied into the last position.

I also modified the CSV reader class since it did not allow for empty string input. I copied the "split" method from https://www.geeksforgeeks.org/program-to-parse-a-comma-separated-string-in-c/.

Differential Revision: D37792933

