### PR TITLE
Serialize EditDistance game results

### DIFF
--- a/example/edit_distance/AsciiString.h
+++ b/example/edit_distance/AsciiString.h
@@ -78,6 +78,37 @@ class AsciiString : public scheduler::SchedulerKeeper<schedulerId> {
       return data_[index];
     }
 
+    StringType getValue() const {
+      if constexpr (usingBatch) {
+        std::vector<char> chars = convertLongsToChar(data_[0].getValue());
+        size_t batchSize = chars.size();
+        std::vector<std::string> rst(batchSize);
+        for (size_t i = 0; i < batchSize; i++) {
+          rst[i].reserve(maxWidth);
+          if (chars[i] != 0) {
+            rst[i].push_back(chars[i]);
+          }
+        }
+        for (size_t j = 1; j < maxWidth; j++) {
+          chars = convertLongsToChar(data_[j].getValue());
+          for (size_t i = 0; i < batchSize; i++) {
+            if (chars[i] != 0) {
+              rst[i].push_back(chars[i]);
+            }
+          }
+        }
+        return rst;
+      } else {
+        std::string rst = "";
+        rst.reserve(maxWidth);
+        for (size_t i = 0; i < maxWidth; i++) {
+          rst.push_back(data_[i].getValue());
+        }
+
+        return rst;
+      }
+    }
+
     size_t width() const {
       return maxWidth;
     }
@@ -179,7 +210,7 @@ class AsciiString : public scheduler::SchedulerKeeper<schedulerId> {
   SizeType knownSize_;
   size_t batchSize_ = 1;
 
-  std::vector<char> convertLongsToChar(std::vector<int64_t> values) const;
+  static std::vector<char> convertLongsToChar(std::vector<int64_t> values);
 
   friend class AsciiString<maxWidth, !isSecret, schedulerId, usingBatch>;
 };

