### PR TITLE
Add support to open integer secrets in SSE communication agent

### DIFF
--- a/fbpcf/engine/communication/ISecretShareEngineCommunicationAgent.h
+++ b/fbpcf/engine/communication/ISecretShareEngineCommunicationAgent.h
@@ -7,6 +7,7 @@
 
 #pragma once
 #include <emmintrin.h>
+#include <cstdint>
 #include <map>
 #include <vector>
 
@@ -40,6 +41,14 @@ class ISecretShareEngineCommunicationAgent {
       const std::vector<bool>& secretShares) = 0;
 
   /**
+   * Jointly open a vector of secrets to every party.
+   * @param secretShares my share of the secrets
+   * @return the revealed secrets
+   */
+  virtual std::vector<uint64_t> openSecretsToAll(
+      const std::vector<uint64_t>& secretShares) = 0;
+
+  /**
    * Jointly open a vector of secrets to a particular party.
    * @param id the the party to revcvevive the secrets.
    * @param secretShares my share of the secrets
@@ -49,6 +58,17 @@ class ISecretShareEngineCommunicationAgent {
   virtual std::vector<bool> openSecretsToParty(
       int id,
       const std::vector<bool>& secretShares) = 0;
+
+  /**
+   * Jointly open a vector of secrets to a particular party.
+   * @param id the the party to revcvevive the secrets.
+   * @param secretShares my share of the secrets
+   * @return the revealed secrets if this party is designed to received them;
+   * otherwise an array of dummy values
+   */
+  virtual std::vector<uint64_t> openSecretsToParty(
+      int id,
+      const std::vector<uint64_t>& secretShares) = 0;
 
   /**
    * Get the total amount of traffic transmitted.

--- a/fbpcf/engine/communication/InMemoryPartyCommunicationAgentHost.cpp
+++ b/fbpcf/engine/communication/InMemoryPartyCommunicationAgentHost.cpp
@@ -16,11 +16,6 @@ void InMemoryPartyCommunicationAgent::sendImpl(const void* data, int nBytes) {
   sentData_ += nBytes;
 }
 
-void InMemoryPartyCommunicationAgent::send(
-    const std::vector<unsigned char>& data) {
-  sendImpl(static_cast<const void*>(data.data()), data.size());
-}
-
 void InMemoryPartyCommunicationAgent::recvImpl(void* data, int nBytes) {
   auto result = host_.receive(myId_, nBytes);
 
@@ -29,13 +24,6 @@ void InMemoryPartyCommunicationAgent::recvImpl(void* data, int nBytes) {
   }
   memcpy(data, result.data(), nBytes);
   receivedData_ += nBytes;
-}
-
-std::vector<unsigned char> InMemoryPartyCommunicationAgent::receive(
-    size_t size) {
-  std::vector<unsigned char> v(size);
-  recvImpl(static_cast<void*>(v.data()), size);
-  return v;
 }
 
 InMemoryPartyCommunicationAgentHost::InMemoryPartyCommunicationAgentHost() {

--- a/fbpcf/engine/communication/InMemoryPartyCommunicationAgentHost.h
+++ b/fbpcf/engine/communication/InMemoryPartyCommunicationAgentHost.h
@@ -28,15 +28,6 @@ class InMemoryPartyCommunicationAgent final : public IPartyCommunicationAgent {
       InMemoryPartyCommunicationAgentHost& host,
       int myId)
       : host_{host}, myId_(myId), sentData_(0), receivedData_(0) {}
-  /**
-   * @inherit doc
-   */
-  void send(const std::vector<unsigned char>& data) override;
-
-  /**
-   * @inherit doc
-   */
-  std::vector<unsigned char> receive(size_t size) override;
 
   /**
    * @inherit doc

--- a/fbpcf/engine/communication/SecretShareEngineCommunicationAgent.h
+++ b/fbpcf/engine/communication/SecretShareEngineCommunicationAgent.h
@@ -6,6 +6,7 @@
  */
 
 #pragma once
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <vector>
@@ -41,9 +42,22 @@ class SecretShareEngineCommunicationAgent final
   /**
    * @inherit doc
    */
+  std::vector<uint64_t> openSecretsToAll(
+      const std::vector<uint64_t>& secretShares) override;
+
+  /**
+   * @inherit doc
+   */
   std::vector<bool> openSecretsToParty(
       int id,
       const std::vector<bool>& secretShares) override;
