### PR TITLE
Revert diff D37557580

### DIFF
--- a/fbpcf/io/cloud_util/CloudFileUtil.cpp
+++ b/fbpcf/io/cloud_util/CloudFileUtil.cpp
@@ -60,10 +60,8 @@ std::unique_ptr<IFileReader> getCloudFileReader(const std::string& filePath) {
   auto fileType = getCloudFileType(filePath);
   if (fileType == CloudFileType::S3) {
     const auto& ref = fbpcf::aws::uriToObjectReference(filePath);
-    return std::make_unique<S3FileReader>(
-        fbpcf::cloudio::S3Client::getInstance(
-            fbpcf::aws::S3ClientOption{.region = ref.region})
-            .getS3Client());
+    return std::make_unique<S3FileReader>(fbpcf::aws::createS3Client(
+        fbpcf::aws::S3ClientOption{.region = ref.region}));
   } else if (fileType == CloudFileType::GCS) {
     return std::make_unique<GCSFileReader>(fbpcf::gcp::createGCSClient());
   } else {

--- a/fbpcf/io/cloud_util/S3FileReader.h
+++ b/fbpcf/io/cloud_util/S3FileReader.h
@@ -16,8 +16,8 @@ namespace fbpcf::cloudio {
 
 class S3FileReader : public IFileReader {
  public:
-  explicit S3FileReader(std::shared_ptr<Aws::S3::S3Client> client)
-      : s3Client_{client} {}
+  explicit S3FileReader(std::unique_ptr<Aws::S3::S3Client> client)
+      : s3Client_{std::move(client)} {}
 
   std::string readBytes(
       const std::string& filePath,
@@ -27,7 +27,7 @@ class S3FileReader : public IFileReader {
   size_t getFileContentLength(const std::string& filePath) override;
 
  private:
-  std::shared_ptr<Aws::S3::S3Client> s3Client_;
+  std::unique_ptr<Aws::S3::S3Client> s3Client_;
 };
 
 } // namespace fbpcf::cloudio


### PR DESCRIPTION
Summary: We wanted to use a singleton S3Client for S3FileReader also, but unfortunately this singleton is shared between S3FileReader and S3FileUploader. So if the reader and uploader are touching files in different region, it will throw error "The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint.". The reason is that the reader will initilize S3Client with one region (e.g. us-west-2), and then the uploader will reuse it to upload file to another region (e.g. us-west-1).

Differential Revision: D37977599

