### PR TITLE
Temporarily use the latest fbpcs in fbpcf

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -55,10 +55,6 @@ jobs:
       run: |
         git clone https://github.com/facebookresearch/fbpcs
         cd fbpcs
-        git reset --hard $(curl \
-        --header 'content-type: application/json' \
-        "https://api.github.com/repos/facebookresearch/fbpcs/actions/workflows/12965519/runs?per_page=1&status=success" | jq \
-        ".workflow_runs[0] .head_sha" | tr -d '"')
 
     - name: Build fbpcs image (this uses the locally built fbpcf image as a dependency)
       run: |


### PR DESCRIPTION
Summary:
The "Publish Docker Image" action in FBPCF (https://github.com/facebookresearch/fbpcf/actions/workflows/docker-publish.yml) has been failing since July 18th. We had a fix D38097834 to fix the issue. But unfortunately this action couldn't pull the latest FBPCS code since the "Publish OneDocker Image" action in FBPCS also failing for a while.

This temporary change is to pull latest code for FBPCS. Once everything works, I'll revert it back.

Differential Revision: D38127933

