### PR TITLE
Arithmetic operation tests for plaintext and network plaintext scheduler

### DIFF
--- a/fbpcf/engine/communication/IPartyCommunicationAgent.h
+++ b/fbpcf/engine/communication/IPartyCommunicationAgent.h
@@ -11,6 +11,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <atomic>
+#include <cstdint>
 #include <vector>
 #include "fbpcf/util/IMetricRecorder.h"
 
@@ -85,6 +86,14 @@ class IPartyCommunicationAgent {
   }
 
   /**
+   * send a byte string to the partner
+   * @param data the data to be sent
+   */
+  void sendInt64(const std::vector<uint64_t>& data) {
+    sendImpl(static_cast<const void*>(data.data()), data.size() * 8);
+  }
+
+  /**
    * receive a byte string from the partner
    * @param size the expected size;
    * @return the received content
@@ -95,6 +104,17 @@ class IPartyCommunicationAgent {
     auto decompressed = decompressToBits(std::move(compressed));
     decompressed.erase(decompressed.begin() + size, decompressed.end());
     return decompressed;
+  }
+
+  /**
+   * receive a byte string from the partner
+   * @param size the expected size of the returned vector;
+   * @return the received content
+   */
+  std::vector<uint64_t> receiveInt64(size_t size) {
+    std::vector<uint64_t> rst(size);
+    recvImpl(static_cast<void*>(rst.data()), size * 8);
+    return rst;
   }
 
   template <typename T>

--- a/fbpcf/scheduler/NetworkPlaintextScheduler.cpp
+++ b/fbpcf/scheduler/NetworkPlaintextScheduler.cpp
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <cstdint>
 #include <stdexcept>
 #include <vector>
 
@@ -120,6 +121,106 @@ std::vector<bool> NetworkPlaintextScheduler::extractBooleanSecretShareBatch(
     return result;
   } else {
     return std::vector<bool>(result.size(), false);
+  }
+}
+
+IScheduler::WireId<IScheduler::Arithmetic>
+NetworkPlaintextScheduler::privateIntegerInput(uint64_t v, int partyId) {
+  freeGates_++;
+  if (partyId == myId_) {
+    // Send my input to all other parties
+    for (auto& iter : agentMap_) {
+      iter.second->sendInt64({v});
+    }
+    return wireKeeper_->allocateIntegerValue(v);
+  }
+  auto otherV = agentMap_.at(partyId)->receiveInt64(1);
+  return wireKeeper_->allocateIntegerValue(otherV[0]);
+}
+
+IScheduler::WireId<IScheduler::Arithmetic>
+NetworkPlaintextScheduler::privateIntegerInputBatch(
+    const std::vector<uint64_t>& v,
+    int partyId) {
+  freeGates_ += v.size();
+  if (partyId == myId_) {
+    // Send my input to all other parties
+    for (auto& iter : agentMap_) {
+      iter.second->sendInt64(v);
+    }
+    return wireKeeper_->allocateBatchIntegerValue(v);
+  }
+  auto otherV = agentMap_.at(partyId)->receiveInt64(v.size());
+  return wireKeeper_->allocateBatchIntegerValue(otherV);
+}
+
+IScheduler::WireId<IScheduler::Arithmetic>
+NetworkPlaintextScheduler::recoverIntegerWire(uint64_t v) {
+  freeGates_++;
+
+  uint64_t result = v;
+  uint64_t receivedShare;
+
+  // XOR the shares from all parties to recover the true value
+  for (auto& iter : agentMap_) {
+    if (iter.first < myId_) {
+      iter.second->sendInt64({v});
+      receivedShare = iter.second->receiveInt64(1)[0];
+    } else {
+      receivedShare = iter.second->receiveInt64(1)[0];
+      iter.second->sendInt64({v});
+    }
+    result += receivedShare;
+  }
+
+  return wireKeeper_->allocateIntegerValue(result);
+}
+
+IScheduler::WireId<IScheduler::Arithmetic>
+NetworkPlaintextScheduler::recoverIntegerWireBatch(
+    const std::vector<uint64_t>& v) {
+  freeGates_ += v.size();
+
+  std::vector<uint64_t> result = v;
+  std::vector<uint64_t> receivedShares;
+
+  // XOR the shares from all parties to recover the true value
+  for (auto& iter : agentMap_) {
+    if (iter.first < myId_) {
+      iter.second->sendInt64(v);
+      receivedShares = iter.second->receiveInt64(v.size());
+    } else {
+      receivedShares = iter.second->receiveInt64(v.size());
+      iter.second->sendInt64(v);
+    }
+    for (size_t i = 0; i < result.size(); i++) {
+      result[i] = result.at(i) + receivedShares.at(i);
+    }
+  }
+
+  return wireKeeper_->allocateBatchIntegerValue(result);
+}
+
+uint64_t NetworkPlaintextScheduler::extractIntegerSecretShare(
+    WireId<IScheduler::Arithmetic> id) {
+  // Party 0 gets the actual value.
+  // Other parties get false, so all parties' shares XOR to the actual value.
+  if (myId_ == 0) {
+    return wireKeeper_->getIntegerValue(id);
+  } else {
+    return 0;
+  }
+}
+
+std::vector<uint64_t> NetworkPlaintextScheduler::extractIntegerSecretShareBatch(
+    WireId<IScheduler::Arithmetic> id) {
+  // Party 0 gets the actual value.
+  // Other parties get false, so all parties' shares XOR to the actual value.
+  auto result = wireKeeper_->getBatchIntegerValue(id);
+  if (myId_ == 0) {
+    return result;
+  } else {
+    return std::vector<uint64_t>(result.size(), 0);
   }
 }
 

