### PR TITLE
Network PlaintextScheduler implementations of arithmetic operations

### DIFF
--- a/fbpcf/engine/communication/InMemoryPartyCommunicationAgentHost.cpp
+++ b/fbpcf/engine/communication/InMemoryPartyCommunicationAgentHost.cpp
@@ -16,11 +16,6 @@ void InMemoryPartyCommunicationAgent::sendImpl(const void* data, int nBytes) {
   sentData_ += nBytes;
 }
 
-void InMemoryPartyCommunicationAgent::send(
-    const std::vector<unsigned char>& data) {
-  sendImpl(static_cast<const void*>(data.data()), data.size());
-}
-
 void InMemoryPartyCommunicationAgent::recvImpl(void* data, int nBytes) {
   auto result = host_.receive(myId_, nBytes);
 
@@ -29,13 +24,6 @@ void InMemoryPartyCommunicationAgent::recvImpl(void* data, int nBytes) {
   }
   memcpy(data, result.data(), nBytes);
   receivedData_ += nBytes;
-}
-
-std::vector<unsigned char> InMemoryPartyCommunicationAgent::receive(
-    size_t size) {
-  std::vector<unsigned char> v(size);
-  recvImpl(static_cast<void*>(v.data()), size);
-  return v;
 }
 
 InMemoryPartyCommunicationAgentHost::InMemoryPartyCommunicationAgentHost() {

--- a/fbpcf/engine/communication/InMemoryPartyCommunicationAgentHost.h
+++ b/fbpcf/engine/communication/InMemoryPartyCommunicationAgentHost.h
@@ -28,15 +28,6 @@ class InMemoryPartyCommunicationAgent final : public IPartyCommunicationAgent {
       InMemoryPartyCommunicationAgentHost& host,
       int myId)
       : host_{host}, myId_(myId), sentData_(0), receivedData_(0) {}
-  /**
-   * @inherit doc
-   */
-  void send(const std::vector<unsigned char>& data) override;
-
-  /**
-   * @inherit doc
-   */
-  std::vector<unsigned char> receive(size_t size) override;
 
   /**
    * @inherit doc

--- a/fbpcf/engine/communication/SocketPartyCommunicationAgent.cpp
+++ b/fbpcf/engine/communication/SocketPartyCommunicationAgent.cpp
@@ -104,11 +104,6 @@ void SocketPartyCommunicationAgent::sendImpl(const void* data, int nBytes) {
   }
 }
 
-void SocketPartyCommunicationAgent::send(
-    const std::vector<unsigned char>& data) {
-  sendImpl(static_cast<const void*>(data.data()), data.size());
-}
-
 void SocketPartyCommunicationAgent::recvImpl(void* data, int nBytes) {
   size_t bytesRead = 0;
 
@@ -128,12 +123,6 @@ void SocketPartyCommunicationAgent::recvImpl(void* data, int nBytes) {
   }
   assert(bytesRead == nBytes);
   recorder_->addReceivedData(bytesRead);
-}
-
-std::vector<unsigned char> SocketPartyCommunicationAgent::receive(size_t size) {
-  std::vector<unsigned char> rst(size);
-  recvImpl(static_cast<void*>(rst.data()), size);
-  return rst;
 }
 
 void SocketPartyCommunicationAgent::openServerPort(int sockFd, int portNo) {

--- a/fbpcf/engine/communication/SocketPartyCommunicationAgent.h
+++ b/fbpcf/engine/communication/SocketPartyCommunicationAgent.h
@@ -46,16 +46,6 @@ class SocketPartyCommunicationAgent final : public IPartyCommunicationAgent {
   /**
    * @inherit doc
    */
-  void send(const std::vector<unsigned char>& data) override;
-
-  /**
-   * @inherit doc
-   */
-  std::vector<unsigned char> receive(size_t size) override;
-
-  /**
-   * @inherit doc
-   */
   std::pair<uint64_t, uint64_t> getTrafficStatistics() const override {
     return recorder_->getTrafficStatistics();
   }

--- a/fbpcf/scheduler/NetworkPlaintextScheduler.h
+++ b/fbpcf/scheduler/NetworkPlaintextScheduler.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <map>
 #include <memory>
 
@@ -57,6 +58,30 @@ class NetworkPlaintextScheduler final : public PlaintextScheduler {
   WireId<IScheduler::Boolean> recoverBooleanWireBatch(
       const std::vector<bool>& v) override;
 
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privateIntegerInput(uint64_t v, int partyId)
+      override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privateIntegerInputBatch(
+      const std::vector<uint64_t>& v,
+      int partyId) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> recoverIntegerWire(uint64_t v) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> recoverIntegerWireBatch(
+      const std::vector<uint64_t>& v) override;
+
   //======== Below are output processing APIs: ========
 
   /**
@@ -69,6 +94,18 @@ class NetworkPlaintextScheduler final : public PlaintextScheduler {
    */
   std::vector<bool> extractBooleanSecretShareBatch(
       WireId<IScheduler::Boolean> id) override;
+
+  /**
+   * @inherit doc
+   */
+  uint64_t extractIntegerSecretShare(
+      WireId<IScheduler::Arithmetic> id) override;
+
+  /**
+   * @inherit doc
+   */
+  std::vector<uint64_t> extractIntegerSecretShareBatch(
+      WireId<IScheduler::Arithmetic> id) override;
 
   //======== Below are miscellaneous APIs: ========
 

--- a/fbpcf/scheduler/PlaintextScheduler.h
+++ b/fbpcf/scheduler/PlaintextScheduler.h
@@ -7,7 +7,10 @@
 
 #pragma once
 
+#include <sys/types.h>
+#include <cstdint>
 #include <memory>
+#include "fbpcf/scheduler/IArithmeticScheduler.h"
 #include "fbpcf/scheduler/IScheduler.h"
 #include "fbpcf/scheduler/IWireKeeper.h"
 
@@ -24,7 +27,7 @@ namespace fbpcf::scheduler {
  * cryptographically secure computations).
  */
 
-class PlaintextScheduler : public IScheduler {
+class PlaintextScheduler : public IArithmeticScheduler {
  public:
   explicit PlaintextScheduler(std::unique_ptr<IWireKeeper> wireKeeper);
 
@@ -38,8 +41,21 @@ class PlaintextScheduler : public IScheduler {
   /**
    * @inherit doc
    */
+  WireId<IScheduler::Arithmetic> privateIntegerInput(uint64_t v, int partyId)
+      override;
+
+  /**
+   * @inherit doc
+   */
   WireId<IScheduler::Boolean> privateBooleanInputBatch(
       const std::vector<bool>& v,
+      int partyId) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privateIntegerInputBatch(
+      const std::vector<uint64_t>& v,
       int partyId) override;
 
   /**
@@ -50,8 +66,19 @@ class PlaintextScheduler : public IScheduler {
   /**
    * @inherit doc
    */
+  WireId<IScheduler::Arithmetic> publicIntegerInput(uint64_t v) override;
+
+  /**
+   * @inherit doc
+   */
   WireId<IScheduler::Boolean> publicBooleanInputBatch(
       const std::vector<bool>& v) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> publicIntegerInputBatch(
+      const std::vector<uint64_t>& v) override;
 
   /**
    * @inherit doc
@@ -61,8 +88,19 @@ class PlaintextScheduler : public IScheduler {
   /**
    * @inherit doc
    */
+  WireId<IScheduler::Arithmetic> recoverIntegerWire(uint64_t v) override;
+
+  /**
+   * @inherit doc
+   */
   WireId<IScheduler::Boolean> recoverBooleanWireBatch(
       const std::vector<bool>& v) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> recoverIntegerWireBatch(
+      const std::vector<uint64_t>& v) override;
 
   //======== Below are output processing APIs: ========
   /**
@@ -75,8 +113,22 @@ class PlaintextScheduler : public IScheduler {
   /**
    * @inherit doc
    */
+  WireId<IScheduler::Arithmetic> openIntegerValueToParty(
+      WireId<IScheduler::Arithmetic> src,
+      int partyId) override;
+
+  /**
+   * @inherit doc
+   */
   WireId<IScheduler::Boolean> openBooleanValueToPartyBatch(
       WireId<IScheduler::Boolean> src,
+      int partyId) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> openIntegerValueToPartyBatch(
+      WireId<IScheduler::Arithmetic> src,
       int partyId) override;
 
   /**
@@ -87,8 +139,20 @@ class PlaintextScheduler : public IScheduler {
   /**
    * @inherit doc
    */
+  uint64_t extractIntegerSecretShare(
+      WireId<IScheduler::Arithmetic> id) override;
+
+  /**
+   * @inherit doc
+   */
   std::vector<bool> extractBooleanSecretShareBatch(
       WireId<IScheduler::Boolean> id) override;
+
+  /**
+   * @inherit doc
+   */
+  std::vector<uint64_t> extractIntegerSecretShareBatch(
+      WireId<IScheduler::Arithmetic> id) override;
 
   /**
    * @inherit doc
@@ -98,8 +162,19 @@ class PlaintextScheduler : public IScheduler {
   /**
    * @inherit doc
    */
+  uint64_t getIntegerValue(WireId<IScheduler::Arithmetic> id) override;
+
+  /**
+   * @inherit doc
+   */
   std::vector<bool> getBooleanValueBatch(
       WireId<IScheduler::Boolean> id) override;
+
+  /**
+   * @inherit doc
+   */
+  std::vector<uint64_t> getIntegerValueBatch(
+      WireId<IScheduler::Arithmetic> id) override;
 
   //======== Below are computation APIs: ========
 
@@ -261,6 +336,120 @@ class PlaintextScheduler : public IScheduler {
   WireId<IScheduler::Boolean> notPublicBatch(
       WireId<IScheduler::Boolean> src) override;
 
+  // ------ Plus gates ------
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privatePlusPrivate(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privatePlusPrivateBatch(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privatePlusPublic(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privatePlusPublicBatch(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> publicPlusPublic(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> publicPlusPublicBatch(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right) override;
+
+  // ------ Mult gates ------
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privateMultPrivate(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privateMultPrivateBatch(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privateMultPublic(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privateMultPublicBatch(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> publicMultPublic(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> publicMultPublicBatch(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right) override;
+
+  // ------ Neg gates ------
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> negPrivate(
+      WireId<IScheduler::Arithmetic> src) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> negPrivateBatch(
+      WireId<IScheduler::Arithmetic> src) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> negPublic(
+      WireId<IScheduler::Arithmetic> src) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> negPublicBatch(
+      WireId<IScheduler::Arithmetic> src) override;
+
   //======== Below are wire management APIs: ========
 
   /**
@@ -282,6 +471,26 @@ class PlaintextScheduler : public IScheduler {
    * @inherit doc
    */
   void decreaseReferenceCountBatch(WireId<IScheduler::Boolean> id) override;
+
+  /**
+   * @inherit doc
+   */
+  void increaseReferenceCount(WireId<IScheduler::Arithmetic> src) override;
+
+  /**
+   * @inherit doc
+   */
+  void increaseReferenceCountBatch(WireId<IScheduler::Arithmetic> src) override;
+
+  /**
+   * @inherit doc
+   */
+  void decreaseReferenceCount(WireId<IScheduler::Arithmetic> id) override;
+
+  /**
+   * @inherit doc
+   */
+  void decreaseReferenceCountBatch(WireId<IScheduler::Arithmetic> id) override;
 
   //======== Below are rebatching APIs: ========
 


### PR DESCRIPTION
Summary:
Add sendInt64 and receiveInt64 function in IPartyCommunicationAgent to support send and receive uint64_t values for the network plaintext scheduler.

Implement integer input/output, integer wire recover/extract in network plaintext scheduler.

Differential Revision: D38187330

