### PR TITLE
Inject metric collector into scheduler

### DIFF
--- a/fbpcf/scheduler/EagerScheduler.cpp
+++ b/fbpcf/scheduler/EagerScheduler.cpp
@@ -8,13 +8,17 @@
 #include "fbpcf/scheduler/EagerScheduler.h"
 #include <stdexcept>
 #include <string>
+#include "fbpcf/util/MetricCollector.h"
 
 namespace fbpcf::scheduler {
 
 EagerScheduler::EagerScheduler(
     std::unique_ptr<engine::ISecretShareEngine> engine,
-    std::unique_ptr<IWireKeeper> wireKeeper)
-    : engine_{std::move(engine)}, wireKeeper_{std::move(wireKeeper)} {}
+    std::unique_ptr<IWireKeeper> wireKeeper,
+    std::shared_ptr<util::MetricCollector> collector)
+    : engine_{std::move(engine)},
+      wireKeeper_{std::move(wireKeeper)},
+      collector_{collector} {}
 
 IScheduler::WireId<IScheduler::Boolean> EagerScheduler::privateBooleanInput(
     bool v,

--- a/fbpcf/scheduler/EagerScheduler.h
+++ b/fbpcf/scheduler/EagerScheduler.h
@@ -26,7 +26,7 @@ class EagerScheduler final : public IScheduler {
       std::unique_ptr<engine::ISecretShareEngine> engine,
       std::unique_ptr<IWireKeeper> wireKeeper,
       std::shared_ptr<util::MetricCollector> collector =
-          std::make_shared<util::MetricCollector>("scheduler"));
+          std::make_shared<util::MetricCollector>("eager_scheduler"));
 
   //======== Below are input processing APIs: ========
 

--- a/fbpcf/scheduler/EagerScheduler.h
+++ b/fbpcf/scheduler/EagerScheduler.h
@@ -7,9 +7,11 @@
 
 #pragma once
 
+#include <memory>
 #include "fbpcf/engine/ISecretShareEngine.h"
 #include "fbpcf/scheduler/IScheduler.h"
 #include "fbpcf/scheduler/IWireKeeper.h"
+#include "fbpcf/util/MetricCollector.h"
 
 namespace fbpcf::scheduler {
 
@@ -22,7 +24,9 @@ class EagerScheduler final : public IScheduler {
  public:
   explicit EagerScheduler(
       std::unique_ptr<engine::ISecretShareEngine> engine,
-      std::unique_ptr<IWireKeeper> wireKeeper);
+      std::unique_ptr<IWireKeeper> wireKeeper,
+      std::shared_ptr<util::MetricCollector> collector =
+          std::make_shared<util::MetricCollector>("scheduler"));
 
   //======== Below are input processing APIs: ========
 
@@ -306,6 +310,7 @@ class EagerScheduler final : public IScheduler {
  private:
   std::unique_ptr<engine::ISecretShareEngine> engine_;
   std::unique_ptr<IWireKeeper> wireKeeper_;
+  std::shared_ptr<util::MetricCollector> collector_;
 };
 
 } // namespace fbpcf::scheduler

--- a/fbpcf/scheduler/LazyScheduler.cpp
+++ b/fbpcf/scheduler/LazyScheduler.cpp
@@ -24,10 +24,12 @@ namespace fbpcf::scheduler {
 LazyScheduler::LazyScheduler(
     std::unique_ptr<engine::ISecretShareEngine> engine,
     std::shared_ptr<IWireKeeper> wireKeeper,
-    std::unique_ptr<IGateKeeper> gateKeeper)
+    std::unique_ptr<IGateKeeper> gateKeeper,
+    std::shared_ptr<util::MetricCollector> collector)
     : engine_{std::move(engine)},
       wireKeeper_{std::move(wireKeeper)},
-      gateKeeper_{std::move(gateKeeper)} {}
+      gateKeeper_{std::move(gateKeeper)},
+      collector_{collector} {}
 
 IScheduler::WireId<IScheduler::Boolean> LazyScheduler::privateBooleanInput(
     bool v,

--- a/fbpcf/scheduler/LazyScheduler.h
+++ b/fbpcf/scheduler/LazyScheduler.h
@@ -29,7 +29,7 @@ class LazyScheduler final : public IScheduler {
       std::shared_ptr<IWireKeeper> wireKeeper,
       std::unique_ptr<IGateKeeper> gateKeeper,
       std::shared_ptr<util::MetricCollector> collector =
-          std::make_shared<util::MetricCollector>("scheduler"));
+          std::make_shared<util::MetricCollector>("lazy_scheduler"));
 
   //======== Below are input processing APIs: ========
 

