### PR TITLE
Add new Gate Type for integers

### DIFF
--- a/fbpcf/scheduler/gate_keeper/ArithmeticGate.h
+++ b/fbpcf/scheduler/gate_keeper/ArithmeticGate.h
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <map>
+
+#include "fbpcf/exception/exceptions.h"
+#include "fbpcf/scheduler/gate_keeper/IArithmeticGate.h"
+
+namespace fbpcf::scheduler {
+
+class ArithmeticGate final : public IArithmeticGate {
+  using IArithmeticGate::gateType_;
+  using IArithmeticGate::left_;
+  using IArithmeticGate::numberOfResults_;
+  using IArithmeticGate::partyID_;
+  using IArithmeticGate::right_;
+  using IArithmeticGate::scheduledResultIndex_;
+  using IArithmeticGate::wireID_;
+  using IArithmeticGate::wireKeeper_;
+  using typename IArithmeticGate::GateType;
+
+ public:
+  ArithmeticGate(
+      GateType gateType,
+      IScheduler::WireId<IScheduler::WireType::Arithmetic> wireID,
+      IScheduler::WireId<IScheduler::WireType::Arithmetic> left,
+      IScheduler::WireId<IScheduler::WireType::Arithmetic> right,
+      int partyID,
+      IWireKeeper& wireKeeper)
+      : IArithmeticGate{
+            gateType,
+            wireID,
+            left,
+            right,
+            partyID,
+            /*numberOfResults*/ 1,
+            wireKeeper} {
+    increaseReferenceCount(wireID_);
+    increaseReferenceCount(left_);
+    increaseReferenceCount(right_);
+  }
+
+  ~ArithmeticGate() override {
+    decreaseReferenceCount(wireID_);
+    decreaseReferenceCount(left_);
+    decreaseReferenceCount(right_);
+  }
+
+  void compute(
+      engine::ISecretShareEngine& engine,
+      std::map<int64_t, Secrets>& secretSharesByParty) override {
+    switch (gateType_) {
+        // Free gates
+      case GateType::AsymmetricPlus:
+        throw common::exceptions::NotImplementedError("Unimplemented");
+        break;
+
+      case GateType::FreeMult:
+        throw common::exceptions::NotImplementedError("Unimplemented");
+        break;
+
+      case GateType::Input:
+        throw common::exceptions::NotImplementedError("Unimplemented");
+        break;
+
+      case GateType::Neg:
+        throw common::exceptions::NotImplementedError("Unimplemented");
+        break;
+
+      case GateType::SymmetricPlus:
+        throw common::exceptions::NotImplementedError("Unimplemented");
+        break;
+
+      // Non-free gates
+      case GateType::Output:
+        throw common::exceptions::NotImplementedError("Unimplemented");
+        break;
+
+      case GateType::NonFreeMult:
+        throw common::exceptions::NotImplementedError("Unimplemented");
+        break;
+    }
+  }
+
+  void collectScheduledResult(
+      engine::ISecretShareEngine& engine,
+      std::map<int64_t, Secrets>& revealedSecretsByParty) override {
+    switch (gateType_) {
+      case GateType::NonFreeMult:
+        throw common::exceptions::NotImplementedError("Unimplemented");
+        break;
+
+      case GateType::Output:
+        throw common::exceptions::NotImplementedError("Unimplemented");
+        break;
+
+      default:
+        break;
+    }
+  }
+
+  void increaseReferenceCount(
+      IScheduler::WireId<IScheduler::WireType::Arithmetic> wire) override {
+    if (!wire.isEmpty()) {
+      wireKeeper_.increaseReferenceCount(wire);
+    }
+  }
+
+  void decreaseReferenceCount(
+      IScheduler::WireId<IScheduler::WireType::Arithmetic> wire) override {
+    if (!wire.isEmpty()) {
+      wireKeeper_.decreaseReferenceCount(wire);
+    }
+  }
+};
+
+} // namespace fbpcf::scheduler

