### PR TITLE
Fix broken AsciiString Test

### DIFF
--- a/example/edit_distance/AsciiString.h
+++ b/example/edit_distance/AsciiString.h
@@ -85,16 +85,11 @@ class AsciiString : public scheduler::SchedulerKeeper<schedulerId> {
         std::vector<std::string> rst(batchSize);
         for (size_t i = 0; i < batchSize; i++) {
           rst[i].reserve(maxWidth);
-          if (chars[i] != 0) {
-            rst[i].push_back(chars[i]);
-          }
         }
-        for (size_t j = 1; j < maxWidth; j++) {
+        for (size_t j = 0; j < maxWidth; j++) {
           chars = convertLongsToChar(data_[j].getValue());
           for (size_t i = 0; i < batchSize; i++) {
-            if (chars[i] != 0) {
-              rst[i].push_back(chars[i]);
-            }
+            rst[i].push_back(chars[i]);
           }
         }
         return rst;


### PR DESCRIPTION
Summary: Fixing the broken test in T127614039. Seems the changes in D38231945 (https://github.com/facebookresearch/fbpcf/commit/416ab36f0627383034be53e3a68c76bbbddf9dbc) had a bug. I was able to re-create this locally with a stress test. Turns out when one of the character "shares" is set to 0, calling getValue() will not include it in the string. This means the string form of the extracted signed characters will be missing a letter. When we call parse JSON on this and try to XOR the shares, they are misaligned and the answer is bogus.

Differential Revision: D38334286