+
+  /**
+   * @inherit doc
+   */
+  std::vector<uint64_t> openSecretsToParty(
+      int id,
+      const std::vector<uint64_t>& secretShares) override;
 
   /**
    * @inherit doc

--- a/fbpcf/engine/communication/SocketPartyCommunicationAgent.cpp
+++ b/fbpcf/engine/communication/SocketPartyCommunicationAgent.cpp
@@ -104,11 +104,6 @@ void SocketPartyCommunicationAgent::sendImpl(const void* data, int nBytes) {
   }
 }
 
-void SocketPartyCommunicationAgent::send(
-    const std::vector<unsigned char>& data) {
-  sendImpl(static_cast<const void*>(data.data()), data.size());
-}
-
 void SocketPartyCommunicationAgent::recvImpl(void* data, int nBytes) {
   size_t bytesRead = 0;
 
@@ -128,12 +123,6 @@ void SocketPartyCommunicationAgent::recvImpl(void* data, int nBytes) {
   }
   assert(bytesRead == nBytes);
   recorder_->addReceivedData(bytesRead);
-}
-
-std::vector<unsigned char> SocketPartyCommunicationAgent::receive(size_t size) {
-  std::vector<unsigned char> rst(size);
-  recvImpl(static_cast<void*>(rst.data()), size);
-  return rst;
 }
 
 void SocketPartyCommunicationAgent::openServerPort(int sockFd, int portNo) {

--- a/fbpcf/engine/communication/SocketPartyCommunicationAgent.h
+++ b/fbpcf/engine/communication/SocketPartyCommunicationAgent.h
@@ -46,16 +46,6 @@ class SocketPartyCommunicationAgent final : public IPartyCommunicationAgent {
   /**
    * @inherit doc
    */
-  void send(const std::vector<unsigned char>& data) override;
-
-  /**
-   * @inherit doc
-   */
-  std::vector<unsigned char> receive(size_t size) override;
-
-  /**
-   * @inherit doc
-   */
   std::pair<uint64_t, uint64_t> getTrafficStatistics() const override {
     return recorder_->getTrafficStatistics();
   }

--- a/fbpcf/scheduler/NetworkPlaintextScheduler.h
+++ b/fbpcf/scheduler/NetworkPlaintextScheduler.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <map>
 #include <memory>
 