--- a/fbpcf/scheduler/LazyScheduler.h
+++ b/fbpcf/scheduler/LazyScheduler.h
@@ -12,6 +12,7 @@
 #include "fbpcf/scheduler/IScheduler.h"
 #include "fbpcf/scheduler/IWireKeeper.h"
 #include "fbpcf/scheduler/gate_keeper/IGateKeeper.h"
+#include "fbpcf/util/MetricCollector.h"
 
 namespace fbpcf::scheduler {
 
@@ -26,7 +27,9 @@ class LazyScheduler final : public IScheduler {
   explicit LazyScheduler(
       std::unique_ptr<engine::ISecretShareEngine> engine,
       std::shared_ptr<IWireKeeper> wireKeeper,
-      std::unique_ptr<IGateKeeper> gateKeeper);
+      std::unique_ptr<IGateKeeper> gateKeeper,
+      std::shared_ptr<util::MetricCollector> collector =
+          std::make_shared<util::MetricCollector>("scheduler"));
 
   //======== Below are input processing APIs: ========
 
@@ -311,6 +314,7 @@ class LazyScheduler final : public IScheduler {
   std::unique_ptr<engine::ISecretShareEngine> engine_;
   std::shared_ptr<IWireKeeper> wireKeeper_;
   std::unique_ptr<IGateKeeper> gateKeeper_;
+  std::shared_ptr<util::MetricCollector> collector_;
 
   // Compute the value for the given wire if it hasn't been set already.
   template <bool usingBatch>

--- a/fbpcf/scheduler/PlaintextScheduler.cpp
+++ b/fbpcf/scheduler/PlaintextScheduler.cpp
@@ -13,8 +13,10 @@
 
 namespace fbpcf::scheduler {
 
-PlaintextScheduler::PlaintextScheduler(std::unique_ptr<IWireKeeper> wireKeeper)
-    : wireKeeper_{std::move(wireKeeper)} {}
+PlaintextScheduler::PlaintextScheduler(
+    std::unique_ptr<IWireKeeper> wireKeeper,
+    std::shared_ptr<util::MetricCollector> collector)
+    : wireKeeper_{std::move(wireKeeper)}, collector_{collector} {}
 
 IScheduler::WireId<IScheduler::Boolean> PlaintextScheduler::privateBooleanInput(
     bool v,

--- a/fbpcf/scheduler/PlaintextScheduler.h
+++ b/fbpcf/scheduler/PlaintextScheduler.h
@@ -10,6 +10,7 @@
 #include <memory>
 #include "fbpcf/scheduler/IScheduler.h"
 #include "fbpcf/scheduler/IWireKeeper.h"
+#include "fbpcf/util/MetricCollector.h"
 
 namespace fbpcf::scheduler {
 /**
@@ -26,7 +27,10 @@ namespace fbpcf::scheduler {
 
 class PlaintextScheduler : public IScheduler {
  public:
-  explicit PlaintextScheduler(std::unique_ptr<IWireKeeper> wireKeeper);
+  explicit PlaintextScheduler(
+      std::unique_ptr<IWireKeeper> wireKeeper,
+      std::shared_ptr<util::MetricCollector> collector =
+          std::make_shared<util::MetricCollector>("scheduler"));
 
   //======== Below are input processing APIs: ========
 
@@ -311,6 +315,7 @@ class PlaintextScheduler : public IScheduler {
 
  protected:
   std::unique_ptr<IWireKeeper> wireKeeper_;
+  std::shared_ptr<util::MetricCollector> collector_;
 
  private:
   std::vector<IScheduler::WireId<IScheduler::Boolean>> computeCompositeAND(

--- a/fbpcf/scheduler/PlaintextScheduler.h
+++ b/fbpcf/scheduler/PlaintextScheduler.h
@@ -30,7 +30,7 @@ class PlaintextScheduler : public IScheduler {
   explicit PlaintextScheduler(
       std::unique_ptr<IWireKeeper> wireKeeper,
       std::shared_ptr<util::MetricCollector> collector =
-          std::make_shared<util::MetricCollector>("scheduler"));
+          std::make_shared<util::MetricCollector>("plaintext_scheduler"));
 
   //======== Below are input processing APIs: ========
 


### PR DESCRIPTION
Summary: Updated the constructors of each scheduler implementation (eager/lazy/plaintext) in a backward compatible way to allow pass in a `shared_pointer` of the metric collector.

Differential Revision: D38318467

