### PR TITLE
Add additional test cases, Modify CSV parsing logic to allow empty fields

### DIFF
--- a/example/edit_distance/test/Constants.h
+++ b/example/edit_distance/test/Constants.h
@@ -11,23 +11,47 @@
 #include <vector>
 namespace fbcpf::edit_distance {
 
-inline const std::vector<std::string> kExpectedWords = {"temporary", "mug"};
-inline const std::vector<std::string> kExpectedSenderMessages = {"box", "soft"};
-inline const std::vector<std::string> kExpectedGuesses = {"curvy", "grain"};
-inline const std::vector<std::string> kEmptyVector = {"", ""};
+inline const std::vector<std::string> kExpectedWords = {
+    "temporary",
+    "mug",
+    "black-and-white",
+    ""};
+inline const std::vector<std::string> kExpectedSenderMessages = {
+    "box",
+    "soft",
+    "hello",
+    "empty"};
+inline const std::vector<std::string> kExpectedGuesses = {
+    "curvy",
+    "grain",
+    "black-and-white",
+    "not-empty"};
+inline const std::vector<int64_t> kExpectedDistances = {131, 81, 0, 315};
+inline const std::vector<std::string> kExpectedReceiverMessages = {
+    "b",
+    "soft",
+    "hello",
+    ""};
+inline const std::vector<std::string> kEmptyVector = {"", "", "", ""};
 
 const int kExpectedThreshold = 100;
 inline const std::vector<int64_t> kExpectedThresholdBatch = {
+    kExpectedThreshold,
+    kExpectedThreshold,
     kExpectedThreshold,
     kExpectedThreshold};
 
 const int kExpectedDeleteCost = 35;
 inline const std::vector<int64_t> kExpectedDeleteBatch = {
     kExpectedDeleteCost,
+    kExpectedDeleteCost,
+    kExpectedDeleteCost,
     kExpectedDeleteCost};
 
 const int kExpectedInsertCost = 30;
 inline const std::vector<int64_t> kExpectedInsertBatch = {
+    kExpectedInsertCost,
+    kExpectedInsertCost,
     kExpectedInsertCost,
     kExpectedInsertCost};
 

--- a/example/edit_distance/test/test_data/edit_distance_test_player_1_input.csv
+++ b/example/edit_distance/test/test_data/edit_distance_test_player_1_input.csv
@@ -1,3 +1,5 @@
 word,sender_message
 temporary,box
 mug,soft
+black-and-white,hello
+,empty

--- a/example/edit_distance/test/test_data/edit_distance_test_player_2_input.csv
+++ b/example/edit_distance/test/test_data/edit_distance_test_player_2_input.csv
@@ -1,3 +1,5 @@
 guess
 curvy
 grain
+black-and-white
+not-empty

--- a/example/edit_distance/test/test_data/edit_distance_test_results.csv
+++ b/example/edit_distance/test/test_data/edit_distance_test_results.csv
@@ -1,3 +1,5 @@
 distance,receiver_message
 131,b
 81,soft
+0,hello
+315,

--- a/fbpcf/io/api/FileIOWrappers.cpp
+++ b/fbpcf/io/api/FileIOWrappers.cpp
@@ -13,6 +13,7 @@
 #include "fbpcf/io/api/FileIOWrappers.h"
 #include "fbpcf/io/api/FileReader.h"
 #include "fbpcf/io/api/FileWriter.h"
+#include "fbpcf/io/api/IOUtils.h"
 
 namespace fbpcf::io {
 
@@ -73,42 +74,16 @@ bool FileIOWrappers::readCsv(
       std::move(inlineReader), kBufferedReaderChunkSize);
 
   std::string line = inlineBufferedReader->readLine();
-  auto header = splitByComma(line);
+  auto header = IOUtils::splitByComma(line);
   processHeader(header);
 
   while (!inlineBufferedReader->eof()) {
-    // Split on commas, but if it looks like we're reading an array
-    // like `[1, 2, 3]`, take the whole array
     line = inlineBufferedReader->readLine();
-    auto parts = splitByComma(line);
+    auto parts = IOUtils::splitByComma(line);
     readLine(header, parts);
   }
   inlineBufferedReader->close();
   return true;
-}
-
-const std::vector<std::string> FileIOWrappers::split(
-    std::string& str,
-    const std::string& delim) {
-  // Preprocessing step: Remove spaces if any
-  str.erase(std::remove(str.begin(), str.end(), ' '), str.end());
-  std::vector<std::string> tokens;
-  re2::RE2 rgx{delim};
-  re2::StringPiece input{str}; // Wrap a StringPiece around it
-
-  std::string token;
-  while (RE2::Consume(&input, rgx, &token)) {
-    tokens.push_back(token);
-  }
-  return tokens;
-}
-
-const std::vector<std::string> FileIOWrappers::splitByComma(std::string& str) {
-  // split internally uses RE2 which relies on
-  // consuming patterns. The pattern here indicates
-  // it will get all the non commas [^,]. The surrounding () makes it
-  // a capture group. ,? means there may or may not be a comma
-  return split(str, "([^,]+),?");
 }
 
 } // namespace fbpcf::io

