### PR TITLE
Implement GateKeeper methods to add arithmetic gates

### DIFF
--- a/fbpcf/scheduler/LazyScheduler.cpp
+++ b/fbpcf/scheduler/LazyScheduler.cpp
@@ -14,6 +14,7 @@
 #include <string>
 
 #include <fbpcf/scheduler/gate_keeper/GateKeeper.h>
+#include <fbpcf/scheduler/gate_keeper/INormalGate.h>
 #include "fbpcf/scheduler/IScheduler.h"
 #include "fbpcf/scheduler/gate_keeper/IGate.h"
 #include "fbpcf/scheduler/gate_keeper/INormalGate.h"
@@ -110,8 +111,8 @@ std::vector<bool> LazyScheduler::getBooleanValueBatch(
 IScheduler::WireId<IScheduler::Boolean> LazyScheduler::privateAndPrivate(
     WireId<IScheduler::Boolean> left,
     WireId<IScheduler::Boolean> right) {
-  auto id = gateKeeper_->normalGate(
-      INormalGate<IScheduler::Boolean>::GateType::NonFreeAnd, left, right);
+  auto id =
+      gateKeeper_->normalGate(INormalGate::GateType::NonFreeAnd, left, right);
   maybeExecuteGates();
   return id;
 }
@@ -120,7 +121,7 @@ IScheduler::WireId<IScheduler::Boolean> LazyScheduler::privateAndPrivateBatch(
     WireId<IScheduler::Boolean> left,
     WireId<IScheduler::Boolean> right) {
   auto id = gateKeeper_->normalGateBatch(
-      INormalGate<IScheduler::Boolean>::GateType::NonFreeAnd, left, right);
+      INormalGate::GateType::NonFreeAnd, left, right);
   maybeExecuteGates();
   return id;
 }
