### PR TITLE
Integer input/output and reference count tests for plaintext and network plaintext scheduler

### DIFF
--- a/fbpcf/scheduler/SchedulerHelper.h
+++ b/fbpcf/scheduler/SchedulerHelper.h
@@ -43,6 +43,29 @@ inline std::unique_ptr<IScheduler> createNetworkPlaintextScheduler(
       myId, std::move(agentMap), WireKeeper::createWithVectorArena<unsafe>());
 }
 
+template <bool unsafe>
+inline std::unique_ptr<IArithmeticScheduler> createArithmeticPlaintextScheduler(
+    int /*myId*/,
+    engine::communication::IPartyCommunicationAgentFactory&
+    /*communicationAgentFactory*/) {
+  return std::make_unique<PlaintextScheduler>(
+      WireKeeper::createWithVectorArena<unsafe>());
+}
+
+template <bool unsafe>
+inline std::unique_ptr<IArithmeticScheduler>
+createArithmeticNetworkPlaintextScheduler(
+    int myId,
+    engine::communication::IPartyCommunicationAgentFactory&
+        communicationAgentFactory) {
+  auto numberOfParties = 2;
+  auto agentMap = engine::communication::getAgentMap(
+      numberOfParties, myId, communicationAgentFactory);
+
+  return std::make_unique<NetworkPlaintextScheduler>(
+      myId, std::move(agentMap), WireKeeper::createWithVectorArena<unsafe>());
+}
+
 // this function creates a eager scheduler with real secure engine
 inline std::unique_ptr<IScheduler> createEagerSchedulerWithRealEngine(
     int myId,

--- a/fbpcf/test/TestHelper.h
+++ b/fbpcf/test/TestHelper.h
@@ -11,7 +11,9 @@
 
 #include <emmintrin.h>
 #include <smmintrin.h>
+#include <stdexcept>
 
+#include <fbpcf/scheduler/IArithmeticScheduler.h>
 #include "fbpcf/engine/SecretShareEngineFactory.h"
 #include "fbpcf/engine/communication/IPartyCommunicationAgentFactory.h"
 #include "fbpcf/scheduler/IScheduler.h"
@@ -91,6 +93,27 @@ inline SchedulerCreator getSchedulerCreator(SchedulerType schedulerType) {
       return scheduler::createEagerSchedulerWithInsecureEngine<unsafe>;
     case SchedulerType::Lazy:
       return scheduler::createLazySchedulerWithInsecureEngine<unsafe>;
+  }
+}
+
+using ArithmeticSchedulerCreator =
+    std::function<std::unique_ptr<scheduler::IArithmeticScheduler>(
+        int myId,
+        engine::communication::IPartyCommunicationAgentFactory&
+            communicationAgentFactory)>;
+
+template <bool unsafe>
+inline ArithmeticSchedulerCreator getArithmeticSchedulerCreator(
+    SchedulerType schedulerType) {
+  switch (schedulerType) {
+    case SchedulerType::Plaintext:
+      return scheduler::createArithmeticPlaintextScheduler<unsafe>;
+    case SchedulerType::NetworkPlaintext:
+      return scheduler::createArithmeticNetworkPlaintextScheduler<unsafe>;
+    case SchedulerType::Eager:
+      throw std::runtime_error("unimplemented");
+    case SchedulerType::Lazy:
+      throw std::runtime_error("unimplemented");
   }
 }
 


### PR DESCRIPTION
Summary:
Added tests for integer input/output and arithmetic reference count for plaintext and network plaintext scheduler.

Created new caller function runWithArithmeticScheduler() that supports a testBody that takes in a scheduler derived from IArithmeticScheduler.
Created a new TestFixture "ArithmeticSchedulerTestFixture" for testing arithmetic related operations in the schedulers.

Differential Revision: D38181831