--- a/fbpcf/io/api/FileIOWrappers.h
+++ b/fbpcf/io/api/FileIOWrappers.h
@@ -49,15 +49,6 @@ class FileIOWrappers {
           const std::vector<std::string>& parts)> readLine,
       std::function<void(const std::vector<std::string>&)> processHeader =
           [](auto) {});
-
- private:
-  // Split an input string into component pieces given a delimiter
-  static const std::vector<std::string> split(
-      std::string& str,
-      const std::string& delim);
-
-  // Same as split, but specifically for comma delimiters.
-  static const std::vector<std::string> splitByComma(std::string& str);
 };
 
 } // namespace fbpcf::io

--- a/fbpcf/io/api/IOUtils.h
+++ b/fbpcf/io/api/IOUtils.h
@@ -7,7 +7,10 @@
 
 #pragma once
 
+#include <algorithm>
+#include <sstream>
 #include <string>
+#include <vector>
 
 namespace fbpcf::io {
 
@@ -15,6 +18,43 @@ class IOUtils {
  public:
   static bool isCloudFile(std::string filePath) {
     return filePath.find("https://", 0) == 0;
+  }
+
+  static const std::vector<std::string> splitByComma(std::string& str) {
+    trim(str);
+    std::vector<std::string> tokens;
+
+    if (str == "") {
+      tokens.push_back("");
+      return tokens;
+    }
+
+    std::stringstream ss(str);
+
+    while (ss.good()) {
+      std::string substr;
+      std::getline(ss, substr, ',');
+      trim(substr);
+      tokens.push_back(substr);
+    }
+    return tokens;
+  }
+
+ private:
+  static void trim(std::string& str) {
+    // Trim space from left
+    str.erase(
+        str.begin(), std::find_if(str.begin(), str.end(), [](unsigned char ch) {
+          return !std::isspace(ch);
+        }));
+    // Trim spaces from right
+    str.erase(
+        std::find_if(
+            str.rbegin(),
+            str.rend(),
+            [](unsigned char ch) { return !std::isspace(ch); })
+            .base(),
+        str.end());
   }
 };
 

--- a/fbpcf/io/api/test/FileIOWrappersTest.cpp
+++ b/fbpcf/io/api/test/FileIOWrappersTest.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "fbpcf/io/api/FileIOWrappers.h"
+#include <fbpcf/test/TestHelper.h>
 #include <folly/Format.h>
 #include <gtest/gtest.h>
 #include <stdio.h>
@@ -66,6 +67,33 @@ TEST(FileIOWrappersTest, testReadFile) {
       "\n"
       "last line here, don't miss me ~~\n";
   EXPECT_EQ(content, expectedContent);
+}
+
+TEST(FileIOWrappersTest, testReadCSV) {
+  std::string baseDir = IOTestHelper::getBaseDirFromPath(__FILE__);
+  std::string fileToRead = baseDir + "data/file_io_wrappers_read_csv_test.csv";
+
+  std::vector<std::vector<std::string>> csvContents;
+
+  fbpcf::io::FileIOWrappers::readCsv(
+      fileToRead,
+      [&csvContents](
+          const std::vector<std::string>& header,
+          const std::vector<std::string>& values) {
+        csvContents.push_back(values);
+      });
+
+  std::vector<std::vector<std::string>> expected = {
+      {"Paul", "35", "Programmer"},
+      {"", "13", ""},
+      {""},
+      {"Bill", "", "Lawyer"}};
+
+  EXPECT_EQ(csvContents.size(), expected.size());
+
+  for (int i = 0; i < csvContents.size(); i++) {
+    testVectorEq(csvContents[i], expected[i]);
+  }
 }
 
 } // namespace fbpcf::io

--- a/fbpcf/io/api/test/data/file_io_wrappers_read_csv_test.csv
+++ b/fbpcf/io/api/test/data/file_io_wrappers_read_csv_test.csv
@@ -1,0 +1,5 @@
+name,age,occupation
+Paul,35, Programmer
+,13,
+
+ Bill,,Lawyer


### PR DESCRIPTION
Summary:
I modified the CSV reader class since it did not allow for empty string input. I copied the "split" method from https://www.geeksforgeeks.org/program-to-parse-a-comma-separated-string-in-c/.

Added some test cases to EditDistanceInputReaderTest which test the new string reading logic.

Differential Revision: D37968979