@@ -128,8 +129,8 @@ IScheduler::WireId<IScheduler::Boolean> LazyScheduler::privateAndPrivateBatch(
 IScheduler::WireId<IScheduler::Boolean> LazyScheduler::privateAndPublic(
     WireId<IScheduler::Boolean> left,
     WireId<IScheduler::Boolean> right) {
-  auto id = gateKeeper_->normalGate(
-      INormalGate<IScheduler::Boolean>::GateType::FreeAnd, left, right);
+  auto id =
+      gateKeeper_->normalGate(INormalGate::GateType::FreeAnd, left, right);
   maybeExecuteGates();
   return id;
 }
@@ -137,8 +138,8 @@ IScheduler::WireId<IScheduler::Boolean> LazyScheduler::privateAndPublic(
 IScheduler::WireId<IScheduler::Boolean> LazyScheduler::privateAndPublicBatch(
     WireId<IScheduler::Boolean> left,
     WireId<IScheduler::Boolean> right) {
-  auto id = gateKeeper_->normalGateBatch(
-      INormalGate<IScheduler::Boolean>::GateType::FreeAnd, left, right);
+  auto id =
+      gateKeeper_->normalGateBatch(INormalGate::GateType::FreeAnd, left, right);
   maybeExecuteGates();
   return id;
 }
@@ -146,8 +147,8 @@ IScheduler::WireId<IScheduler::Boolean> LazyScheduler::privateAndPublicBatch(
 IScheduler::WireId<IScheduler::Boolean> LazyScheduler::publicAndPublic(
     WireId<IScheduler::Boolean> left,
     WireId<IScheduler::Boolean> right) {
-  auto id = gateKeeper_->normalGate(
-      INormalGate<IScheduler::Boolean>::GateType::FreeAnd, left, right);
+  auto id =
+      gateKeeper_->normalGate(INormalGate::GateType::FreeAnd, left, right);
   maybeExecuteGates();
   return id;
 }
@@ -155,8 +156,8 @@ IScheduler::WireId<IScheduler::Boolean> LazyScheduler::publicAndPublic(
 IScheduler::WireId<IScheduler::Boolean> LazyScheduler::publicAndPublicBatch(
     WireId<IScheduler::Boolean> left,
     WireId<IScheduler::Boolean> right) {
-  auto id = gateKeeper_->normalGateBatch(
-      INormalGate<IScheduler::Boolean>::GateType::FreeAnd, left, right);
+  auto id =
+      gateKeeper_->normalGateBatch(INormalGate::GateType::FreeAnd, left, right);
   maybeExecuteGates();
   return id;
 }
@@ -224,8 +225,8 @@ LazyScheduler::publicAndPublicCompositeBatch(
 IScheduler::WireId<IScheduler::Boolean> LazyScheduler::privateXorPrivate(
     WireId<IScheduler::Boolean> left,
     WireId<IScheduler::Boolean> right) {
-  auto id = gateKeeper_->normalGate(
-      INormalGate<IScheduler::Boolean>::GateType::SymmetricXOR, left, right);
+  auto id =
+      gateKeeper_->normalGate(INormalGate::GateType::SymmetricXOR, left, right);
   maybeExecuteGates();
   return id;
 }
@@ -234,7 +235,7 @@ IScheduler::WireId<IScheduler::Boolean> LazyScheduler::privateXorPrivateBatch(
     WireId<IScheduler::Boolean> left,
     WireId<IScheduler::Boolean> right) {
   auto id = gateKeeper_->normalGateBatch(
-      INormalGate<IScheduler::Boolean>::GateType::SymmetricXOR, left, right);
+      INormalGate::GateType::SymmetricXOR, left, right);
   maybeExecuteGates();
   return id;
 }
@@ -243,7 +244,7 @@ IScheduler::WireId<IScheduler::Boolean> LazyScheduler::privateXorPublic(
     WireId<IScheduler::Boolean> left,
     WireId<IScheduler::Boolean> right) {
   auto id = gateKeeper_->normalGate(
-      INormalGate<IScheduler::Boolean>::GateType::AsymmetricXOR, left, right);
+      INormalGate::GateType::AsymmetricXOR, left, right);
   maybeExecuteGates();
   return id;
 }
@@ -252,7 +253,7 @@ IScheduler::WireId<IScheduler::Boolean> LazyScheduler::privateXorPublicBatch(
     WireId<IScheduler::Boolean> left,
     WireId<IScheduler::Boolean> right) {
   auto id = gateKeeper_->normalGateBatch(
-      INormalGate<IScheduler::Boolean>::GateType::AsymmetricXOR, left, right);
+      INormalGate::GateType::AsymmetricXOR, left, right);
   maybeExecuteGates();
   return id;
 }
@@ -260,8 +261,8 @@ IScheduler::WireId<IScheduler::Boolean> LazyScheduler::privateXorPublicBatch(
 IScheduler::WireId<IScheduler::Boolean> LazyScheduler::publicXorPublic(
     WireId<IScheduler::Boolean> left,
     WireId<IScheduler::Boolean> right) {
-  auto id = gateKeeper_->normalGate(
-      INormalGate<IScheduler::Boolean>::GateType::SymmetricXOR, left, right);
+  auto id =
+      gateKeeper_->normalGate(INormalGate::GateType::SymmetricXOR, left, right);
   maybeExecuteGates();
   return id;
 }
@@ -270,39 +271,37 @@ IScheduler::WireId<IScheduler::Boolean> LazyScheduler::publicXorPublicBatch(
     WireId<IScheduler::Boolean> left,
     WireId<IScheduler::Boolean> right) {
   auto id = gateKeeper_->normalGateBatch(
-      INormalGate<IScheduler::Boolean>::GateType::SymmetricXOR, left, right);
+      INormalGate::GateType::SymmetricXOR, left, right);
   maybeExecuteGates();
   return id;
 }
 
 IScheduler::WireId<IScheduler::Boolean> LazyScheduler::notPrivate(
     WireId<IScheduler::Boolean> src) {
-  auto id = gateKeeper_->normalGate(
-      INormalGate<IScheduler::Boolean>::GateType::AsymmetricNot, src);
+  auto id = gateKeeper_->normalGate(INormalGate::GateType::AsymmetricNot, src);
   maybeExecuteGates();
   return id;
 }
 
 IScheduler::WireId<IScheduler::Boolean> LazyScheduler::notPrivateBatch(
     WireId<IScheduler::Boolean> src) {
-  auto id = gateKeeper_->normalGateBatch(
-      INormalGate<IScheduler::Boolean>::GateType::AsymmetricNot, src);
+  auto id =
+      gateKeeper_->normalGateBatch(INormalGate::GateType::AsymmetricNot, src);
   maybeExecuteGates();
   return id;
 }
 
 IScheduler::WireId<IScheduler::Boolean> LazyScheduler::notPublic(
     WireId<IScheduler::Boolean> src) {
-  auto id = gateKeeper_->normalGate(
-      INormalGate<IScheduler::Boolean>::GateType::SymmetricNot, src);
+  auto id = gateKeeper_->normalGate(INormalGate::GateType::SymmetricNot, src);
   maybeExecuteGates();
   return id;
 }
 
 IScheduler::WireId<IScheduler::Boolean> LazyScheduler::notPublicBatch(
     WireId<IScheduler::Boolean> src) {
-  auto id = gateKeeper_->normalGateBatch(
-      INormalGate<IScheduler::Boolean>::GateType::SymmetricNot, src);
+  auto id =
+      gateKeeper_->normalGateBatch(INormalGate::GateType::SymmetricNot, src);
   maybeExecuteGates();
   return id;
 }

--- a/fbpcf/scheduler/gate_keeper/ArithmeticGate.h
+++ b/fbpcf/scheduler/gate_keeper/ArithmeticGate.h
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <map>
+
+#include "fbpcf/scheduler/gate_keeper/IArithmeticGate.h"
+
+namespace fbpcf::scheduler {
+
+class ArithmeticGate final : public IArithmeticGate {
+  using IArithmeticGate::gateType_;
+  using IArithmeticGate::left_;
+  using IArithmeticGate::numberOfResults_;
+  using IArithmeticGate::partyID_;
+  using IArithmeticGate::right_;
+  using IArithmeticGate::scheduledResultIndex_;
+  using IArithmeticGate::wireID_;
+  using IArithmeticGate::wireKeeper_;
+  using typename IArithmeticGate::GateType;
+
+ public:
+  ArithmeticGate(
+      GateType gateType,
+      IScheduler::WireId<IScheduler::WireType::Arithmetic> wireID,
+      IScheduler::WireId<IScheduler::WireType::Arithmetic> left,
+      IScheduler::WireId<IScheduler::WireType::Arithmetic> right,
+      int partyID,
+      IWireKeeper& wireKeeper)
+      : IArithmeticGate{
+            gateType,
+            wireID,
+            left,
+            right,
+            partyID,
+            /*numberOfResults*/ 1,
+            wireKeeper} {
+    increaseReferenceCount(wireID_);
+    increaseReferenceCount(left_);
+    increaseReferenceCount(right_);
+  }
+
+  ~ArithmeticGate() override {
+    decreaseReferenceCount(wireID_);
+    decreaseReferenceCount(left_);
+    decreaseReferenceCount(right_);
+  }
+
+  void compute(
+      engine::ISecretShareEngine& engine,
+      std::map<int64_t, IGate::Secrets>& secretSharesByParty) override {
+    switch (gateType_) {
+        // Free gates
+      case GateType::AsymmetricPlus:
+        throw std::runtime_error("Unimplemented");
+        break;
+
+      case GateType::FreeMult:
+        throw std::runtime_error("Unimplemented");
+        break;
+
+      case GateType::Input:
+        throw std::runtime_error("Unimplemented");
+        break;
+
+      case GateType::Neg:
+        throw std::runtime_error("Unimplemented");
+        break;
+
+      case GateType::SymmetricPlus:
+        throw std::runtime_error("Unimplemented");
+        break;
+
+      // Non-free gates
+      case GateType::Output:
+        throw std::runtime_error("Unimplemented");
+        break;
+
+      case GateType::NonFreeMult:
+        throw std::runtime_error("Unimplemented");
+        break;
+    }
+  }
+
+  void collectScheduledResult(
+      engine::ISecretShareEngine& engine,
+      std::map<int64_t, IGate::Secrets>& revealedSecretsByParty) override {
+    switch (gateType_) {
+      case GateType::NonFreeMult:
+        throw std::runtime_error("Unimplemented");
+        break;
+
+      case GateType::Output:
+        throw std::runtime_error("Unimplemented");
+        break;
+
+      default:
+        break;
+    }
+  }
+
+  void increaseReferenceCount(
+      IScheduler::WireId<IScheduler::WireType::Arithmetic> wire) override {
+    if (!wire.isEmpty()) {
+      wireKeeper_.increaseReferenceCount(wire);
+    }
+  }
+
+  void decreaseReferenceCount(
+      IScheduler::WireId<IScheduler::WireType::Arithmetic> wire) override {
+    if (!wire.isEmpty()) {
+      wireKeeper_.decreaseReferenceCount(wire);
+    }
+  }
+};
+
+} // namespace fbpcf::scheduler

--- a/fbpcf/scheduler/gate_keeper/BatchArithmeticGate.h
+++ b/fbpcf/scheduler/gate_keeper/BatchArithmeticGate.h
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <map>
+
+#include "fbpcf/scheduler/gate_keeper/IArithmeticGate.h"
+
+namespace fbpcf::scheduler {
+
+class BatchArithmeticGate final : public IArithmeticGate {
+ public:
+  using IArithmeticGate::gateType_;
+  using IArithmeticGate::left_;
+  using IArithmeticGate::numberOfResults_;
+  using IArithmeticGate::partyID_;
+  using IArithmeticGate::right_;
+  using IArithmeticGate::scheduledResultIndex_;
+  using IArithmeticGate::wireID_;
+  using IArithmeticGate::wireKeeper_;
+  using typename IArithmeticGate::GateType;
+  BatchArithmeticGate(
+      GateType gateType,
+      IScheduler::WireId<IScheduler::WireType::Arithmetic> wireID,
+      IScheduler::WireId<IScheduler::WireType::Arithmetic> left,
+      IScheduler::WireId<IScheduler::WireType::Arithmetic> right,
+      int partyID,
+      uint32_t numberOfResults,
+      IWireKeeper& wireKeeper)
+      : IArithmeticGate{
+            gateType,
+            wireID,
+            left,
+            right,
+            partyID,
+            numberOfResults,
+            wireKeeper} {
+    increaseReferenceCount(wireID_);
+    increaseReferenceCount(left_);
+    increaseReferenceCount(right_);
+  }
+
+  ~BatchArithmeticGate() override {
+    decreaseReferenceCount(wireID_);
+    decreaseReferenceCount(left_);
+    decreaseReferenceCount(right_);
+  }
+
+  void compute(
+      engine::ISecretShareEngine& engine,
+      std::map<int64_t, IGate::Secrets>& secretSharesByParty) override {
+    switch (gateType_) {
+        // Free gates
+      case GateType::AsymmetricPlus:
+        throw std::runtime_error("Unimplemented");
+        break;
+
+      case GateType::FreeMult:
+        throw std::runtime_error("Unimplemented");
+        break;
+
+      case GateType::Input:
+        throw std::runtime_error("Unimplemented");
+        break;
+
+      case GateType::Neg:
+        throw std::runtime_error("Unimplemented");
+        break;
+
+      case GateType::SymmetricPlus:
+        throw std::runtime_error("Unimplemented");
+        break;
+
+      // Non-free gates
+      case GateType::Output:
+        throw std::runtime_error("Unimplemented");
+        break;
+
+      case GateType::NonFreeMult:
+        throw std::runtime_error("Unimplemented");
+        break;
+    }
+  }
+
+  void collectScheduledResult(
+      engine::ISecretShareEngine& engine,
+      std::map<int64_t, IGate::Secrets>& revealedSecretsByParty) override {
+    switch (gateType_) {
+      case GateType::NonFreeMult:
+        throw std::runtime_error("Unimplemented");
+        break;
+
+      case GateType::Output:
+        throw std::runtime_error("Unimplemented");
+        break;
+
+      default:
+        break;
+    }
+  }
+
+  void increaseReferenceCount(
+      IScheduler::WireId<IScheduler::WireType::Arithmetic> wire) override {
+    if (!wire.isEmpty()) {
+      wireKeeper_.increaseBatchReferenceCount(wire);
+    }
+  }
+
+  void decreaseReferenceCount(
+      IScheduler::WireId<IScheduler::WireType::Arithmetic> wire) override {
+    if (!wire.isEmpty()) {
+      wireKeeper_.decreaseBatchReferenceCount(wire);
+    }
+  }
+};
+
+} // namespace fbpcf::scheduler

--- a/fbpcf/scheduler/gate_keeper/BatchCompositeGate.h
+++ b/fbpcf/scheduler/gate_keeper/BatchCompositeGate.h
@@ -45,7 +45,7 @@ class BatchCompositeGate final : public ICompositeGate {
 
   void compute(
       engine::ISecretShareEngine& engine,
-      std::map<int64_t, std::vector<bool>>& /*secretSharesByParty*/) override {
+      std::map<int64_t, IGate::Secrets>& /*secretSharesByParty*/) override {
     switch (gateType_) {
         // Free gates
       case GateType::FreeAnd: {
@@ -76,8 +76,7 @@ class BatchCompositeGate final : public ICompositeGate {
 
   void collectScheduledResult(
       engine::ISecretShareEngine& engine,
-      std::map<int64_t, std::vector<bool>>& /*revealedSecretsByParty*/)
-      override {
+      std::map<int64_t, IGate::Secrets>& /*revealedSecretsByParty*/) override {
     std::vector<std::vector<bool>> result;
     switch (gateType_) {
       case GateType::NonFreeAnd: {

--- a/fbpcf/scheduler/gate_keeper/BatchNormalGate.h
+++ b/fbpcf/scheduler/gate_keeper/BatchNormalGate.h
@@ -10,31 +10,31 @@
 #include <cstdint>
 #include <map>
 
-#include "fbpcf/scheduler/gate_keeper/INormalGate.h"
+#include <fbpcf/scheduler/IScheduler.h>
+#include <fbpcf/scheduler/gate_keeper/INormalGate.h>
 
 namespace fbpcf::scheduler {
 
-template <IScheduler::WireType T>
-class BatchNormalGate final : public INormalGate<T> {
+class BatchNormalGate final : public INormalGate {
  public:
-  using typename INormalGate<T>::GateType;
-  using INormalGate<T>::gateType_;
-  using INormalGate<T>::wireID_;
-  using INormalGate<T>::left_;
-  using INormalGate<T>::right_;
-  using INormalGate<T>::partyID_;
-  using INormalGate<T>::scheduledResultIndex_;
-  using INormalGate<T>::numberOfResults_;
-  using INormalGate<T>::wireKeeper_;
+  using INormalGate::gateType_;
+  using INormalGate::left_;
+  using INormalGate::numberOfResults_;
+  using INormalGate::partyID_;
+  using INormalGate::right_;
+  using INormalGate::scheduledResultIndex_;
+  using INormalGate::wireID_;
+  using INormalGate::wireKeeper_;
+  using typename INormalGate::GateType;
   BatchNormalGate(
       GateType gateType,
-      IScheduler::WireId<T> wireID,
-      IScheduler::WireId<T> left,
-      IScheduler::WireId<T> right,
+      IScheduler::WireId<IScheduler::Boolean> wireID,
+      IScheduler::WireId<IScheduler::Boolean> left,
+      IScheduler::WireId<IScheduler::Boolean> right,
       int partyID,
       uint32_t numberOfResults,
       IWireKeeper& wireKeeper)
-      : INormalGate<T>{
+      : INormalGate{
             gateType,
             wireID,
             left,
@@ -159,13 +159,15 @@ class BatchNormalGate final : public INormalGate<T> {
     }
   }
 
-  void increaseReferenceCount(IScheduler::WireId<T> wire) override {
+  void increaseReferenceCount(
+      IScheduler::WireId<IScheduler::Boolean> wire) override {
     if (!wire.isEmpty()) {
       wireKeeper_.increaseBatchReferenceCount(wire);
     }
   }
 
-  void decreaseReferenceCount(IScheduler::WireId<T> wire) override {
+  void decreaseReferenceCount(
+      IScheduler::WireId<IScheduler::Boolean> wire) override {
     if (!wire.isEmpty()) {
       wireKeeper_.decreaseBatchReferenceCount(wire);
     }

--- a/fbpcf/scheduler/gate_keeper/CompositeGate.h
+++ b/fbpcf/scheduler/gate_keeper/CompositeGate.h
@@ -7,10 +7,12 @@
 
 #pragma once
 
+#include <cstdint>
 #include <exception>
 #include <map>
 #include <stdexcept>
 
+#include <fbpcf/scheduler/gate_keeper/IGate.h>
 #include "fbpcf/scheduler/gate_keeper/ICompositeGate.h"
 
 namespace fbpcf::scheduler {
@@ -51,7 +53,7 @@ class CompositeGate final : public ICompositeGate {
 
   void compute(
       engine::ISecretShareEngine& engine,
-      std::map<int64_t, std::vector<bool>>& /*secretSharesByParty*/) override {
+      std::map<int64_t, IGate::Secrets>& /*secretSharesByParty*/) override {
     switch (gateType_) {
         // Free gates
       case GateType::FreeAnd:
@@ -78,8 +80,7 @@ class CompositeGate final : public ICompositeGate {
 
   void collectScheduledResult(
       engine::ISecretShareEngine& engine,
-      std::map<int64_t, std::vector<bool>>& /*revealedSecretsByParty*/)
-      override {
+      std::map<int64_t, IGate::Secrets>& /*revealedSecretsByParty*/) override {
     std::vector<bool> result;
     switch (gateType_) {
       case GateType::NonFreeAnd:

--- a/fbpcf/scheduler/gate_keeper/GateKeeper.cpp
+++ b/fbpcf/scheduler/gate_keeper/GateKeeper.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "fbpcf/scheduler/gate_keeper/GateKeeper.h"
+#include <fbpcf/scheduler/gate_keeper/INormalGate.h>
 #include <cstddef>
 #include <memory>
 #include "fbpcf/scheduler/IScheduler.h"
@@ -22,13 +23,12 @@ GateKeeper::GateKeeper(std::shared_ptr<IWireKeeper> wireKeeper)
 IScheduler::WireId<IScheduler::Boolean> GateKeeper::inputGate(
     BoolType<false> initialValue) {
   auto level = getOutputLevel(
-      GateClass<false>::isFree(
-          INormalGate<IScheduler::Boolean>::GateType::Input),
+      GateClass<false>::isFree(INormalGate::GateType::Input),
       firstUnexecutedLevel_);
   auto outputWire = allocateNewWire(initialValue, level);
   addGate(
-      std::make_unique<NormalGate<IScheduler::Boolean>>(
-          INormalGate<IScheduler::Boolean>::GateType::Input,
+      std::make_unique<NormalGate>(
+          INormalGate::GateType::Input,
           outputWire,
           IScheduler::WireId<IScheduler::Boolean>(),
           IScheduler::WireId<IScheduler::Boolean>(),
@@ -42,14 +42,13 @@ IScheduler::WireId<IScheduler::Boolean> GateKeeper::inputGateBatch(
     BoolType<true> initialValue) {
   auto size = initialValue.size();
   auto level = getOutputLevel(
-      GateClass<false>::isFree(
-          INormalGate<IScheduler::Boolean>::GateType::Input),
+      GateClass<false>::isFree(INormalGate::GateType::Input),
       firstUnexecutedLevel_);
 
   auto outputWire = allocateNewWire(initialValue, level);
   addGate(
-      std::make_unique<BatchNormalGate<IScheduler::Boolean>>(
-          INormalGate<IScheduler::Boolean>::GateType::Input,
+      std::make_unique<BatchNormalGate>(
+          INormalGate::GateType::Input,
           outputWire,
           IScheduler::WireId<IScheduler::Boolean>(),
           IScheduler::WireId<IScheduler::Boolean>(),
@@ -64,14 +63,13 @@ IScheduler::WireId<IScheduler::Boolean> GateKeeper::outputGate(
     IScheduler::WireId<IScheduler::Boolean> src,
     int partyID) {
   auto level = getOutputLevel(
-      GateClass<false>::isFree(
-          INormalGate<IScheduler::Boolean>::GateType::Output),
+      GateClass<false>::isFree(INormalGate::GateType::Output),
       getMaxLevel<false>(src));
   auto outputWire = allocateNewWire(false, level);
 
   addGate(
-      std::make_unique<NormalGate<IScheduler::Boolean>>(
-          INormalGate<IScheduler::Boolean>::GateType::Output,
+      std::make_unique<NormalGate>(
+          INormalGate::GateType::Output,
           outputWire,
           src,
           IScheduler::WireId<IScheduler::Boolean>(),
@@ -86,14 +84,13 @@ IScheduler::WireId<IScheduler::Boolean> GateKeeper::outputGateBatch(
     IScheduler::WireId<IScheduler::Boolean> src,
     int partyID) {
   auto level = getOutputLevel(
-      GateClass<false>::isFree(
-          INormalGate<IScheduler::Boolean>::GateType::Output),
+      GateClass<false>::isFree(INormalGate::GateType::Output),
       getMaxLevel<true>(src));
   auto outputWire = allocateNewWire(std::vector<bool>(), level);
 
   addGate(
-      std::make_unique<BatchNormalGate<IScheduler::Boolean>>(
-          INormalGate<IScheduler::Boolean>::GateType::Output,
+      std::make_unique<BatchNormalGate>(
+          INormalGate::GateType::Output,
           outputWire,
           src,
           IScheduler::WireId<IScheduler::Boolean>(),
@@ -106,7 +103,7 @@ IScheduler::WireId<IScheduler::Boolean> GateKeeper::outputGateBatch(
 }
 
 IScheduler::WireId<IScheduler::Boolean> GateKeeper::normalGate(
-    INormalGate<IScheduler::Boolean>::GateType gateType,
+    INormalGate::GateType gateType,
     IScheduler::WireId<IScheduler::Boolean> left,
     IScheduler::WireId<IScheduler::Boolean> right) {
   auto level = getOutputLevel(
@@ -115,7 +112,7 @@ IScheduler::WireId<IScheduler::Boolean> GateKeeper::normalGate(
   auto outputWire = allocateNewWire(false, level);
 
   addGate(
-      std::make_unique<NormalGate<IScheduler::Boolean>>(
+      std::make_unique<NormalGate>(
           gateType, outputWire, left, right, 0, *wireKeeper_),
       level);
 
@@ -123,7 +120,7 @@ IScheduler::WireId<IScheduler::Boolean> GateKeeper::normalGate(
 }
 
 IScheduler::WireId<IScheduler::Boolean> GateKeeper::normalGateBatch(
-    INormalGate<IScheduler::Boolean>::GateType gateType,
+    INormalGate::GateType gateType,
     IScheduler::WireId<IScheduler::Boolean> left,
     IScheduler::WireId<IScheduler::Boolean> right) {
   auto level = getOutputLevel(
@@ -132,7 +129,7 @@ IScheduler::WireId<IScheduler::Boolean> GateKeeper::normalGateBatch(
   auto outputWire = allocateNewWire(std::vector<bool>(), level);
 
   addGate(
-      std::make_unique<BatchNormalGate<IScheduler::Boolean>>(
+      std::make_unique<BatchNormalGate>(
           gateType, outputWire, left, right, 0, 0, *wireKeeper_),
       level);
 

--- a/fbpcf/scheduler/gate_keeper/GateKeeper.cpp
+++ b/fbpcf/scheduler/gate_keeper/GateKeeper.cpp
@@ -9,6 +9,7 @@
 #include <fbpcf/scheduler/gate_keeper/INormalGate.h>
 #include <cstddef>
 #include <memory>
+#include <stdexcept>
 #include "fbpcf/scheduler/IScheduler.h"
 #include "fbpcf/scheduler/gate_keeper/BatchCompositeGate.h"
 #include "fbpcf/scheduler/gate_keeper/BatchNormalGate.h"
@@ -38,6 +39,11 @@ IScheduler::WireId<IScheduler::Boolean> GateKeeper::inputGate(
   return outputWire;
 }
 
+IScheduler::WireId<IScheduler::Arithmetic> GateKeeper::inputGate(
+    IntType<false> initialValue) {
+  throw std::runtime_error("Unimplemented");
+}
+
 IScheduler::WireId<IScheduler::Boolean> GateKeeper::inputGateBatch(
     BoolType<true> initialValue) {
   auto size = initialValue.size();
@@ -57,6 +63,11 @@ IScheduler::WireId<IScheduler::Boolean> GateKeeper::inputGateBatch(
           *wireKeeper_),
       level);
   return outputWire;
+}
+
+IScheduler::WireId<IScheduler::Arithmetic> GateKeeper::inputGateBatch(
+    IntType<true> initialValue) {
+  throw std::runtime_error("Unimplemented");
 }
 
 IScheduler::WireId<IScheduler::Boolean> GateKeeper::outputGate(
@@ -80,6 +91,12 @@ IScheduler::WireId<IScheduler::Boolean> GateKeeper::outputGate(
   return outputWire;
 }
 
+IScheduler::WireId<IScheduler::Arithmetic> GateKeeper::outputGate(
+    IScheduler::WireId<IScheduler::Arithmetic> src,
+    int partyID) {
+  throw std::runtime_error("Unimplemented");
+}
+
 IScheduler::WireId<IScheduler::Boolean> GateKeeper::outputGateBatch(
     IScheduler::WireId<IScheduler::Boolean> src,
     int partyID) {
@@ -100,6 +117,12 @@ IScheduler::WireId<IScheduler::Boolean> GateKeeper::outputGateBatch(
       level);
 
   return outputWire;
+}
+
+IScheduler::WireId<IScheduler::Arithmetic> GateKeeper::outputGateBatch(
+    IScheduler::WireId<IScheduler::Arithmetic> src,
+    int partyID) {
+  throw std::runtime_error("Unimplemented");
 }
 
 IScheduler::WireId<IScheduler::Boolean> GateKeeper::normalGate(
@@ -134,6 +157,20 @@ IScheduler::WireId<IScheduler::Boolean> GateKeeper::normalGateBatch(
       level);
 
   return outputWire;
+}
+
+IScheduler::WireId<IScheduler::Arithmetic> GateKeeper::arithmeticGate(
+    IArithmeticGate::GateType gateType,
+    IScheduler::WireId<IScheduler::Arithmetic> left,
+    IScheduler::WireId<IScheduler::Arithmetic> right) {
+  throw std::runtime_error("Unimplemented");
+}
+
+IScheduler::WireId<IScheduler::Arithmetic> GateKeeper::arithmeticGateBatch(
+    IArithmeticGate::GateType gateType,
+    IScheduler::WireId<IScheduler::Arithmetic> left,
+    IScheduler::WireId<IScheduler::Arithmetic> right) {
+  throw std::runtime_error("Unimplemented");
 }
 
 std::vector<IScheduler::WireId<IScheduler::Boolean>> GateKeeper::compositeGate(

--- a/fbpcf/scheduler/gate_keeper/GateKeeper.h
+++ b/fbpcf/scheduler/gate_keeper/GateKeeper.h
@@ -7,10 +7,12 @@
 
 #pragma once
 
+#include <cstdint>
 #include <deque>
 #include <memory>
 #include <stdexcept>
 
+#include <fbpcf/scheduler/IScheduler.h>
 #include <fbpcf/scheduler/gate_keeper/INormalGate.h>
 #include "fbpcf/scheduler/gate_keeper/IGateKeeper.h"
 
@@ -29,8 +31,20 @@ class GateKeeper : public IGateKeeper {
   /**
    * @inherit doc
    */
+  IScheduler::WireId<IScheduler::Arithmetic> inputGate(
+      IntType<false> initialValue) override;
+
+  /**
+   * @inherit doc
+   */
   IScheduler::WireId<IScheduler::Boolean> inputGateBatch(
       BoolType<true> initialValue) override;
+
+  /**
+   * @inherit doc
+   */
+  IScheduler::WireId<IScheduler::Arithmetic> inputGateBatch(
+      IntType<true> initialValue) override;
 
   /**
    * @inherit doc
@@ -42,8 +56,22 @@ class GateKeeper : public IGateKeeper {
   /**
    * @inherit doc
    */
+  IScheduler::WireId<IScheduler::Arithmetic> outputGate(
+      IScheduler::WireId<IScheduler::Arithmetic> src,
+      int partyID) override;
+
+  /**
+   * @inherit doc
+   */
   IScheduler::WireId<IScheduler::Boolean> outputGateBatch(
       IScheduler::WireId<IScheduler::Boolean> src,
+      int partyID) override;
+
+  /**
+   * @inherit doc
+   */
+  IScheduler::WireId<IScheduler::Arithmetic> outputGateBatch(
+      IScheduler::WireId<IScheduler::Arithmetic> src,
       int partyID) override;
 
   /**
@@ -67,6 +95,24 @@ class GateKeeper : public IGateKeeper {
   /**
    * @inherit doc
    */
+  IScheduler::WireId<IScheduler::Arithmetic> arithmeticGate(
+      IArithmeticGate::GateType gateType,
+      IScheduler::WireId<IScheduler::Arithmetic> left,
+      IScheduler::WireId<IScheduler::Arithmetic> right =
+          IScheduler::WireId<IScheduler::Arithmetic>()) override;
+
+  /**
+   * @inherit doc
+   */
+  IScheduler::WireId<IScheduler::Arithmetic> arithmeticGateBatch(
+      IArithmeticGate::GateType gateType,
+      IScheduler::WireId<IScheduler::Arithmetic> left,
+      IScheduler::WireId<IScheduler::Arithmetic> right =
+          IScheduler::WireId<IScheduler::Arithmetic>()) override;
+
+  /**
+   * @inherit doc
+   */
   std::vector<IScheduler::WireId<IScheduler::Boolean>> compositeGate(
       ICompositeGate::GateType gateType,
       IScheduler::WireId<IScheduler::Boolean> left,
@@ -80,11 +126,11 @@ class GateKeeper : public IGateKeeper {
       IScheduler::WireId<IScheduler::Boolean> left,
       std::vector<IScheduler::WireId<IScheduler::Boolean>> rights) override;
 
-  // band a number of batches into one batch.
+  // band a number of boolean batches into one batch.
   IScheduler::WireId<IScheduler::Boolean> batchingUp(
       std::vector<IScheduler::WireId<IScheduler::Boolean>> src) override;
 
-  // decompose a batch of values into several smaller batches.
+  // decompose a batch of boolean values into several smaller batches.
   std::vector<IScheduler::WireId<IScheduler::Boolean>> unbatching(
       IScheduler::WireId<IScheduler::Boolean> src,
       std::shared_ptr<std::vector<uint32_t>> unbatchingStrategy) override;
@@ -106,10 +152,8 @@ class GateKeeper : public IGateKeeper {
 
  private:
   template <bool isCompositeWire>
-  using GateClass = typename std::conditional<
-      isCompositeWire,
-      ICompositeGate,
-      INormalGate>::type;
+  using GateClass = typename std::
+      conditional<isCompositeWire, ICompositeGate, INormalGate>::type;
 
   template <bool isCompositeWire>
   using GateType = typename std::conditional<

--- a/fbpcf/scheduler/gate_keeper/GateKeeper.h
+++ b/fbpcf/scheduler/gate_keeper/GateKeeper.h
@@ -11,6 +11,7 @@
 #include <memory>
 #include <stdexcept>
 
+#include <fbpcf/scheduler/gate_keeper/INormalGate.h>
 #include "fbpcf/scheduler/gate_keeper/IGateKeeper.h"
 
 namespace fbpcf::scheduler {
@@ -49,7 +50,7 @@ class GateKeeper : public IGateKeeper {
    * @inherit doc
    */
   IScheduler::WireId<IScheduler::Boolean> normalGate(
-      INormalGate<IScheduler::Boolean>::GateType gateType,
+      INormalGate::GateType gateType,
       IScheduler::WireId<IScheduler::Boolean> left,
       IScheduler::WireId<IScheduler::Boolean> right =
           IScheduler::WireId<IScheduler::Boolean>()) override;
@@ -58,7 +59,7 @@ class GateKeeper : public IGateKeeper {
    * @inherit doc
    */
   IScheduler::WireId<IScheduler::Boolean> normalGateBatch(
-      INormalGate<IScheduler::Boolean>::GateType gateType,
+      INormalGate::GateType gateType,
       IScheduler::WireId<IScheduler::Boolean> left,
       IScheduler::WireId<IScheduler::Boolean> right =
           IScheduler::WireId<IScheduler::Boolean>()) override;
@@ -108,13 +109,13 @@ class GateKeeper : public IGateKeeper {
   using GateClass = typename std::conditional<
       isCompositeWire,
       ICompositeGate,
-      INormalGate<IScheduler::Boolean>>::type;
+      INormalGate>::type;
 
   template <bool isCompositeWire>
   using GateType = typename std::conditional<
       isCompositeWire,
       ICompositeGate::GateType,
-      INormalGate<IScheduler::Boolean>::GateType>::type;
+      INormalGate::GateType>::type;
 
   template <bool isCompositeWire>
   using RightWireType = typename std::conditional<

--- a/fbpcf/scheduler/gate_keeper/IArithmeticGate.h
+++ b/fbpcf/scheduler/gate_keeper/IArithmeticGate.h
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <map>
+
+#include "fbpcf/engine/ISecretShareEngine.h"
+#include "fbpcf/scheduler/IScheduler.h"
+#include "fbpcf/scheduler/IWireKeeper.h"
+#include "fbpcf/scheduler/gate_keeper/IGate.h"
+
+namespace fbpcf::scheduler {
+
+/**
+ * This class executes arithmetic gates in a circuit.
+ * There are subclasses for batched and non-batched gates.
+ */
+class IArithmeticGate : public IGate {
+ public:
+  enum class GateType {
+    Input,
+    Output,
+    FreeMult,
+    NonFreeMult,
+    AsymmetricPlus,
+    SymmetricPlus,
+    Neg,
+  };
+
+  IArithmeticGate(
+      GateType gateType,
+      IScheduler::WireId<IScheduler::WireType::Arithmetic> wireID,
+      IScheduler::WireId<IScheduler::WireType::Arithmetic> left,
+      IScheduler::WireId<IScheduler::WireType::Arithmetic> right,
+      int partyID,
+      uint32_t numberOfResults,
+      IWireKeeper& wireKeeper)
+      : gateType_{gateType},
+        wireID_{wireID},
+        left_{left},
+        right_{right},
+        partyID_{partyID},
+        numberOfResults_{numberOfResults},
+        wireKeeper_{wireKeeper} {}
+
+  IArithmeticGate(const IArithmeticGate& g) : wireKeeper_(g.wireKeeper_) {
+    copy(g);
+  }
+
+  IArithmeticGate(IArithmeticGate&& g) noexcept : wireKeeper_(g.wireKeeper_) {
+    move(std::move(g));
+  }
+
+  IArithmeticGate& operator=(const IArithmeticGate& g) {
+    copy(g);
+    return *this;
+  }
+
+  IArithmeticGate& operator=(IArithmeticGate&& g) {
+    move(std::move(g));
+    return *this;
+  }
+
+  static bool isFree(GateType gateType) {
+    switch (gateType) {
+      case GateType::AsymmetricPlus:
+      case GateType::FreeMult:
+      case GateType::Input:
+      case GateType::Neg:
+      case GateType::SymmetricPlus:
+        return true;
+
+      case GateType::NonFreeMult:
+      case GateType::Output:
+        return false;
+    }
+  }
+
+  IScheduler::WireId<IScheduler::WireType::Arithmetic> getWireId() const {
+    return wireID_;
+  }
+
+  // The number of values in a batch gate (1 for non-batch case)
+  uint32_t getNumberOfResults() const override {
+    return numberOfResults_;
+  }
+
+ protected:
+  GateType gateType_;
+  IScheduler::WireId<IScheduler::WireType::Arithmetic> wireID_;
+  IScheduler::WireId<IScheduler::WireType::Arithmetic> left_;
+  IScheduler::WireId<IScheduler::WireType::Arithmetic> right_;
+  int partyID_;
+  uint32_t scheduledResultIndex_;
+  uint32_t numberOfResults_;
+  IWireKeeper& wireKeeper_;
+
+  void copy(const IArithmeticGate& src) {
+    decreaseReferenceCount(wireID_);
+    decreaseReferenceCount(left_);
+    decreaseReferenceCount(right_);
+    gateType_ = src.gateType_;
+    wireID_ = src.wireID_;
+    left_ = src.left_;
+    right_ = src.right_;
+    partyID_ = src.partyID_;
+    scheduledResultIndex_ = src.scheduledResultIndex_;
+    numberOfResults_ = src.numberOfResults_;
+    increaseReferenceCount(wireID_);
+    increaseReferenceCount(left_);
+    increaseReferenceCount(right_);
+  }
+
+  void move(IArithmeticGate&& src) {
+    decreaseReferenceCount(wireID_);
+    decreaseReferenceCount(left_);
+    decreaseReferenceCount(right_);
+    gateType_ = src.gateType_;
+    wireID_ = src.wireID_;
+    left_ = src.left_;
+    right_ = src.right_;
+    partyID_ = src.partyID_;
+    scheduledResultIndex_ = src.scheduledResultIndex_;
+    numberOfResults_ = src.numberOfResults_;
+
+    src.wireID_ = src.left_ = src.right_ =
+        IScheduler::WireId<IScheduler::WireType::Arithmetic>();
+  }
+
+  virtual void increaseReferenceCount(
+      IScheduler::WireId<IScheduler::WireType::Arithmetic> wire) = 0;
+
+  virtual void decreaseReferenceCount(
+      IScheduler::WireId<IScheduler::WireType::Arithmetic> wire) = 0;
+};
+
+} // namespace fbpcf::scheduler

--- a/fbpcf/scheduler/gate_keeper/ICompositeGate.h
+++ b/fbpcf/scheduler/gate_keeper/ICompositeGate.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <exception>
 #include <map>
 #include <stdexcept>
@@ -82,14 +83,13 @@ class ICompositeGate : public IGate {
   // Run or schedule the computation for this gate.
   virtual void compute(
       engine::ISecretShareEngine& engine,
-      std::map<int64_t, std::vector<bool>>& secretSharesByParty) override = 0;
+      std::map<int64_t, IGate::Secrets>& secretSharesByParty) override = 0;
 
   // For non-free gates, get the result of the computation that was scheduled
   // and store it on the appropriate wire.
   virtual void collectScheduledResult(
       engine::ISecretShareEngine& engine,
-      std::map<int64_t, std::vector<bool>>& revealedSecretsByParty)
-      override = 0;
+      std::map<int64_t, IGate::Secrets>& revealedSecretsByParty) override = 0;
 
   uint32_t getNumberOfResults() const override {
     return numberOfResults_;

--- a/fbpcf/scheduler/gate_keeper/IGate.h
+++ b/fbpcf/scheduler/gate_keeper/IGate.h
@@ -7,18 +7,30 @@
 
 #pragma once
 
+#include <cstdint>
 #include <map>
+#include <vector>
 
 #include "fbpcf/engine/ISecretShareEngine.h"
+#include "fbpcf/scheduler/IScheduler.h"
 
 namespace fbpcf::scheduler {
 
 /**
- * Base interface for Gates in a boolean circuit. It is used to encapsulate
- * operations that will happen at some point in the future.
+ * Base interface for Gates in a boolean and/or arithmetic circuit. It is used
+ * to encapsulate operations that will happen at some point in the future.
  */
 class IGate {
  public:
+  struct Secrets {
+    std::vector<bool> booleanSecrets;
+    std::vector<uint64_t> integerSecrets;
+    Secrets(
+        std::vector<bool> booleanSecrets,
+        std::vector<uint64_t> integerSecrets)
+        : booleanSecrets(booleanSecrets), integerSecrets(integerSecrets) {}
+  };
+
   virtual ~IGate() = default;
 
   /* Run or schedule the computation for this gate.
@@ -29,21 +41,20 @@ class IGate {
    */
   virtual void compute(
       engine::ISecretShareEngine& engine,
-      std::map<int64_t, std::vector<bool>>& secretSharesByParty) = 0;
+      std::map<int64_t, Secrets>& secretSharesByParty) = 0;
 
   /* For non-free gates, get the result of the computation that was scheduled
    * and store it on the appropriate wire(s).
-   * @param engine Will be used to retrieve AND gates results in XOR ss form
+   * @param engine Will be used to retrieve AND/MULT gates results in XOR/ADD ss
+   * form
    * @param revealedSecretsByParty Will hold values for output gates shared from
    * other parties.
    */
   virtual void collectScheduledResult(
       engine::ISecretShareEngine& engine,
-      std::map<int64_t, std::vector<bool>>& revealedSecretsByParty) = 0;
+      std::map<int64_t, Secrets>& revealedSecretsByParty) = 0;
 
   // The number of values in a batch gate (1 for non-batch case)
   virtual uint32_t getNumberOfResults() const = 0;
-
- protected:
 };
 } // namespace fbpcf::scheduler

--- a/fbpcf/scheduler/gate_keeper/IGateKeeper.h
+++ b/fbpcf/scheduler/gate_keeper/IGateKeeper.h
@@ -47,7 +47,7 @@ class IGateKeeper {
   // Create a unary/binary gate (e.g. AND, XOR, NOT) and return its output wire
   // ID.
   virtual IScheduler::WireId<IScheduler::Boolean> normalGate(
-      INormalGate<IScheduler::Boolean>::GateType gateType,
+      INormalGate::GateType gateType,
       IScheduler::WireId<IScheduler::Boolean> left,
       IScheduler::WireId<IScheduler::Boolean> right =
           IScheduler::WireId<IScheduler::Boolean>()) = 0;
@@ -55,7 +55,7 @@ class IGateKeeper {
   // Create a batch unary/binary gate (e.g. AND, XOR, NOT) and return its output
   // wire ID.
   virtual IScheduler::WireId<IScheduler::Boolean> normalGateBatch(
-      INormalGate<IScheduler::Boolean>::GateType gateType,
+      INormalGate::GateType gateType,
       IScheduler::WireId<IScheduler::Boolean> left,
       IScheduler::WireId<IScheduler::Boolean> right =
           IScheduler::WireId<IScheduler::Boolean>()) = 0;

--- a/fbpcf/scheduler/gate_keeper/IGateKeeper.h
+++ b/fbpcf/scheduler/gate_keeper/IGateKeeper.h
@@ -7,7 +7,9 @@
 
 #pragma once
 
+#include <cstdint>
 #include "fbpcf/scheduler/IScheduler.h"
+#include "fbpcf/scheduler/gate_keeper/IArithmeticGate.h"
 #include "fbpcf/scheduler/gate_keeper/ICompositeGate.h"
 #include "fbpcf/scheduler/gate_keeper/IGate.h"
 #include "fbpcf/scheduler/gate_keeper/INormalGate.h"
@@ -23,25 +25,46 @@ class IGateKeeper {
   template <bool usingBatch>
   using BoolType = typename std::
       conditional<usingBatch, const std::vector<bool>&, bool>::type;
+  template <bool usingBatch>
+  using IntType = typename std::
+      conditional<usingBatch, const std::vector<uint64_t>&, uint64_t>::type;
 
   virtual ~IGateKeeper() = default;
 
-  // Create an input gate and return its output wire ID.
+  // Create a boolean input gate and return its output wire ID.
   virtual IScheduler::WireId<IScheduler::Boolean> inputGate(
       BoolType<false> initialValue) = 0;
 
-  // Create a batch input gate and return its output wire ID.
+  // Create an arithmetic input gate and return its output wire ID.
+  virtual IScheduler::WireId<IScheduler::Arithmetic> inputGate(
+      IntType<false> initialValue) = 0;
+
+  // Create a batch boolean input gate and return its output wire ID.
   virtual IScheduler::WireId<IScheduler::Boolean> inputGateBatch(
       BoolType<true> initialValue) = 0;
 
-  // Create an output gate and return its output wire ID.
+  // Create a batch arithmetic input gate and return its output wire ID.
+  virtual IScheduler::WireId<IScheduler::Arithmetic> inputGateBatch(
+      IntType<true> initialValue) = 0;
+
+  // Create a boolean output gate and return its output wire ID.
   virtual IScheduler::WireId<IScheduler::Boolean> outputGate(
       IScheduler::WireId<IScheduler::Boolean> src,
       int partyID) = 0;
 
-  // Create a batch output gate and return its output wire ID.
+  // Create an arithmetic output gate and return its output wire ID.
+  virtual IScheduler::WireId<IScheduler::Arithmetic> outputGate(
+      IScheduler::WireId<IScheduler::Arithmetic> src,
+      int partyID) = 0;
+
+  // Create a batch boolean output gate and return its output wire ID.
   virtual IScheduler::WireId<IScheduler::Boolean> outputGateBatch(
       IScheduler::WireId<IScheduler::Boolean> src,
+      int partyID) = 0;
+
+  // Create a batch arithmetic output gate and return its output wire ID.
+  virtual IScheduler::WireId<IScheduler::Arithmetic> outputGateBatch(
+      IScheduler::WireId<IScheduler::Arithmetic> src,
       int partyID) = 0;
 
   // Create a unary/binary gate (e.g. AND, XOR, NOT) and return its output wire
@@ -60,6 +83,22 @@ class IGateKeeper {
       IScheduler::WireId<IScheduler::Boolean> right =
           IScheduler::WireId<IScheduler::Boolean>()) = 0;
 
+  // Create an integer gate (e.g. MULT, ADD, NEG) and return its output wire
+  // ID.
+  virtual IScheduler::WireId<IScheduler::Arithmetic> arithmeticGate(
+      IArithmeticGate::GateType gateType,
+      IScheduler::WireId<IScheduler::Arithmetic> left,
+      IScheduler::WireId<IScheduler::Arithmetic> right =
+          IScheduler::WireId<IScheduler::Arithmetic>()) = 0;
+
+  // Create a batch integer gate (e.g. MULT, ADD, NEG) and return its output
+  // wire ID.
+  virtual IScheduler::WireId<IScheduler::Arithmetic> arithmeticGateBatch(
+      IArithmeticGate::GateType gateType,
+      IScheduler::WireId<IScheduler::Arithmetic> left,
+      IScheduler::WireId<IScheduler::Arithmetic> right =
+          IScheduler::WireId<IScheduler::Arithmetic>()) = 0;
+
   // Create a binary composite gate (e.g. AND, XOR) from a single left input and
   // multiple right inputs. Returns its output wire ID's
   virtual std::vector<IScheduler::WireId<IScheduler::Boolean>> compositeGate(
@@ -75,11 +114,11 @@ class IGateKeeper {
       IScheduler::WireId<IScheduler::Boolean> left,
       std::vector<IScheduler::WireId<IScheduler::Boolean>> rights) = 0;
 
-  // band a number of batches into one batch.
+  // band a number of boolean batches into one batch.
   virtual IScheduler::WireId<IScheduler::Boolean> batchingUp(
       std::vector<IScheduler::WireId<IScheduler::Boolean>> src) = 0;
 
-  // decompose a batch of values into several smaller batches.
+  // decompose a batch of boolean values into several smaller batches.
   virtual std::vector<IScheduler::WireId<IScheduler::Boolean>> unbatching(
       IScheduler::WireId<IScheduler::Boolean> src,
       std::shared_ptr<std::vector<uint32_t>> unbatchingStrategy) = 0;

--- a/fbpcf/scheduler/gate_keeper/INormalGate.h
+++ b/fbpcf/scheduler/gate_keeper/INormalGate.h
@@ -20,7 +20,6 @@ namespace fbpcf::scheduler {
  * This class executes gates in a circuit. There are subclasses for batched and
  * non-batched gates.
  */
-template <IScheduler::WireType T>
 class INormalGate : public IGate {
  public:
   enum class GateType {
@@ -36,9 +35,9 @@ class INormalGate : public IGate {
 
   INormalGate(
       GateType gateType,
-      IScheduler::WireId<T> wireID,
-      IScheduler::WireId<T> left,
-      IScheduler::WireId<T> right,
+      IScheduler::WireId<IScheduler::Boolean> wireID,
+      IScheduler::WireId<IScheduler::Boolean> left,
+      IScheduler::WireId<IScheduler::Boolean> right,
       int partyID,
       uint32_t numberOfResults,
       IWireKeeper& wireKeeper)
@@ -84,7 +83,7 @@ class INormalGate : public IGate {
     }
   }
 
-  IScheduler::WireId<T> getWireId() const {
+  IScheduler::WireId<IScheduler::Boolean> getWireId() const {
     return wireID_;
   }
 
@@ -95,15 +94,15 @@ class INormalGate : public IGate {
 
  protected:
   GateType gateType_;
-  IScheduler::WireId<T> wireID_;
-  IScheduler::WireId<T> left_;
-  IScheduler::WireId<T> right_;
+  IScheduler::WireId<IScheduler::Boolean> wireID_;
+  IScheduler::WireId<IScheduler::Boolean> left_;
+  IScheduler::WireId<IScheduler::Boolean> right_;
   int partyID_;
   uint32_t scheduledResultIndex_;
   uint32_t numberOfResults_;
   IWireKeeper& wireKeeper_;
 
-  void copy(const INormalGate<T>& src) {
+  void copy(const INormalGate& src) {
     decreaseReferenceCount(wireID_);
     decreaseReferenceCount(left_);
     decreaseReferenceCount(right_);
@@ -119,7 +118,7 @@ class INormalGate : public IGate {
     increaseReferenceCount(right_);
   }
 
-  void move(INormalGate<T>&& src) {
+  void move(INormalGate&& src) {
     decreaseReferenceCount(wireID_);
     decreaseReferenceCount(left_);
     decreaseReferenceCount(right_);
@@ -131,12 +130,15 @@ class INormalGate : public IGate {
     scheduledResultIndex_ = src.scheduledResultIndex_;
     numberOfResults_ = src.numberOfResults_;
 
-    src.wireID_ = src.left_ = src.right_ = IScheduler::WireId<T>();
+    src.wireID_ = src.left_ = src.right_ =
+        IScheduler::WireId<IScheduler::Boolean>();
   }
 
-  virtual void increaseReferenceCount(IScheduler::WireId<T> wire) = 0;
+  virtual void increaseReferenceCount(
+      IScheduler::WireId<IScheduler::Boolean> wire) = 0;
 
-  virtual void decreaseReferenceCount(IScheduler::WireId<T> wire) = 0;
+  virtual void decreaseReferenceCount(
+      IScheduler::WireId<IScheduler::Boolean> wire) = 0;
 };
 
 } // namespace fbpcf::scheduler

--- a/fbpcf/scheduler/gate_keeper/NormalGate.h
+++ b/fbpcf/scheduler/gate_keeper/NormalGate.h
@@ -10,31 +10,31 @@
 #include <cstdint>
 #include <map>
 
+#include <fbpcf/scheduler/IScheduler.h>
 #include "fbpcf/scheduler/gate_keeper/INormalGate.h"
 
 namespace fbpcf::scheduler {
 
-template <IScheduler::WireType T>
-class NormalGate final : public INormalGate<T> {
-  using typename INormalGate<T>::GateType;
-  using INormalGate<T>::gateType_;
-  using INormalGate<T>::wireID_;
-  using INormalGate<T>::left_;
-  using INormalGate<T>::right_;
-  using INormalGate<T>::partyID_;
-  using INormalGate<T>::scheduledResultIndex_;
-  using INormalGate<T>::numberOfResults_;
-  using INormalGate<T>::wireKeeper_;
+class NormalGate final : public INormalGate {
+  using INormalGate::gateType_;
+  using INormalGate::left_;
+  using INormalGate::numberOfResults_;
+  using INormalGate::partyID_;
+  using INormalGate::right_;
+  using INormalGate::scheduledResultIndex_;
+  using INormalGate::wireID_;
+  using INormalGate::wireKeeper_;
+  using typename INormalGate::GateType;
 
  public:
   NormalGate(
       GateType gateType,
-      IScheduler::WireId<T> wireID,
-      IScheduler::WireId<T> left,
-      IScheduler::WireId<T> right,
+      IScheduler::WireId<IScheduler::Boolean> wireID,
+      IScheduler::WireId<IScheduler::Boolean> left,
+      IScheduler::WireId<IScheduler::Boolean> right,
       int partyID,
       IWireKeeper& wireKeeper)
-      : INormalGate<T>{
+      : INormalGate{
             gateType,
             wireID,
             left,
@@ -139,13 +139,15 @@ class NormalGate final : public INormalGate<T> {
     }
   }
 
-  void increaseReferenceCount(IScheduler::WireId<T> wire) override {
+  void increaseReferenceCount(
+      IScheduler::WireId<IScheduler::Boolean> wire) override {
     if (!wire.isEmpty()) {
       wireKeeper_.increaseReferenceCount(wire);
     }
   }
 
-  void decreaseReferenceCount(IScheduler::WireId<T> wire) override {
+  void decreaseReferenceCount(
+      IScheduler::WireId<IScheduler::Boolean> wire) override {
     if (!wire.isEmpty()) {
       wireKeeper_.decreaseReferenceCount(wire);
     }

--- a/fbpcf/scheduler/gate_keeper/RebatchingGate.h
+++ b/fbpcf/scheduler/gate_keeper/RebatchingGate.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <stdexcept>
 #include <string>
@@ -74,9 +75,8 @@ class RebatchingBooleanGate : public IGate {
     }
   }
 
-  void compute(
-      engine::ISecretShareEngine&,
-      std::map<int64_t, std::vector<bool>>&) override {
+  void compute(engine::ISecretShareEngine&, std::map<int64_t, IGate::Secrets>&)
+      override {
     switch (gateType_) {
       case GateType::Batching:
         executeBatchingGate();
@@ -89,7 +89,7 @@ class RebatchingBooleanGate : public IGate {
 
   void collectScheduledResult(
       engine::ISecretShareEngine&,
-      std::map<int64_t, std::vector<bool>>&) override {}
+      std::map<int64_t, IGate::Secrets>&) override {}
 
   uint32_t getNumberOfResults() const override {
     return 0;

--- a/fbpcf/scheduler/gate_keeper/test/GateKeeperTest.cpp
+++ b/fbpcf/scheduler/gate_keeper/test/GateKeeperTest.cpp
@@ -39,8 +39,7 @@ void testLevel(
   int rebatchingGateIndex = 0;
   for (auto i = 0; i < level.size(); ++i) {
     IGate* gate = level.at(i).get();
-    INormalGate<IScheduler::Boolean>* normalGate =
-        dynamic_cast<INormalGate<IScheduler::Boolean>*>(gate);
+    INormalGate* normalGate = dynamic_cast<INormalGate*>(gate);
     ICompositeGate* compositeGate = dynamic_cast<ICompositeGate*>(gate);
     RebatchingBooleanGate* rebatchingBooleanGate =
         dynamic_cast<RebatchingBooleanGate*>(gate);
@@ -93,8 +92,8 @@ TEST(GateKeeperTest, TestAddAndRemoveGates) {
   auto wire2 = gateKeeper->inputGate(false);
 
   // Level 1
-  auto wire3 = gateKeeper->normalGate(
-      INormalGate<IScheduler::Boolean>::GateType::NonFreeAnd, wire1, wire2);
+  auto wire3 =
+      gateKeeper->normalGate(INormalGate::GateType::NonFreeAnd, wire1, wire2);
 
   EXPECT_EQ(gateKeeper->getFirstUnexecutedLevel(), 0);
 
@@ -103,20 +102,20 @@ TEST(GateKeeperTest, TestAddAndRemoveGates) {
 
   // Level 2
   auto wire4 = gateKeeper->normalGate(
-      INormalGate<IScheduler::Boolean>::GateType::AsymmetricXOR, wire1, wire2);
+      INormalGate::GateType::AsymmetricXOR, wire1, wire2);
 
   // Level 3
   auto wire5 = gateKeeper->outputGate(wire4, 0);
   auto wire6 = gateKeeper->outputGate(wire3, 1);
 
   // Level 5
-  auto wire7 = gateKeeper->normalGate(
-      INormalGate<IScheduler::Boolean>::GateType::NonFreeAnd, wire3, wire6);
+  auto wire7 =
+      gateKeeper->normalGate(INormalGate::GateType::NonFreeAnd, wire3, wire6);
 
   // Level 2
   auto wire8 = gateKeeper->inputGate(true);
-  auto wire9 = gateKeeper->normalGate(
-      INormalGate<IScheduler::Boolean>::GateType::AsymmetricNot, wire4);
+  auto wire9 =
+      gateKeeper->normalGate(INormalGate::GateType::AsymmetricNot, wire4);
 
   EXPECT_EQ(gateKeeper->getFirstUnexecutedLevel(), 2);
 
@@ -139,7 +138,7 @@ TEST(GateKeeperTest, TestAddAndRemoveGates) {
 
   // Level 7
   wire3 = gateKeeper->normalGateBatch(
-      INormalGate<IScheduler::Boolean>::GateType::NonFreeAnd, wire1, wire2);
+      INormalGate::GateType::NonFreeAnd, wire1, wire2);
 
   EXPECT_EQ(gateKeeper->getFirstUnexecutedLevel(), 6);
 
@@ -152,7 +151,7 @@ TEST(GateKeeperTest, TestAddAndRemoveGates) {
 
   // Level 8
   wire4 = gateKeeper->normalGateBatch(
-      INormalGate<IScheduler::Boolean>::GateType::AsymmetricXOR, wire1, wire2);
+      INormalGate::GateType::AsymmetricXOR, wire1, wire2);
 
   // Level 9
   wire5 = gateKeeper->outputGateBatch(wire4, 0);
@@ -160,12 +159,12 @@ TEST(GateKeeperTest, TestAddAndRemoveGates) {
 
   // Level 11
   wire7 = gateKeeper->normalGateBatch(
-      INormalGate<IScheduler::Boolean>::GateType::NonFreeAnd, wire3, wire6);
+      INormalGate::GateType::NonFreeAnd, wire3, wire6);
 
   // Level 8
   wire8 = gateKeeper->inputGateBatch({true, true});
-  wire9 = gateKeeper->normalGateBatch(
-      INormalGate<IScheduler::Boolean>::GateType::AsymmetricNot, wire4);
+  wire9 =
+      gateKeeper->normalGateBatch(INormalGate::GateType::AsymmetricNot, wire4);
 
   EXPECT_EQ(gateKeeper->getFirstUnexecutedLevel(), 8);
 
@@ -207,9 +206,7 @@ TEST(GateKeeperTest, TestCompositeGates) {
 
   // level 2
   auto leftWire2 = gateKeeper->normalGate(
-      INormalGate<IScheduler::Boolean>::GateType::AsymmetricXOR,
-      leftWire,
-      wires2[0]);
+      INormalGate::GateType::AsymmetricXOR, leftWire, wires2[0]);
 
   std::vector<IScheduler::WireId<IScheduler::Boolean>> rightWires2;
   auto lastLevelNotInput = leftWire;
@@ -217,13 +214,10 @@ TEST(GateKeeperTest, TestCompositeGates) {
   for (int i = 0; i < 64; ++i) {
     // level 2i + 2
     auto notGateWire = gateKeeper->normalGate(
-        INormalGate<IScheduler::Boolean>::GateType::SymmetricNot,
-        lastLevelNotInput);
+        INormalGate::GateType::SymmetricNot, lastLevelNotInput);
     // level 2i + 3
     auto andGateWire = gateKeeper->normalGate(
-        INormalGate<IScheduler::Boolean>::GateType::NonFreeAnd,
-        leftWire2,
-        notGateWire);
+        INormalGate::GateType::NonFreeAnd, leftWire2, notGateWire);
 
     lastLevelNotInput = andGateWire;
     rightWires2.push_back(notGateWire);

--- a/fbpcf/scheduler/gate_keeper/test/GateKeeperTest.cpp
+++ b/fbpcf/scheduler/gate_keeper/test/GateKeeperTest.cpp
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 
 #include <fbpcf/scheduler/gate_keeper/IGate.h>
+#include <vector>
 #include "fbpcf/scheduler/IScheduler.h"
 #include "fbpcf/scheduler/WireKeeper.h"
 #include "fbpcf/scheduler/gate_keeper/GateKeeper.h"
@@ -128,8 +129,10 @@ TEST(GateKeeperTest, TestAddAndRemoveGates) {
   // Batching API
 
   // Level 6
-  wire1 = gateKeeper->inputGateBatch({true, false});
-  wire2 = gateKeeper->inputGateBatch({false, true});
+  auto w1 = std::vector<bool>(true, false);
+  auto w2 = std::vector<bool>(false, true);
+  wire1 = gateKeeper->inputGateBatch(w1);
+  wire2 = gateKeeper->inputGateBatch(w2);
 
   auto wire12 = gateKeeper->batchingUp({wire1, wire2});
   auto wire1And2 = gateKeeper->unbatching(
@@ -162,7 +165,8 @@ TEST(GateKeeperTest, TestAddAndRemoveGates) {
       INormalGate::GateType::NonFreeAnd, wire3, wire6);
 
   // Level 8
-  wire8 = gateKeeper->inputGateBatch({true, true});
+  auto w8 = std::vector<bool>(true, true);
+  wire8 = gateKeeper->inputGateBatch(w8);
   wire9 =
       gateKeeper->normalGateBatch(INormalGate::GateType::AsymmetricNot, wire4);
 


### PR DESCRIPTION
Summary: Implement gate keeper methods to add arithmetic input/output and arithmetic gates. Input/output functions and gate functions have the same name as their boolean counterparts, but with different arguments. The implementations are symmetric to the corresponding boolean gate ones.

Differential Revision: D38038065

