### PR TITLE
Change unit test inputs to use attribution values

### DIFF
--- a/fbpcf/mpc_std_lib/util/Intp_impl.h
+++ b/fbpcf/mpc_std_lib/util/Intp_impl.h
@@ -225,6 +225,18 @@ class MpcAdapters<Intp<isSigned, width>, schedulerId> {
         buf.begin(), buf.end(), rst.begin(), [](auto v) { return v; });
     return rst;
   }
+
+  static SecBatchType batchingWith(
+      const SecBatchType& src,
+      const std::vector<SecBatchType>& others) {
+    return src.batchingWith(others);
+  }
+
+  static std::vector<SecBatchType> unbatching(
+      const SecBatchType& src,
+      std::shared_ptr<std::vector<uint32_t>> unbatchingStrategy) {
+    return src.unbatching(unbatchingStrategy);
+  }
 };
 
 } // namespace fbpcf::mpc_std_lib::util

--- a/fbpcf/mpc_std_lib/util/pairUtil.h
+++ b/fbpcf/mpc_std_lib/util/pairUtil.h
@@ -25,30 +25,84 @@ struct SecBatchType<std::pair<T, U>, schedulerId> {
 template <typename T, typename U, int schedulerId>
 class MpcAdapters<std::pair<T, U>, schedulerId> {
  public:
+  using SecBatchTypeT = typename SecBatchType<T, schedulerId>::type;
+  using SecBatchTypeU = typename SecBatchType<U, schedulerId>::type;
   using SecBatchType =
       typename SecBatchType<std::pair<T, U>, schedulerId>::type;
   static SecBatchType processSecretInputs(
       const std::vector<std::pair<T, U>>& secrets,
-      int secretOwnerPartyId);
+      int secretOwnerPartyId) {
+    auto size = secrets.size();
+    std::vector<T> secrets1(size);
+    std::vector<U> secrets2(size);
+    for (size_t i = 0; i < size; i++) {
+      secrets1[i] = secrets.at(i).first;
+      secrets2[i] = secrets.at(i).second;
+    }
+    auto rst1 = MpcAdapters<T, schedulerId>::processSecretInputs(
+        secrets1, secretOwnerPartyId);
+    auto rst2 = MpcAdapters<U, schedulerId>::processSecretInputs(
+        secrets2, secretOwnerPartyId);
+    return {rst1, rst2};
+  }
 
   static std::pair<SecBatchType, SecBatchType> obliviousSwap(
       const SecBatchType& src1,
       const SecBatchType& src2,
-      frontend::Bit<true, schedulerId, true> indicator);
+      frontend::Bit<true, schedulerId, true> indicator) {
+    auto [rst11, rst12] = MpcAdapters<T, schedulerId>::obliviousSwap(
+        src1.first, src2.first, indicator);
+    auto [rst21, rst22] = MpcAdapters<U, schedulerId>::obliviousSwap(
+        src1.second, src2.second, indicator);
+    return {{rst11, rst21}, {rst12, rst22}};
+  }
 
   static std::vector<std::pair<T, U>> openToParty(
       const SecBatchType& src,
-      int partyId);
+      int partyId) {
+    auto rst1 = MpcAdapters<T, schedulerId>::openToParty(src.first, partyId);
+    auto rst2 = MpcAdapters<U, schedulerId>::openToParty(src.second, partyId);
+    if (rst1.size() != rst2.size()) {
+      throw std::runtime_error("data size does not match");
+    }
+
+    auto size = rst1.size();
+    std::vector<std::pair<T, U>> rst(size);
+    for (size_t i = 0; i < size; i++) {
+      rst[i] = {rst1.at(i), rst2.at(i)};
+    }
+    return rst;
+  }
 
   static SecBatchType batchingWith(
       const SecBatchType& src,
-      const std::vector<SecBatchType>& others);
+      const std::vector<SecBatchType>& others) {
+    std::vector<SecBatchTypeT> others1(others.size());
+    std::vector<SecBatchTypeU> others2(others.size());
+    for (size_t i = 0; i < others.size(); i++) {
+      others1[i] = others.at(i).first;
+      others2[i] = others.at(i).second;
+    }
+    auto rst1 = MpcAdapters<T, schedulerId>::batchingWith(src.first, others1);
+    auto rst2 = MpcAdapters<U, schedulerId>::batchingWith(src.second, others2);
+    return {rst1, rst2};
+  }
 
   static std::vector<SecBatchType> unbatching(
       const SecBatchType& src,
-      std::shared_ptr<std::vector<uint32_t>> unbatchingStrategy);
+      std::shared_ptr<std::vector<uint32_t>> unbatchingStrategy) {
+    auto rst1 =
+        MpcAdapters<T, schedulerId>::unbatching(src.first, unbatchingStrategy);
+    auto rst2 =
+        MpcAdapters<U, schedulerId>::unbatching(src.second, unbatchingStrategy);
+    std::vector<SecBatchType> rst(rst1.size());
+    for (size_t i = 0; i < rst.size(); i++) {
+      rst[i] = {rst1.at(i), rst2.at(i)};
+    }
+    return rst;
+  }
 };
 
 } // namespace fbpcf::mpc_std_lib::util
 
-#include "fbpcf/mpc_std_lib/util/pair_impl.h"
+//#include "fbpcf/mpc_std_lib/util/pair_impl.h"


### PR DESCRIPTION
Summary:
Modify test data used in unit test on the compactor to integrate with attribution output data.

Details:
- use the following data type: ```std::pair<std::pair<uint64_t, uint32_t>, bool>```, where ```uint64_t```, ```uint32_t``` and ```bool``` correspond to ad ids, conversion values, and is_attributed labels, respectively.
- implement partially specialized template std::pair<T, U>, which calls MPC adapters on inputs types T and U. This technically supports a pair of any two input data types.

Reviewed By: chualynn

Differential Revision: D37830635

