### PR TITLE
Implement Gatekeeper methods for arithmetic gates

### DIFF
--- a/fbpcf/scheduler/gate_keeper/GateKeeper.cpp
+++ b/fbpcf/scheduler/gate_keeper/GateKeeper.cpp
@@ -6,15 +6,19 @@
  */
 
 #include "fbpcf/scheduler/gate_keeper/GateKeeper.h"
-#include <fbpcf/scheduler/gate_keeper/INormalGate.h>
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <stdexcept>
 #include "fbpcf/scheduler/IScheduler.h"
+#include "fbpcf/scheduler/gate_keeper/ArithmeticGate.h"
+#include "fbpcf/scheduler/gate_keeper/BatchArithmeticGate.h"
 #include "fbpcf/scheduler/gate_keeper/BatchCompositeGate.h"
 #include "fbpcf/scheduler/gate_keeper/BatchNormalGate.h"
 #include "fbpcf/scheduler/gate_keeper/CompositeGate.h"
+#include "fbpcf/scheduler/gate_keeper/IArithmeticGate.h"
 #include "fbpcf/scheduler/gate_keeper/IGate.h"
+#include "fbpcf/scheduler/gate_keeper/INormalGate.h"
 #include "fbpcf/scheduler/gate_keeper/NormalGate.h"
 
 namespace fbpcf::scheduler {
@@ -41,7 +45,20 @@ IScheduler::WireId<IScheduler::Boolean> GateKeeper::inputGate(
 
 IScheduler::WireId<IScheduler::Arithmetic> GateKeeper::inputGate(
     IntType<false> initialValue) {
-  throw std::runtime_error("Unimplemented");
+  auto level = getOutputLevel(
+      IArithmeticGate::isFree(IArithmeticGate::GateType::Input),
+      firstUnexecutedLevel_);
+  auto outputWire = allocateNewWire(initialValue, level);
+  addGate(
+      std::make_unique<ArithmeticGate>(
+          IArithmeticGate::GateType::Input,
+          outputWire,
+          IScheduler::WireId<IScheduler::Arithmetic>(),
+          IScheduler::WireId<IScheduler::Arithmetic>(),
+          0,
+          *wireKeeper_),
+      level);
+  return outputWire;
 }
 
 IScheduler::WireId<IScheduler::Boolean> GateKeeper::inputGateBatch(
@@ -67,7 +84,23 @@ IScheduler::WireId<IScheduler::Boolean> GateKeeper::inputGateBatch(
 
 IScheduler::WireId<IScheduler::Arithmetic> GateKeeper::inputGateBatch(
     IntType<true> initialValue) {
-  throw std::runtime_error("Unimplemented");
+  auto size = initialValue.size();
+  auto level = getOutputLevel(
+      IArithmeticGate::isFree(IArithmeticGate::GateType::Input),
+      firstUnexecutedLevel_);
+
+  auto outputWire = allocateNewWire(initialValue, level);
+  addGate(
+      std::make_unique<BatchArithmeticGate>(
+          IArithmeticGate::GateType::Input,
+          outputWire,
+          IScheduler::WireId<IScheduler::Arithmetic>(),
+          IScheduler::WireId<IScheduler::Arithmetic>(),
+          0,
+          size,
+          *wireKeeper_),
+      level);
+  return outputWire;
 }
 
 IScheduler::WireId<IScheduler::Boolean> GateKeeper::outputGate(
@@ -75,7 +108,7 @@ IScheduler::WireId<IScheduler::Boolean> GateKeeper::outputGate(
     int partyID) {
   auto level = getOutputLevel(
       GateClass<false>::isFree(INormalGate::GateType::Output),
-      getMaxLevel<false>(src));
+      getMaxLevel<false, IScheduler::Boolean>(src));
   auto outputWire = allocateNewWire(false, level);
 
   addGate(
@@ -94,7 +127,22 @@ IScheduler::WireId<IScheduler::Boolean> GateKeeper::outputGate(
 IScheduler::WireId<IScheduler::Arithmetic> GateKeeper::outputGate(
     IScheduler::WireId<IScheduler::Arithmetic> src,
     int partyID) {
-  throw std::runtime_error("Unimplemented");
+  auto level = getOutputLevel(
+      IArithmeticGate::isFree(IArithmeticGate::GateType::Output),
+      getMaxLevel<false, IScheduler::Arithmetic>(src));
+  auto outputWire = allocateNewWire((uint64_t)0, level);
+
+  addGate(
+      std::make_unique<ArithmeticGate>(
+          IArithmeticGate::GateType::Output,
+          outputWire,
+          src,
+          IScheduler::WireId<IScheduler::Arithmetic>(),
+          partyID,
+          *wireKeeper_),
+      level);
+
+  return outputWire;
 }
 
 IScheduler::WireId<IScheduler::Boolean> GateKeeper::outputGateBatch(
@@ -102,7 +150,7 @@ IScheduler::WireId<IScheduler::Boolean> GateKeeper::outputGateBatch(
     int partyID) {
   auto level = getOutputLevel(
       GateClass<false>::isFree(INormalGate::GateType::Output),
-      getMaxLevel<true>(src));
+      getMaxLevel<true, IScheduler::Boolean>(src));
   auto outputWire = allocateNewWire(std::vector<bool>(), level);
 
   addGate(
@@ -122,7 +170,23 @@ IScheduler::WireId<IScheduler::Boolean> GateKeeper::outputGateBatch(
 IScheduler::WireId<IScheduler::Arithmetic> GateKeeper::outputGateBatch(
     IScheduler::WireId<IScheduler::Arithmetic> src,
     int partyID) {
-  throw std::runtime_error("Unimplemented");
+  auto level = getOutputLevel(
+      IArithmeticGate::isFree(IArithmeticGate::GateType::Output),
+      getMaxLevel<true, IScheduler::Arithmetic>(src));
+  auto outputWire = allocateNewWire(std::vector<uint64_t>(), level);
+
+  addGate(
+      std::make_unique<BatchArithmeticGate>(
+          IArithmeticGate::GateType::Output,
+          outputWire,
+          src,
+          IScheduler::WireId<IScheduler::Arithmetic>(),
+          partyID,
+          0,
+          *wireKeeper_),
+      level);
+
+  return outputWire;
 }
 
 IScheduler::WireId<IScheduler::Boolean> GateKeeper::normalGate(
@@ -131,7 +195,9 @@ IScheduler::WireId<IScheduler::Boolean> GateKeeper::normalGate(
     IScheduler::WireId<IScheduler::Boolean> right) {
   auto level = getOutputLevel(
       GateClass<false>::isFree(gateType),
-      std::max(getMaxLevel<false>(left), getMaxLevel<false>(right)));
+      std::max(
+          getMaxLevel<false, IScheduler::Boolean>(left),
+          getMaxLevel<false, IScheduler::Boolean>(right)));
   auto outputWire = allocateNewWire(false, level);
 
   addGate(
@@ -148,7 +214,9 @@ IScheduler::WireId<IScheduler::Boolean> GateKeeper::normalGateBatch(
     IScheduler::WireId<IScheduler::Boolean> right) {
   auto level = getOutputLevel(
       GateClass<false>::isFree(gateType),
-      std::max(getMaxLevel<true>(left), getMaxLevel<true>(right)));
+      std::max(
+          getMaxLevel<true, IScheduler::Boolean>(left),
+          getMaxLevel<true, IScheduler::Boolean>(right)));
   auto outputWire = allocateNewWire(std::vector<bool>(), level);
 
   addGate(
@@ -163,14 +231,38 @@ IScheduler::WireId<IScheduler::Arithmetic> GateKeeper::arithmeticGate(
     IArithmeticGate::GateType gateType,
     IScheduler::WireId<IScheduler::Arithmetic> left,
     IScheduler::WireId<IScheduler::Arithmetic> right) {
-  throw std::runtime_error("Unimplemented");
+  auto level = getOutputLevel(
+      IArithmeticGate::isFree(gateType),
+      std::max(
+          getMaxLevel<false, IScheduler::Arithmetic>(left),
+          getMaxLevel<false, IScheduler::Arithmetic>(right)));
+  auto outputWire = allocateNewWire((uint64_t)0, level);
+
+  addGate(
+      std::make_unique<ArithmeticGate>(
+          gateType, outputWire, left, right, 0, *wireKeeper_),
+      level);
+
+  return outputWire;
 }
 
 IScheduler::WireId<IScheduler::Arithmetic> GateKeeper::arithmeticGateBatch(
     IArithmeticGate::GateType gateType,
     IScheduler::WireId<IScheduler::Arithmetic> left,
     IScheduler::WireId<IScheduler::Arithmetic> right) {
-  throw std::runtime_error("Unimplemented");
+  auto level = getOutputLevel(
+      IArithmeticGate::isFree(gateType),
+      std::max(
+          getMaxLevel<true, IScheduler::Arithmetic>(left),
+          getMaxLevel<true, IScheduler::Arithmetic>(right)));
+  auto outputWire = allocateNewWire(std::vector<uint64_t>(), level);
+
+  addGate(
+      std::make_unique<BatchArithmeticGate>(
+          gateType, outputWire, left, right, 0, 0, *wireKeeper_),
+      level);
+
+  return outputWire;
 }
 
 std::vector<IScheduler::WireId<IScheduler::Boolean>> GateKeeper::compositeGate(
@@ -182,7 +274,9 @@ std::vector<IScheduler::WireId<IScheduler::Boolean>> GateKeeper::compositeGate(
       compositeSize);
   auto level = getOutputLevel(
       GateClass<true>::isFree(gateType),
-      std::max(getMaxLevel<false>(left), getMaxLevel<false>(rights)));
+      std::max(
+          getMaxLevel<false, IScheduler::Boolean>(left),
+          getMaxLevel<false>(rights)));
   for (size_t i = 0; i < compositeSize; i++) {
     outputWires[i] = allocateNewWire(false, level);
   }
@@ -205,7 +299,9 @@ GateKeeper::compositeGateBatch(
       compositeSize);
   auto level = getOutputLevel(
       GateClass<true>::isFree(gateType),
-      std::max(getMaxLevel<true>(left), getMaxLevel<true>(rights)));
+      std::max(
+          getMaxLevel<true, IScheduler::Boolean>(left),
+          getMaxLevel<true>(rights)));
   for (size_t i = 0; i < compositeSize; i++) {
     outputWires[i] = allocateNewWire(std::vector<bool>(), level);
   }
@@ -218,7 +314,7 @@ GateKeeper::compositeGateBatch(
   return outputWires;
 }
 
-// band a number of batches into one batch.
+// band a number of boolean batches into one batch.
 IScheduler::WireId<IScheduler::Boolean> GateKeeper::batchingUp(
     std::vector<IScheduler::WireId<IScheduler::Boolean>> src) {
   auto level = getOutputLevel(true, getMaxLevel<true>(src));
@@ -233,7 +329,7 @@ IScheduler::WireId<IScheduler::Boolean> GateKeeper::batchingUp(
   return outputWire;
 }
 
-// decompose a batch of values into several smaller batches.
+// decompose a batch of boolean values into several smaller batches.
 std::vector<IScheduler::WireId<IScheduler::Boolean>> GateKeeper::unbatching(
     IScheduler::WireId<IScheduler::Boolean> src,
     std::shared_ptr<std::vector<uint32_t>> unbatchingStrategy) {

--- a/fbpcf/scheduler/gate_keeper/GateKeeper.h
+++ b/fbpcf/scheduler/gate_keeper/GateKeeper.h
@@ -196,10 +196,22 @@ class GateKeeper : public IGateKeeper {
     return wireKeeper_->allocateBooleanValue(v, level);
   }
 
+  inline IScheduler::WireId<IScheduler::Arithmetic> allocateNewWire(
+      uint64_t v,
+      uint32_t level) const {
+    return wireKeeper_->allocateIntegerValue(v, level);
+  }
+
   inline IScheduler::WireId<IScheduler::Boolean> allocateNewWire(
       const std::vector<bool>& v,
       uint32_t level) const {
     return wireKeeper_->allocateBatchBooleanValue(v, level);
+  }
+
+  inline IScheduler::WireId<IScheduler::Arithmetic> allocateNewWire(
+      const std::vector<uint64_t>& v,
+      uint32_t level) const {
+    return wireKeeper_->allocateBatchIntegerValue(v, level);
   }
 
   inline uint32_t getOutputLevel(bool isGateFree, uint32_t maxInputLevel)
@@ -211,9 +223,8 @@ class GateKeeper : public IGateKeeper {
         ((IGateKeeper::isLevelFree(outputLevel) != isGateFree) ? 1 : 0);
   }
 
-  template <bool usingBatch>
-  inline uint32_t getMaxLevel(
-      IScheduler::WireId<IScheduler::Boolean> id) const {
+  template <bool usingBatch, IScheduler::WireType wireType>
+  inline uint32_t getMaxLevel(IScheduler::WireId<wireType> id) const {
     if (id.isEmpty()) {
       return 0;
     } else if constexpr (usingBatch) {


### PR DESCRIPTION
Summary: Implement gate keeper methods to add arithmetic input/output and arithmetic gates. The implementations are symmetric to the corresponding boolean gate ones.

Differential Revision: D38078219