--- a/fbpcf/scheduler/gate_keeper/BatchArithmeticGate.h
+++ b/fbpcf/scheduler/gate_keeper/BatchArithmeticGate.h
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <map>
+
+#include "fbpcf/exception/exceptions.h"
+#include "fbpcf/scheduler/gate_keeper/IArithmeticGate.h"
+
+namespace fbpcf::scheduler {
+
+class BatchArithmeticGate final : public IArithmeticGate {
+ public:
+  using IArithmeticGate::gateType_;
+  using IArithmeticGate::left_;
+  using IArithmeticGate::numberOfResults_;
+  using IArithmeticGate::partyID_;
+  using IArithmeticGate::right_;
+  using IArithmeticGate::scheduledResultIndex_;
+  using IArithmeticGate::wireID_;
+  using IArithmeticGate::wireKeeper_;
+  using typename IArithmeticGate::GateType;
+  BatchArithmeticGate(
+      GateType gateType,
+      IScheduler::WireId<IScheduler::WireType::Arithmetic> wireID,
+      IScheduler::WireId<IScheduler::WireType::Arithmetic> left,
+      IScheduler::WireId<IScheduler::WireType::Arithmetic> right,
+      int partyID,
+      uint32_t numberOfResults,
+      IWireKeeper& wireKeeper)
+      : IArithmeticGate{
+            gateType,
+            wireID,
+            left,
+            right,
+            partyID,
+            numberOfResults,
+            wireKeeper} {
+    increaseReferenceCount(wireID_);
+    increaseReferenceCount(left_);
+    increaseReferenceCount(right_);
+  }
+
+  ~BatchArithmeticGate() override {
+    decreaseReferenceCount(wireID_);
+    decreaseReferenceCount(left_);
+    decreaseReferenceCount(right_);
+  }
+
+  void compute(
+      engine::ISecretShareEngine& engine,
+      std::map<int64_t, IGate::Secrets>& secretSharesByParty) override {
+    switch (gateType_) {
+        // Free gates
+      case GateType::AsymmetricPlus:
+        throw common::exceptions::NotImplementedError("Unimplemented");
+        break;
+
+      case GateType::FreeMult:
+        throw common::exceptions::NotImplementedError("Unimplemented");
+        break;
+
+      case GateType::Input:
+        throw common::exceptions::NotImplementedError("Unimplemented");
+        break;
+
+      case GateType::Neg:
+        throw common::exceptions::NotImplementedError("Unimplemented");
+        break;
+
+      case GateType::SymmetricPlus:
+        throw common::exceptions::NotImplementedError("Unimplemented");
+        break;
+
+      // Non-free gates
+      case GateType::Output:
+        throw common::exceptions::NotImplementedError("Unimplemented");
+        break;
+
+      case GateType::NonFreeMult:
+        throw common::exceptions::NotImplementedError("Unimplemented");
+        break;
+    }
+  }
+
+  void collectScheduledResult(
+      engine::ISecretShareEngine& engine,
+      std::map<int64_t, IGate::Secrets>& revealedSecretsByParty) override {
+    switch (gateType_) {
+      case GateType::NonFreeMult:
+        throw common::exceptions::NotImplementedError("Unimplemented");
+        break;
+
+      case GateType::Output:
+        throw common::exceptions::NotImplementedError("Unimplemented");
+        break;
+
+      default:
+        break;
+    }
+  }
+
+  void increaseReferenceCount(
+      IScheduler::WireId<IScheduler::WireType::Arithmetic> wire) override {
+    if (!wire.isEmpty()) {
+      wireKeeper_.increaseBatchReferenceCount(wire);
+    }
+  }
+
+  void decreaseReferenceCount(
+      IScheduler::WireId<IScheduler::WireType::Arithmetic> wire) override {
+    if (!wire.isEmpty()) {
+      wireKeeper_.decreaseBatchReferenceCount(wire);
+    }
+  }
+};
+
+} // namespace fbpcf::scheduler

