### PR TITLE
Delete PIDInstanceRepository

### DIFF
--- a/fbpcf/tests/github/fbpcf_e2e_aws.yml
+++ b/fbpcf/tests/github/fbpcf_e2e_aws.yml
@@ -32,10 +32,6 @@ private_computation:
         task_definition: onedocker-task-fbpcf-e2e-workflow:7#onedocker-container-fbpcf-e2e-workflow
 pid:
   dependency:
-    PIDInstanceRepository:
-      class: fbpcs.pid.repository.pid_instance_local.LocalPIDInstanceRepository
-      constructor:
-        base_dir: /instances
   skip_aggregation_step: true
   task_definition:
 mpc:


### PR DESCRIPTION
Summary:
PIDInstanceRepository is used by the old PIDService which was replace by the new PID stage services (D37619253). In this diff, we delete all PIDInstanceRepository related code.
And because we updated the repo configs for mpc_aem/experimentation_platform.  EP also used manifold config files to run continuous measurements.  The same changes should be included in continuous measurement as well. We assign the task (T126244336) to ajinkya-ghonge

# Changelog
[Removed] - Delete PIDInstanceRepository

Reviewed By: jrodal98

Differential Revision: D37874084