--- a/fbpcf/scheduler/NetworkPlaintextScheduler.h
+++ b/fbpcf/scheduler/NetworkPlaintextScheduler.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <map>
 #include <memory>
 
@@ -57,6 +58,30 @@ class NetworkPlaintextScheduler final : public PlaintextScheduler {
   WireId<IScheduler::Boolean> recoverBooleanWireBatch(
       const std::vector<bool>& v) override;
 
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privateIntegerInput(uint64_t v, int partyId)
+      override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privateIntegerInputBatch(
+      const std::vector<uint64_t>& v,
+      int partyId) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> recoverIntegerWire(uint64_t v) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> recoverIntegerWireBatch(
+      const std::vector<uint64_t>& v) override;
+
   //======== Below are output processing APIs: ========
 
   /**
@@ -69,6 +94,18 @@ class NetworkPlaintextScheduler final : public PlaintextScheduler {
    */
   std::vector<bool> extractBooleanSecretShareBatch(
       WireId<IScheduler::Boolean> id) override;
+
+  /**
+   * @inherit doc
+   */
+  uint64_t extractIntegerSecretShare(
+      WireId<IScheduler::Arithmetic> id) override;
+
+  /**
+   * @inherit doc
+   */
+  std::vector<uint64_t> extractIntegerSecretShareBatch(
+      WireId<IScheduler::Arithmetic> id) override;
 
   //======== Below are miscellaneous APIs: ========
 

--- a/fbpcf/scheduler/PlaintextScheduler.cpp
+++ b/fbpcf/scheduler/PlaintextScheduler.cpp
@@ -9,6 +9,7 @@
 #include <stdexcept>
 #include <vector>
 
+#include <fbpcf/scheduler/IScheduler.h>
 #include "fbpcf/scheduler/PlaintextScheduler.h"
 
 namespace fbpcf::scheduler {
@@ -89,6 +90,81 @@ bool PlaintextScheduler::getBooleanValue(WireId<IScheduler::Boolean> id) {
 std::vector<bool> PlaintextScheduler::getBooleanValueBatch(
     WireId<IScheduler::Boolean> id) {
   return wireKeeper_->getBatchBooleanValue(id);
+}
+
+IScheduler::WireId<IScheduler::Arithmetic>
+PlaintextScheduler::privateIntegerInput(uint64_t v, int /*partyId*/) {
+  freeGates_++;
+  return wireKeeper_->allocateIntegerValue(v);
+}
+
+IScheduler::WireId<IScheduler::Arithmetic>
+PlaintextScheduler::privateIntegerInputBatch(
+    const std::vector<uint64_t>& v,
+    int /*partyId*/) {
+  freeGates_ += v.size();
+  return wireKeeper_->allocateBatchIntegerValue(v);
+}
+
+IScheduler::WireId<IScheduler::Arithmetic>
+PlaintextScheduler::publicIntegerInput(uint64_t v) {
+  freeGates_++;
+  return wireKeeper_->allocateIntegerValue(v);
+}
+
+IScheduler::WireId<IScheduler::Arithmetic>
+PlaintextScheduler::publicIntegerInputBatch(const std::vector<uint64_t>& v) {
+  freeGates_ += v.size();
+  return wireKeeper_->allocateBatchIntegerValue(v);
+}
+
+IScheduler::WireId<IScheduler::Arithmetic>
+PlaintextScheduler::recoverIntegerWire(uint64_t v) {
+  freeGates_++;
+  return wireKeeper_->allocateIntegerValue(v);
+}
+
+IScheduler::WireId<IScheduler::Arithmetic>
+PlaintextScheduler::recoverIntegerWireBatch(const std::vector<uint64_t>& v) {
+  freeGates_ += v.size();
+  return wireKeeper_->allocateBatchIntegerValue(v);
+}
+
+IScheduler::WireId<IScheduler::Arithmetic>
+PlaintextScheduler::openIntegerValueToParty(
+    WireId<IScheduler::Arithmetic> src,
+    int /*partyId*/) {
+  nonFreeGates_++;
+  return wireKeeper_->allocateIntegerValue(wireKeeper_->getIntegerValue(src));
+}
+
+IScheduler::WireId<IScheduler::Arithmetic>
+PlaintextScheduler::openIntegerValueToPartyBatch(
+    WireId<IScheduler::Arithmetic> src,
+    int /*partyId*/) {
+  auto& v = wireKeeper_->getBatchIntegerValue(src);
+  nonFreeGates_ += v.size();
+  return wireKeeper_->allocateBatchIntegerValue(v);
+}
+
+uint64_t PlaintextScheduler::extractIntegerSecretShare(
+    WireId<IScheduler::Arithmetic> id) {
+  return wireKeeper_->getIntegerValue(id);
+}
+
+std::vector<uint64_t> PlaintextScheduler::extractIntegerSecretShareBatch(
+    WireId<IScheduler::Arithmetic> id) {
+  return wireKeeper_->getBatchIntegerValue(id);
+}
+
+uint64_t PlaintextScheduler::getIntegerValue(
+    WireId<IScheduler::Arithmetic> id) {
+  return wireKeeper_->getIntegerValue(id);
+}
+
+std::vector<uint64_t> PlaintextScheduler::getIntegerValueBatch(
+    WireId<IScheduler::Arithmetic> id) {
+  return wireKeeper_->getBatchIntegerValue(id);
 }
 
 IScheduler::WireId<IScheduler::Boolean> PlaintextScheduler::privateAndPrivate(
@@ -274,6 +350,151 @@ IScheduler::WireId<IScheduler::Boolean> PlaintextScheduler::notPublicBatch(
   return notPrivateBatch(src);
 }
 
+IScheduler::WireId<IScheduler::Arithmetic>
+PlaintextScheduler::privatePlusPrivate(
+    WireId<IScheduler::Arithmetic> left,
+    WireId<IScheduler::Arithmetic> right) {
+  freeGates_++;
+  return wireKeeper_->allocateIntegerValue(
+      wireKeeper_->getIntegerValue(left) + wireKeeper_->getIntegerValue(right));
+}
+
+IScheduler::WireId<IScheduler::Arithmetic>
+PlaintextScheduler::privatePlusPrivateBatch(
+    WireId<IScheduler::Arithmetic> left,
+    WireId<IScheduler::Arithmetic> right) {
+  auto& leftValue = wireKeeper_->getBatchIntegerValue(left);
+  auto& rightValue = wireKeeper_->getBatchIntegerValue(right);
+  if (leftValue.size() != rightValue.size()) {
+    throw std::invalid_argument("invalid inputs!");
+  }
+  freeGates_ += leftValue.size();
+  std::vector<uint64_t> rst(leftValue.size());
+  for (size_t i = 0; i < leftValue.size(); i++) {
+    rst[i] = leftValue[i] + rightValue[i];
+  }
+  return wireKeeper_->allocateBatchIntegerValue(rst);
+}
+
+IScheduler::WireId<IScheduler::Arithmetic>
+PlaintextScheduler::privatePlusPublic(
+    WireId<IScheduler::Arithmetic> left,
+    WireId<IScheduler::Arithmetic> right) {
+  return privatePlusPrivate(left, right);
+}
+
+IScheduler::WireId<IScheduler::Arithmetic>
+PlaintextScheduler::privatePlusPublicBatch(
+    WireId<IScheduler::Arithmetic> left,
+    WireId<IScheduler::Arithmetic> right) {
+  return privatePlusPrivateBatch(left, right);
+}
+
+IScheduler::WireId<IScheduler::Arithmetic> PlaintextScheduler::publicPlusPublic(
+    WireId<IScheduler::Arithmetic> left,
+    WireId<IScheduler::Arithmetic> right) {
+  return privatePlusPrivate(left, right);
+}
+
+IScheduler::WireId<IScheduler::Arithmetic>
+PlaintextScheduler::publicPlusPublicBatch(
+    WireId<IScheduler::Arithmetic> left,
+    WireId<IScheduler::Arithmetic> right) {
+  return privatePlusPrivateBatch(left, right);
+}
+
+IScheduler::WireId<IScheduler::Arithmetic>
+PlaintextScheduler::privateMultPrivate(
+    WireId<IScheduler::Arithmetic> left,
+    WireId<IScheduler::Arithmetic> right) {
+  nonFreeGates_++;
+  return wireKeeper_->allocateIntegerValue(
+      wireKeeper_->getIntegerValue(left) * wireKeeper_->getIntegerValue(right));
+}
+
+IScheduler::WireId<IScheduler::Arithmetic>
+PlaintextScheduler::privateMultPrivateBatch(
+    WireId<IScheduler::Arithmetic> left,
+    WireId<IScheduler::Arithmetic> right) {
+  auto& leftValue = wireKeeper_->getBatchIntegerValue(left);
+  auto& rightValue = wireKeeper_->getBatchIntegerValue(right);
+  if (leftValue.size() != rightValue.size()) {
+    throw std::invalid_argument("invalid inputs!");
+  }
+  nonFreeGates_ += leftValue.size();
+  std::vector<uint64_t> rst(leftValue.size());
+  for (size_t i = 0; i < leftValue.size(); i++) {
+    rst[i] = leftValue[i] * rightValue[i];
+  }
+  return wireKeeper_->allocateBatchIntegerValue(rst);
+}
+
+IScheduler::WireId<IScheduler::Arithmetic>
+PlaintextScheduler::privateMultPublic(
+    WireId<IScheduler::Arithmetic> left,
+    WireId<IScheduler::Arithmetic> right) {
+  freeGates_++;
+  return wireKeeper_->allocateIntegerValue(
+      wireKeeper_->getIntegerValue(left) * wireKeeper_->getIntegerValue(right));
+}
+
+IScheduler::WireId<IScheduler::Arithmetic>
+PlaintextScheduler::privateMultPublicBatch(
+    WireId<IScheduler::Arithmetic> left,
+    WireId<IScheduler::Arithmetic> right) {
+  auto& leftValue = wireKeeper_->getBatchIntegerValue(left);
+  auto& rightValue = wireKeeper_->getBatchIntegerValue(right);
+  if (leftValue.size() != rightValue.size()) {
+    throw std::invalid_argument("invalid inputs!");
+  }
+  freeGates_ += leftValue.size();
+  std::vector<uint64_t> rst(leftValue.size());
+  for (size_t i = 0; i < leftValue.size(); i++) {
+    rst[i] = leftValue[i] * rightValue[i];
+  }
+  return wireKeeper_->allocateBatchIntegerValue(rst);
+}
+
+IScheduler::WireId<IScheduler::Arithmetic> PlaintextScheduler::publicMultPublic(
+    WireId<IScheduler::Arithmetic> left,
+    WireId<IScheduler::Arithmetic> right) {
+  return privateMultPublic(left, right);
+}
+
+IScheduler::WireId<IScheduler::Arithmetic>
+PlaintextScheduler::publicMultPublicBatch(
+    WireId<IScheduler::Arithmetic> left,
+    WireId<IScheduler::Arithmetic> right) {
+  return privateMultPublicBatch(left, right);
+}
+
+IScheduler::WireId<IScheduler::Arithmetic> PlaintextScheduler::negPrivate(
+    WireId<IScheduler::Arithmetic> src) {
+  freeGates_++;
+  return wireKeeper_->allocateIntegerValue(-wireKeeper_->getIntegerValue(src));
+}
+
+IScheduler::WireId<IScheduler::Arithmetic> PlaintextScheduler::negPrivateBatch(
+    WireId<IScheduler::Arithmetic> src) {
+  auto& value = wireKeeper_->getBatchIntegerValue(src);
+  freeGates_ += value.size();
+  std::vector<uint64_t> rst(value.size());
+  for (size_t i = 0; i < value.size(); i++) {
+    rst[i] = -value[i];
+  }
+  return wireKeeper_->allocateBatchIntegerValue(rst);
+}
+
+IScheduler::WireId<IScheduler::Arithmetic> PlaintextScheduler::negPublic(
+    WireId<IScheduler::Arithmetic> src) {
+  return negPrivate(src);
+}
+
+IScheduler::WireId<IScheduler::Arithmetic> PlaintextScheduler::negPublicBatch(
+    WireId<IScheduler::Arithmetic> src) {
+  return negPrivateBatch(src);
+}
+
 void PlaintextScheduler::increaseReferenceCount(
     WireId<IScheduler::Boolean> id) {
   wireKeeper_->increaseReferenceCount(id);
@@ -291,6 +512,26 @@ void PlaintextScheduler::decreaseReferenceCount(
 
 void PlaintextScheduler::decreaseReferenceCountBatch(
     WireId<IScheduler::Boolean> id) {
+  wireKeeper_->decreaseBatchReferenceCount(id);
+}
+
+void PlaintextScheduler::increaseReferenceCount(
+    WireId<IScheduler::Arithmetic> id) {
+  wireKeeper_->increaseReferenceCount(id);
+}
+
+void PlaintextScheduler::increaseReferenceCountBatch(
+    WireId<IScheduler::Arithmetic> id) {
+  wireKeeper_->increaseBatchReferenceCount(id);
+}
+
+void PlaintextScheduler::decreaseReferenceCount(
+    WireId<IScheduler::Arithmetic> id) {
+  wireKeeper_->decreaseReferenceCount(id);
+}
+
+void PlaintextScheduler::decreaseReferenceCountBatch(
+    WireId<IScheduler::Arithmetic> id) {
   wireKeeper_->decreaseBatchReferenceCount(id);
 }
 

--- a/fbpcf/scheduler/PlaintextScheduler.h
+++ b/fbpcf/scheduler/PlaintextScheduler.h
@@ -7,7 +7,10 @@
 
 #pragma once
 
+#include <sys/types.h>
+#include <cstdint>
 #include <memory>
+#include "fbpcf/scheduler/IArithmeticScheduler.h"
 #include "fbpcf/scheduler/IScheduler.h"
 #include "fbpcf/scheduler/IWireKeeper.h"
 
@@ -24,7 +27,7 @@ namespace fbpcf::scheduler {
  * cryptographically secure computations).
  */
 
-class PlaintextScheduler : public IScheduler {
+class PlaintextScheduler : public IArithmeticScheduler {
  public:
   explicit PlaintextScheduler(std::unique_ptr<IWireKeeper> wireKeeper);
 
@@ -38,8 +41,21 @@ class PlaintextScheduler : public IScheduler {
   /**
    * @inherit doc
    */
+  WireId<IScheduler::Arithmetic> privateIntegerInput(uint64_t v, int partyId)
+      override;
+
+  /**
+   * @inherit doc
+   */
   WireId<IScheduler::Boolean> privateBooleanInputBatch(
       const std::vector<bool>& v,
+      int partyId) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privateIntegerInputBatch(
+      const std::vector<uint64_t>& v,
       int partyId) override;
 
   /**
@@ -50,8 +66,19 @@ class PlaintextScheduler : public IScheduler {
   /**
    * @inherit doc
    */
+  WireId<IScheduler::Arithmetic> publicIntegerInput(uint64_t v) override;
+
+  /**
+   * @inherit doc
+   */
   WireId<IScheduler::Boolean> publicBooleanInputBatch(
       const std::vector<bool>& v) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> publicIntegerInputBatch(
+      const std::vector<uint64_t>& v) override;
 
   /**
    * @inherit doc
@@ -61,8 +88,19 @@ class PlaintextScheduler : public IScheduler {
   /**
    * @inherit doc
    */
+  WireId<IScheduler::Arithmetic> recoverIntegerWire(uint64_t v) override;
+
+  /**
+   * @inherit doc
+   */
   WireId<IScheduler::Boolean> recoverBooleanWireBatch(
       const std::vector<bool>& v) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> recoverIntegerWireBatch(
+      const std::vector<uint64_t>& v) override;
 
   //======== Below are output processing APIs: ========
   /**
@@ -75,8 +113,22 @@ class PlaintextScheduler : public IScheduler {
   /**
    * @inherit doc
    */
+  WireId<IScheduler::Arithmetic> openIntegerValueToParty(
+      WireId<IScheduler::Arithmetic> src,
+      int partyId) override;
+
+  /**
+   * @inherit doc
+   */
   WireId<IScheduler::Boolean> openBooleanValueToPartyBatch(
       WireId<IScheduler::Boolean> src,
+      int partyId) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> openIntegerValueToPartyBatch(
+      WireId<IScheduler::Arithmetic> src,
       int partyId) override;
 
   /**
@@ -87,8 +139,20 @@ class PlaintextScheduler : public IScheduler {
   /**
    * @inherit doc
    */
+  uint64_t extractIntegerSecretShare(
+      WireId<IScheduler::Arithmetic> id) override;
+
+  /**
+   * @inherit doc
+   */
   std::vector<bool> extractBooleanSecretShareBatch(
       WireId<IScheduler::Boolean> id) override;
+
+  /**
+   * @inherit doc
+   */
+  std::vector<uint64_t> extractIntegerSecretShareBatch(
+      WireId<IScheduler::Arithmetic> id) override;
 
   /**
    * @inherit doc
@@ -98,8 +162,19 @@ class PlaintextScheduler : public IScheduler {
   /**
    * @inherit doc
    */
+  uint64_t getIntegerValue(WireId<IScheduler::Arithmetic> id) override;
+
+  /**
+   * @inherit doc
+   */
   std::vector<bool> getBooleanValueBatch(
       WireId<IScheduler::Boolean> id) override;
+
+  /**
+   * @inherit doc
+   */
+  std::vector<uint64_t> getIntegerValueBatch(
+      WireId<IScheduler::Arithmetic> id) override;
 
   //======== Below are computation APIs: ========
 
@@ -261,6 +336,118 @@ class PlaintextScheduler : public IScheduler {
   WireId<IScheduler::Boolean> notPublicBatch(
       WireId<IScheduler::Boolean> src) override;
 
+  // ------ Plus gates ------
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privatePlusPrivate(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right);
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privatePlusPrivateBatch(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right);
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privatePlusPublic(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right);
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privatePlusPublicBatch(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right);
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> publicPlusPublic(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right);
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> publicPlusPublicBatch(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right);
+
+  // ------ Mult gates ------
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privateMultPrivate(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right);
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privateMultPrivateBatch(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right);
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privateMultPublic(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right);
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privateMultPublicBatch(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right);
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> publicMultPublic(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right);
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> publicMultPublicBatch(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right);
+
+  // ------ Neg gates ------
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> negPrivate(WireId<IScheduler::Arithmetic> src);
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> negPrivateBatch(
+      WireId<IScheduler::Arithmetic> src);
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> negPublic(WireId<IScheduler::Arithmetic> src);
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> negPublicBatch(
+      WireId<IScheduler::Arithmetic> src);
+
   //======== Below are wire management APIs: ========
 
   /**
@@ -282,6 +469,26 @@ class PlaintextScheduler : public IScheduler {
    * @inherit doc
    */
   void decreaseReferenceCountBatch(WireId<IScheduler::Boolean> id) override;
+
+  /**
+   * @inherit doc
+   */
+  void increaseReferenceCount(WireId<IScheduler::Arithmetic> src) override;
+
+  /**
+   * @inherit doc
+   */
+  void increaseReferenceCountBatch(WireId<IScheduler::Arithmetic> src) override;
+
+  /**
+   * @inherit doc
+   */
+  void decreaseReferenceCount(WireId<IScheduler::Arithmetic> id) override;
+
+  /**
+   * @inherit doc
+   */
+  void decreaseReferenceCountBatch(WireId<IScheduler::Arithmetic> id) override;
 
   //======== Below are rebatching APIs: ========
 

--- a/fbpcf/scheduler/SchedulerHelper.h
+++ b/fbpcf/scheduler/SchedulerHelper.h
@@ -22,7 +22,7 @@
 namespace fbpcf::scheduler {
 
 template <bool unsafe>
-inline std::unique_ptr<IScheduler> createPlaintextScheduler(
+inline std::unique_ptr<IArithmeticScheduler> createPlaintextScheduler(
     int /*myId*/,
     engine::communication::IPartyCommunicationAgentFactory&
     /*communicationAgentFactory*/) {
@@ -31,7 +31,7 @@ inline std::unique_ptr<IScheduler> createPlaintextScheduler(
 }
 
 template <bool unsafe>
-inline std::unique_ptr<IScheduler> createNetworkPlaintextScheduler(
+inline std::unique_ptr<IArithmeticScheduler> createNetworkPlaintextScheduler(
     int myId,
     engine::communication::IPartyCommunicationAgentFactory&
         communicationAgentFactory) {

--- a/fbpcf/test/TestHelper.h
+++ b/fbpcf/test/TestHelper.h
@@ -11,6 +11,7 @@
 
 #include <emmintrin.h>
 #include <smmintrin.h>
+#include <stdexcept>
 
 #include "fbpcf/engine/SecretShareEngineFactory.h"
 #include "fbpcf/engine/communication/IPartyCommunicationAgentFactory.h"
@@ -91,6 +92,27 @@ inline SchedulerCreator getSchedulerCreator(SchedulerType schedulerType) {
       return scheduler::createEagerSchedulerWithInsecureEngine<unsafe>;
     case SchedulerType::Lazy:
       return scheduler::createLazySchedulerWithInsecureEngine<unsafe>;
+  }
+}
+
+using ArithmeticSchedulerCreator =
+    std::function<std::unique_ptr<scheduler::IArithmeticScheduler>(
+        int myId,
+        engine::communication::IPartyCommunicationAgentFactory&
+            communicationAgentFactory)>;
+
+template <bool unsafe>
+inline ArithmeticSchedulerCreator getArithmeticSchedulerCreator(
+    SchedulerType schedulerType) {
+  switch (schedulerType) {
+    case SchedulerType::Plaintext:
+      return scheduler::createPlaintextScheduler<unsafe>;
+    case SchedulerType::NetworkPlaintext:
+      return scheduler::createNetworkPlaintextScheduler<unsafe>;
+    case SchedulerType::Eager:
+      throw std::runtime_error("unimplemented");
+    case SchedulerType::Lazy:
+      throw std::runtime_error("unimplemented");
   }
 }
 


### PR DESCRIPTION
Summary: Add tests for arithmetic operations (Plus, Mult, Neg) in plaintext and network plaintext scheduler. Checks unsigned long overflow. All operations should be under 2^64 modular arithmetic.

Differential Revision: D38187863