--- a/fbpcf/scheduler/gate_keeper/BatchCompositeGate.h
+++ b/fbpcf/scheduler/gate_keeper/BatchCompositeGate.h
@@ -45,7 +45,7 @@ class BatchCompositeGate final : public ICompositeGate {
 
   void compute(
       engine::ISecretShareEngine& engine,
-      std::map<int64_t, std::vector<bool>>& /*secretSharesByParty*/) override {
+      std::map<int64_t, IGate::Secrets>& /*secretSharesByParty*/) override {
     switch (gateType_) {
         // Free gates
       case GateType::FreeAnd: {
@@ -76,8 +76,7 @@ class BatchCompositeGate final : public ICompositeGate {
 
   void collectScheduledResult(
       engine::ISecretShareEngine& engine,
-      std::map<int64_t, std::vector<bool>>& /*revealedSecretsByParty*/)
-      override {
+      std::map<int64_t, IGate::Secrets>& /*revealedSecretsByParty*/) override {
     std::vector<std::vector<bool>> result;
     switch (gateType_) {
       case GateType::NonFreeAnd: {

--- a/fbpcf/scheduler/gate_keeper/CompositeGate.h
+++ b/fbpcf/scheduler/gate_keeper/CompositeGate.h
@@ -7,10 +7,12 @@
 
 #pragma once
 
+#include <cstdint>
 #include <exception>
 #include <map>
 #include <stdexcept>
 
+#include <fbpcf/scheduler/gate_keeper/IGate.h>
 #include "fbpcf/scheduler/gate_keeper/ICompositeGate.h"
 
 namespace fbpcf::scheduler {
@@ -51,7 +53,7 @@ class CompositeGate final : public ICompositeGate {
 
   void compute(
       engine::ISecretShareEngine& engine,
-      std::map<int64_t, std::vector<bool>>& /*secretSharesByParty*/) override {
+      std::map<int64_t, IGate::Secrets>& /*secretSharesByParty*/) override {
     switch (gateType_) {
         // Free gates
       case GateType::FreeAnd:
@@ -78,8 +80,7 @@ class CompositeGate final : public ICompositeGate {
 
   void collectScheduledResult(
       engine::ISecretShareEngine& engine,
-      std::map<int64_t, std::vector<bool>>& /*revealedSecretsByParty*/)
-      override {
+      std::map<int64_t, IGate::Secrets>& /*revealedSecretsByParty*/) override {
     std::vector<bool> result;
     switch (gateType_) {
       case GateType::NonFreeAnd:

--- a/fbpcf/scheduler/gate_keeper/IArithmeticGate.h
+++ b/fbpcf/scheduler/gate_keeper/IArithmeticGate.h
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <map>
+
+#include "fbpcf/engine/ISecretShareEngine.h"
+#include "fbpcf/scheduler/IScheduler.h"
+#include "fbpcf/scheduler/IWireKeeper.h"
+#include "fbpcf/scheduler/gate_keeper/IGate.h"
+
+namespace fbpcf::scheduler {
+
+/**
+ * This class executes arithmetic gates in a circuit.
+ * There are subclasses for batched and non-batched gates.
+ */
+class IArithmeticGate : public IGate {
+ public:
+  enum class GateType {
+    Input,
+    Output,
+    FreeMult,
+    NonFreeMult,
+    AsymmetricPlus,
+    SymmetricPlus,
+    Neg,
+  };
+
+  IArithmeticGate(
+      GateType gateType,
+      IScheduler::WireId<IScheduler::WireType::Arithmetic> wireID,
+      IScheduler::WireId<IScheduler::WireType::Arithmetic> left,
+      IScheduler::WireId<IScheduler::WireType::Arithmetic> right,
+      int partyID,
+      uint32_t numberOfResults,
+      IWireKeeper& wireKeeper)
+      : gateType_{gateType},
+        wireID_{wireID},
+        left_{left},
+        right_{right},
+        partyID_{partyID},
+        numberOfResults_{numberOfResults},
+        wireKeeper_{wireKeeper} {}
+
+  IArithmeticGate(const IArithmeticGate& g) : wireKeeper_(g.wireKeeper_) {
+    copy(g);
+  }
+
+  IArithmeticGate(IArithmeticGate&& g) noexcept : wireKeeper_(g.wireKeeper_) {
+    move(std::move(g));
+  }
+
+  IArithmeticGate& operator=(const IArithmeticGate& g) {
+    copy(g);
+    return *this;
+  }
+
+  IArithmeticGate& operator=(IArithmeticGate&& g) {
+    move(std::move(g));
+    return *this;
+  }
+
+  static bool isFree(GateType gateType) {
+    switch (gateType) {
+      case GateType::AsymmetricPlus:
+      case GateType::FreeMult:
+      case GateType::Input:
+      case GateType::Neg:
+      case GateType::SymmetricPlus:
+        return true;
+
+      case GateType::NonFreeMult:
+      case GateType::Output:
+        return false;
+    }
+  }
+
+  IScheduler::WireId<IScheduler::WireType::Arithmetic> getWireId() const {
+    return wireID_;
+  }
+
+  // The number of values in a batch gate (1 for non-batch case)
+  uint32_t getNumberOfResults() const override {
+    return numberOfResults_;
+  }
+
+ protected:
+  GateType gateType_;
+  IScheduler::WireId<IScheduler::WireType::Arithmetic> wireID_;
+  IScheduler::WireId<IScheduler::WireType::Arithmetic> left_;
+  IScheduler::WireId<IScheduler::WireType::Arithmetic> right_;
+  int partyID_;
+  uint32_t scheduledResultIndex_;
+  uint32_t numberOfResults_;
+  IWireKeeper& wireKeeper_;
+
+  void copy(const IArithmeticGate& src) {
+    decreaseReferenceCount(wireID_);
+    decreaseReferenceCount(left_);
+    decreaseReferenceCount(right_);
+    gateType_ = src.gateType_;
+    wireID_ = src.wireID_;
+    left_ = src.left_;
+    right_ = src.right_;
+    partyID_ = src.partyID_;
+    scheduledResultIndex_ = src.scheduledResultIndex_;
+    numberOfResults_ = src.numberOfResults_;
+    increaseReferenceCount(wireID_);
+    increaseReferenceCount(left_);
+    increaseReferenceCount(right_);
+  }
+
+  void move(IArithmeticGate&& src) {
+    decreaseReferenceCount(wireID_);
+    decreaseReferenceCount(left_);
+    decreaseReferenceCount(right_);
+    gateType_ = src.gateType_;
+    wireID_ = src.wireID_;
+    left_ = src.left_;
+    right_ = src.right_;
+    partyID_ = src.partyID_;
+    scheduledResultIndex_ = src.scheduledResultIndex_;
+    numberOfResults_ = src.numberOfResults_;
+
+    src.wireID_ = src.left_ = src.right_ =
+        IScheduler::WireId<IScheduler::WireType::Arithmetic>();
+  }
+
+  virtual void increaseReferenceCount(
+      IScheduler::WireId<IScheduler::WireType::Arithmetic> wire) = 0;
+
+  virtual void decreaseReferenceCount(
+      IScheduler::WireId<IScheduler::WireType::Arithmetic> wire) = 0;
+};
+
+} // namespace fbpcf::scheduler

--- a/fbpcf/scheduler/gate_keeper/ICompositeGate.h
+++ b/fbpcf/scheduler/gate_keeper/ICompositeGate.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <exception>
 #include <map>
 #include <stdexcept>
@@ -82,14 +83,13 @@ class ICompositeGate : public IGate {
   // Run or schedule the computation for this gate.
   virtual void compute(
       engine::ISecretShareEngine& engine,
-      std::map<int64_t, std::vector<bool>>& secretSharesByParty) override = 0;
+      std::map<int64_t, IGate::Secrets>& secretSharesByParty) override = 0;
 
   // For non-free gates, get the result of the computation that was scheduled
   // and store it on the appropriate wire.
   virtual void collectScheduledResult(
       engine::ISecretShareEngine& engine,
-      std::map<int64_t, std::vector<bool>>& revealedSecretsByParty)
-      override = 0;
+      std::map<int64_t, IGate::Secrets>& revealedSecretsByParty) override = 0;
 
   uint32_t getNumberOfResults() const override {
     return numberOfResults_;

--- a/fbpcf/scheduler/gate_keeper/IGate.h
+++ b/fbpcf/scheduler/gate_keeper/IGate.h
@@ -7,18 +7,32 @@
 
 #pragma once
 
+#include <cstdint>
 #include <map>
+#include <vector>
 
 #include "fbpcf/engine/ISecretShareEngine.h"
+#include "fbpcf/scheduler/IScheduler.h"
 
 namespace fbpcf::scheduler {
 
 /**
- * Base interface for Gates in a boolean circuit. It is used to encapsulate
- * operations that will happen at some point in the future.
+ * Base interface for Gates in a boolean and/or arithmetic circuit. It is used
+ * to encapsulate operations that would be evaluated at some point in the
+ * future.
  */
 class IGate {
  public:
+  struct Secrets {
+    std::vector<bool> booleanSecrets;
+    std::vector<uint64_t> integerSecrets;
+    Secrets(
+        std::vector<bool>&& booleanSecrets,
+        std::vector<uint64_t>&& integerSecrets)
+        : booleanSecrets(std::move(booleanSecrets)),
+          integerSecrets(std::move(integerSecrets)) {}
+  };
+
   virtual ~IGate() = default;
 
   /* Run or schedule the computation for this gate.
@@ -29,21 +43,20 @@ class IGate {
    */
   virtual void compute(
       engine::ISecretShareEngine& engine,
-      std::map<int64_t, std::vector<bool>>& secretSharesByParty) = 0;
+      std::map<int64_t, Secrets>& secretSharesByParty) = 0;
 
   /* For non-free gates, get the result of the computation that was scheduled
    * and store it on the appropriate wire(s).
-   * @param engine Will be used to retrieve AND gates results in XOR ss form
+   * @param engine Will be used to retrieve AND/MULT gates results in XOR/ADD ss
+   * form
    * @param revealedSecretsByParty Will hold values for output gates shared from
    * other parties.
    */
   virtual void collectScheduledResult(
       engine::ISecretShareEngine& engine,
-      std::map<int64_t, std::vector<bool>>& revealedSecretsByParty) = 0;
+      std::map<int64_t, Secrets>& revealedSecretsByParty) = 0;
 
   // The number of values in a batch gate (1 for non-batch case)
   virtual uint32_t getNumberOfResults() const = 0;
-
- protected:
 };
 } // namespace fbpcf::scheduler

--- a/fbpcf/scheduler/gate_keeper/RebatchingGate.h
+++ b/fbpcf/scheduler/gate_keeper/RebatchingGate.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <stdexcept>
 #include <string>
@@ -74,9 +75,8 @@ class RebatchingBooleanGate : public IGate {
     }
   }
 
-  void compute(
-      engine::ISecretShareEngine&,
-      std::map<int64_t, std::vector<bool>>&) override {
+  void compute(engine::ISecretShareEngine&, std::map<int64_t, IGate::Secrets>&)
+      override {
     switch (gateType_) {
       case GateType::Batching:
         executeBatchingGate();
@@ -89,7 +89,7 @@ class RebatchingBooleanGate : public IGate {
 
   void collectScheduledResult(
       engine::ISecretShareEngine&,
-      std::map<int64_t, std::vector<bool>>&) override {}
+      std::map<int64_t, IGate::Secrets>&) override {}
 
   uint32_t getNumberOfResults() const override {
     return 0;


### PR DESCRIPTION
Summary:
Added a new Gate type to represent the arithmetic operations created by the scheduler. Supporting operations: input, output, plus, neg, mult.

Changed the compute and collectScheduledResult function arguments in IGate.h so a partyID is mapped to a pair of vectors, one for boolean and one for integer.

Differential Revision: D37931698