@@ -57,6 +58,30 @@ class NetworkPlaintextScheduler final : public PlaintextScheduler {
   WireId<IScheduler::Boolean> recoverBooleanWireBatch(
       const std::vector<bool>& v) override;
 
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privateIntegerInput(uint64_t v, int partyId)
+      override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privateIntegerInputBatch(
+      const std::vector<uint64_t>& v,
+      int partyId) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> recoverIntegerWire(uint64_t v) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> recoverIntegerWireBatch(
+      const std::vector<uint64_t>& v) override;
+
   //======== Below are output processing APIs: ========
 
   /**
@@ -69,6 +94,18 @@ class NetworkPlaintextScheduler final : public PlaintextScheduler {
    */
   std::vector<bool> extractBooleanSecretShareBatch(
       WireId<IScheduler::Boolean> id) override;
+
+  /**
+   * @inherit doc
+   */
+  uint64_t extractIntegerSecretShare(
+      WireId<IScheduler::Arithmetic> id) override;
+
+  /**
+   * @inherit doc
+   */
+  std::vector<uint64_t> extractIntegerSecretShareBatch(
+      WireId<IScheduler::Arithmetic> id) override;
 
   //======== Below are miscellaneous APIs: ========
 

--- a/fbpcf/scheduler/PlaintextScheduler.h
+++ b/fbpcf/scheduler/PlaintextScheduler.h
@@ -7,7 +7,10 @@
 
 #pragma once
 
+#include <sys/types.h>
+#include <cstdint>
 #include <memory>
+#include "fbpcf/scheduler/IArithmeticScheduler.h"
 #include "fbpcf/scheduler/IScheduler.h"
 #include "fbpcf/scheduler/IWireKeeper.h"
 
@@ -24,7 +27,7 @@ namespace fbpcf::scheduler {
  * cryptographically secure computations).
  */
 
-class PlaintextScheduler : public IScheduler {
+class PlaintextScheduler : public IArithmeticScheduler {
  public:
   explicit PlaintextScheduler(std::unique_ptr<IWireKeeper> wireKeeper);
 
@@ -38,8 +41,21 @@ class PlaintextScheduler : public IScheduler {
   /**
    * @inherit doc
    */
+  WireId<IScheduler::Arithmetic> privateIntegerInput(uint64_t v, int partyId)
+      override;
+
+  /**
+   * @inherit doc
+   */
   WireId<IScheduler::Boolean> privateBooleanInputBatch(
       const std::vector<bool>& v,
+      int partyId) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privateIntegerInputBatch(
+      const std::vector<uint64_t>& v,
       int partyId) override;
 
   /**
@@ -50,8 +66,19 @@ class PlaintextScheduler : public IScheduler {
   /**
    * @inherit doc
    */
+  WireId<IScheduler::Arithmetic> publicIntegerInput(uint64_t v) override;
+
+  /**
+   * @inherit doc
+   */
   WireId<IScheduler::Boolean> publicBooleanInputBatch(
       const std::vector<bool>& v) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> publicIntegerInputBatch(
+      const std::vector<uint64_t>& v) override;
 
   /**
    * @inherit doc
@@ -61,8 +88,19 @@ class PlaintextScheduler : public IScheduler {
   /**
    * @inherit doc
    */
+  WireId<IScheduler::Arithmetic> recoverIntegerWire(uint64_t v) override;
+
+  /**
+   * @inherit doc
+   */
   WireId<IScheduler::Boolean> recoverBooleanWireBatch(
       const std::vector<bool>& v) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> recoverIntegerWireBatch(
+      const std::vector<uint64_t>& v) override;
 
   //======== Below are output processing APIs: ========
   /**
@@ -75,8 +113,22 @@ class PlaintextScheduler : public IScheduler {
   /**
    * @inherit doc
    */
+  WireId<IScheduler::Arithmetic> openIntegerValueToParty(
+      WireId<IScheduler::Arithmetic> src,
+      int partyId) override;
+
+  /**
+   * @inherit doc
+   */
   WireId<IScheduler::Boolean> openBooleanValueToPartyBatch(
       WireId<IScheduler::Boolean> src,
+      int partyId) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> openIntegerValueToPartyBatch(
+      WireId<IScheduler::Arithmetic> src,
       int partyId) override;
 
   /**
@@ -87,8 +139,20 @@ class PlaintextScheduler : public IScheduler {
   /**
    * @inherit doc
    */
+  uint64_t extractIntegerSecretShare(
+      WireId<IScheduler::Arithmetic> id) override;
+
+  /**
+   * @inherit doc
+   */
   std::vector<bool> extractBooleanSecretShareBatch(
       WireId<IScheduler::Boolean> id) override;
+
+  /**
+   * @inherit doc
+   */
+  std::vector<uint64_t> extractIntegerSecretShareBatch(
+      WireId<IScheduler::Arithmetic> id) override;
 
   /**
    * @inherit doc
@@ -98,8 +162,19 @@ class PlaintextScheduler : public IScheduler {
   /**
    * @inherit doc
    */
+  uint64_t getIntegerValue(WireId<IScheduler::Arithmetic> id) override;
+
+  /**
+   * @inherit doc
+   */
   std::vector<bool> getBooleanValueBatch(
       WireId<IScheduler::Boolean> id) override;
+
+  /**
+   * @inherit doc
+   */
+  std::vector<uint64_t> getIntegerValueBatch(
+      WireId<IScheduler::Arithmetic> id) override;
 
   //======== Below are computation APIs: ========
 
@@ -261,6 +336,120 @@ class PlaintextScheduler : public IScheduler {
   WireId<IScheduler::Boolean> notPublicBatch(
       WireId<IScheduler::Boolean> src) override;
 
+  // ------ Plus gates ------
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privatePlusPrivate(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privatePlusPrivateBatch(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privatePlusPublic(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privatePlusPublicBatch(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> publicPlusPublic(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> publicPlusPublicBatch(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right) override;
+
+  // ------ Mult gates ------
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privateMultPrivate(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privateMultPrivateBatch(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privateMultPublic(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privateMultPublicBatch(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> publicMultPublic(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> publicMultPublicBatch(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right) override;
+
+  // ------ Neg gates ------
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> negPrivate(
+      WireId<IScheduler::Arithmetic> src) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> negPrivateBatch(
+      WireId<IScheduler::Arithmetic> src) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> negPublic(
+      WireId<IScheduler::Arithmetic> src) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> negPublicBatch(
+      WireId<IScheduler::Arithmetic> src) override;
+
   //======== Below are wire management APIs: ========
 
   /**
@@ -282,6 +471,26 @@ class PlaintextScheduler : public IScheduler {
    * @inherit doc
    */
   void decreaseReferenceCountBatch(WireId<IScheduler::Boolean> id) override;
+
+  /**
+   * @inherit doc
+   */
+  void increaseReferenceCount(WireId<IScheduler::Arithmetic> src) override;
+
+  /**
+   * @inherit doc
+   */
+  void increaseReferenceCountBatch(WireId<IScheduler::Arithmetic> src) override;
+
+  /**
+   * @inherit doc
+   */
+  void decreaseReferenceCount(WireId<IScheduler::Arithmetic> id) override;
+
+  /**
+   * @inherit doc
+   */
+  void decreaseReferenceCountBatch(WireId<IScheduler::Arithmetic> id) override;
 
   //======== Below are rebatching APIs: ========
 

--- a/fbpcf/scheduler/SchedulerHelper.h
+++ b/fbpcf/scheduler/SchedulerHelper.h
@@ -43,6 +43,29 @@ inline std::unique_ptr<IScheduler> createNetworkPlaintextScheduler(
       myId, std::move(agentMap), WireKeeper::createWithVectorArena<unsafe>());
 }
 
+template <bool unsafe>
+inline std::unique_ptr<IArithmeticScheduler> createArithmeticPlaintextScheduler(
+    int /*myId*/,
+    engine::communication::IPartyCommunicationAgentFactory&
+    /*communicationAgentFactory*/) {
+  return std::make_unique<PlaintextScheduler>(
+      WireKeeper::createWithVectorArena<unsafe>());
+}
+
+template <bool unsafe>
+inline std::unique_ptr<IArithmeticScheduler>
+createArithmeticNetworkPlaintextScheduler(
+    int myId,
+    engine::communication::IPartyCommunicationAgentFactory&
+        communicationAgentFactory) {
+  auto numberOfParties = 2;
+  auto agentMap = engine::communication::getAgentMap(
+      numberOfParties, myId, communicationAgentFactory);
+
+  return std::make_unique<NetworkPlaintextScheduler>(
+      myId, std::move(agentMap), WireKeeper::createWithVectorArena<unsafe>());
+}
+
 // this function creates a eager scheduler with real secure engine
 inline std::unique_ptr<IScheduler> createEagerSchedulerWithRealEngine(
     int myId,

--- a/fbpcf/test/TestHelper.h
+++ b/fbpcf/test/TestHelper.h
@@ -11,7 +11,9 @@
 
 #include <emmintrin.h>
 #include <smmintrin.h>
+#include <stdexcept>
 
+#include <fbpcf/scheduler/IArithmeticScheduler.h>
 #include "fbpcf/engine/SecretShareEngineFactory.h"
 #include "fbpcf/engine/communication/IPartyCommunicationAgentFactory.h"
 #include "fbpcf/scheduler/IScheduler.h"
@@ -91,6 +93,27 @@ inline SchedulerCreator getSchedulerCreator(SchedulerType schedulerType) {
       return scheduler::createEagerSchedulerWithInsecureEngine<unsafe>;
     case SchedulerType::Lazy:
       return scheduler::createLazySchedulerWithInsecureEngine<unsafe>;
+  }
+}
+
+using ArithmeticSchedulerCreator =
+    std::function<std::unique_ptr<scheduler::IArithmeticScheduler>(
+        int myId,
+        engine::communication::IPartyCommunicationAgentFactory&
+            communicationAgentFactory)>;
+
+template <bool unsafe>
+inline ArithmeticSchedulerCreator getArithmeticSchedulerCreator(
+    SchedulerType schedulerType) {
+  switch (schedulerType) {
+    case SchedulerType::Plaintext:
+      return scheduler::createArithmeticPlaintextScheduler<unsafe>;
+    case SchedulerType::NetworkPlaintext:
+      return scheduler::createArithmeticNetworkPlaintextScheduler<unsafe>;
+    case SchedulerType::Eager:
+      throw std::runtime_error("unimplemented");
+    case SchedulerType::Lazy:
+      throw std::runtime_error("unimplemented");
   }
 }
 


### PR DESCRIPTION
Summary: Add the integer version of openSecretsToAll and openSecretsToParty in the secret share engine communication agent for future use in the secret share engine arithmetic operation implementation.

Differential Revision: D38329176