--- a/example/edit_distance/AsciiString_impl.h
+++ b/example/edit_distance/AsciiString_impl.h
@@ -323,7 +323,7 @@ AsciiString<maxWidth, isSecret, schedulerId, usingBatch>::mux(
 template <int maxWidth, bool isSecret, int schedulerId, bool usingBatch>
 std::vector<char>
 AsciiString<maxWidth, isSecret, schedulerId, usingBatch>::convertLongsToChar(
-    std::vector<int64_t> values) const {
+    std::vector<int64_t> values) {
   std::vector<char> rst(values.size());
   for (size_t i = 0; i < values.size(); i++) {
     rst[i] = values[i];

--- a/example/edit_distance/EditDistanceCalculator.h
+++ b/example/edit_distance/EditDistanceCalculator.h
@@ -24,17 +24,19 @@ class EditDistanceCalculator {
     calculateMessages();
   }
 
-  InputProcessor<schedulerId>& getInputProcessor() {
+  const InputProcessor<schedulerId>& getInputProcessor() const {
     return inputProcessor_;
   }
 
-  SecString<schedulerId>& getReceiverMessages() {
+  const SecString<schedulerId>& getReceiverMessages() const {
     return receiverMessages_;
   }
 
-  Sec32Int<schedulerId> getEditDistances() {
+  const Sec32Int<schedulerId> getEditDistances() const {
     return editDistances_;
   }
+
+  std::string toJson() const;
 
  private:
   void calculateEditDistances();

--- a/example/edit_distance/test/EditDistanceCalculatorTest.cpp
+++ b/example/edit_distance/test/EditDistanceCalculatorTest.cpp
@@ -7,6 +7,7 @@
 
 #include "../EditDistanceCalculator.h" // @manual
 #include <fbpcf/scheduler/SchedulerHelper.h>
+#include <folly/json.h>
 #include <gtest/gtest.h>
 #include "../EditDistanceInputReader.h" // @manual
 #include "../MPCTypes.h" // @manual
@@ -116,5 +117,81 @@ TEST(EditDistanceCalculatorTest, testEditDistanceCalculator) {
 
   testVectorEq(std::get<0>(player1Results), kExpectedDistances);
   testVectorEq(std::get<1>(player1Results), kExpectedReceiverMessages);
+}
+
+TEST(EditDistanceCalculatorTest, testToJson) {
+  using namespace fbcpf::edit_distance;
+
+  boost::filesystem::path dataFilepath1 =
+      build::getResourcePath(std::getenv("DATA_FILE_PATH_1"));
+
+  boost::filesystem::path dataFilepath2 =
+      build::getResourcePath(std::getenv("DATA_FILE_PATH_2"));
+  boost::filesystem::path paramsFilePath =
+      build::getResourcePath(std::getenv("PARAMS_FILE_PATH"));
+
+  auto player0InputData =
+      EditDistanceInputReader(dataFilepath1.native(), paramsFilePath.native());
+
+  auto player1InputData =
+      EditDistanceInputReader(dataFilepath2.native(), paramsFilePath.native());
+
+  auto schedulerCreator = fbpcf::scheduler::createLazySchedulerWithRealEngine;
+  auto factories = fbpcf::engine::communication::getInMemoryAgentFactory(2);
+
+  auto future0 = std::async(
+      createCalculatorWithScheduler<0>,
+      PLAYER0,
+      std::move(player0InputData),
+      std::reference_wrapper<
+          fbpcf::engine::communication::IPartyCommunicationAgentFactory>(
+          *factories[0]),
+      schedulerCreator);
+
+  auto future1 = std::async(
+      createCalculatorWithScheduler<1>,
+      PLAYER1,
+      std::move(player1InputData),
+      std::reference_wrapper<
+          fbpcf::engine::communication::IPartyCommunicationAgentFactory>(
+          *factories[1]),
+      schedulerCreator);
+
+  EditDistanceCalculator<0> player0Calculator = future0.get();
+  EditDistanceCalculator<1> player1Calculator = future1.get();
+
+  auto player0SharesJson = player0Calculator.toJson();
+  auto player1SharesJson = player1Calculator.toJson();
+
+  folly::dynamic player0Shares = folly::parseJson(player0SharesJson);
+  folly::dynamic player1Shares = folly::parseJson(player1SharesJson);
+
+  size_t numRows = player0Shares["editDistanceShares"].size();
+
+  std::vector<int64_t> editDistancesRecovered(numRows);
+  std::vector<std::string> receiverMessagesRecovered(numRows);
+
+  for (int i = 0; i < numRows; i++) {
+    editDistancesRecovered[i] = player0Shares["editDistanceShares"][i].asInt() ^
+        player1Shares["editDistanceShares"][i].asInt();
+
+    std::string strShare0 =
+        player0Shares["receiverMessageShares"][i].asString();
+    std::string strShare1 =
+        player1Shares["receiverMessageShares"][i].asString();
+    std::string recoveredMessage;
+    for (int j = 0; j < maxStringLength; j++) {
+      char c = (strShare0.size() > j ? strShare0[j] : 0) ^
+          (strShare1.size() > j ? strShare1[j] : 0);
+      if (c == 0) {
+        break;
+      } else {
+        recoveredMessage.push_back(c);
+      }
+    }
+    receiverMessagesRecovered[i] = recoveredMessage;
+  }
+  testVectorEq(editDistancesRecovered, kExpectedDistances);
+  testVectorEq(receiverMessagesRecovered, kExpectedReceiverMessages);
 }
 } // namespace fbpcf::edit_distance


### PR DESCRIPTION
Summary:
Adds a helper method to serialize the results of the EditDistance game. It will extract the integer and string shares of the `receiverMessages` and `editDistances` into a folly::dynamic object and then serialize with `folly::json`.

This will be used to write the results to disk and then validate in a later stage.

Differential Revision: D38217636

