### PR TITLE
Add Validator class

### DIFF
--- a/example/edit_distance/EditDistanceResults.h
+++ b/example/edit_distance/EditDistanceResults.h
@@ -13,7 +13,7 @@
 
 namespace fbpcf::edit_distance {
 struct EditDistanceResults {
-  EditDistanceResults() = delete;
+  EditDistanceResults() = default;
   explicit EditDistanceResults(std::vector<folly::dynamic>& individualShares) {
     if (individualShares.empty()) {
       throw common::exceptions::ConstructionError("No shares to recover.");

--- a/example/edit_distance/Validator.cpp
+++ b/example/edit_distance/Validator.cpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <folly/json.h>
+#include <folly/logging/xlog.h>
+#include <math.h>
+#include <sstream>
+
+#include "./Validator.h" // @manual
+#include "fbpcf/exception/exceptions.h"
+#include "fbpcf/io/api/FileIOWrappers.h"
+
+namespace fbpcf::edit_distance {
+
+int Validator::validate() {
+  std::vector<folly::dynamic> shares;
+
+  for (auto& outputPath : outputPaths_) {
+    auto sharesJson = io::FileIOWrappers::readFile(outputPath);
+    shares.push_back(folly::parseJson(sharesJson));
+  }
+
+  actualResults_ = EditDistanceResults(shares);
+
+  io::FileIOWrappers::readCsv(
+      expectedOutputPath_,
+      [&](const std::vector<std::string>& header,
+          const std::vector<std::string>& parts) {
+        appendOutputLine(header, parts);
+      });
+
+  if (actualResults_.editDistances.size() !=
+      expectedResults_.editDistances.size()) {
+    XLOGF(
+        ERR,
+        "Mismatched size in edit distance results. Expected {} elements but got {}",
+        expectedResults_.editDistances.size(),
+        actualResults_.editDistances.size());
+    return Validator::SIZE_MISMATCH;
+  }
+
+  if (actualResults_.receiverMessages.size() !=
+      expectedResults_.receiverMessages.size()) {
+    XLOGF(
+        ERR,
+        "Mismatched size in receiver message results. Expected {} elements but got {}",
+        expectedResults_.receiverMessages.size(),
+        actualResults_.receiverMessages.size());
+    return Validator::SIZE_MISMATCH;
+  }
+
+  for (int i = 0; i < actualResults_.editDistances.size(); i++) {
+    if (actualResults_.editDistances[i] != expectedResults_.editDistances[i]) {
+      XLOGF(
+          ERR,
+          "Mismatch in results for edit distance at index {}. Expected {} but got {}",
+          i,
+          expectedResults_.editDistances[i],
+          actualResults_.editDistances[i]);
+      return Validator::RESULT_MISMATCH;
+    }
+    if (actualResults_.receiverMessages[i] !=
+        expectedResults_.receiverMessages[i]) {
+      XLOGF(
+          ERR,
+          "Mismatch in results for receiver message at index {}. Expected {} but got {}",
+          i,
+          expectedResults_.receiverMessages[i],
+          actualResults_.receiverMessages[i]);
+      return Validator::RESULT_MISMATCH;
+    }
+  }
+
+  return Validator::SUCCESS;
+}
+
+void Validator::appendOutputLine(
+    const std::vector<std::string>& header,
+    const std::vector<std::string>& parts) {
+  for (size_t i = 0; i < header.size(); i++) {
+    const std::string& column = header[i];
+    const std::string& value = parts[i];
+    std::istringstream iss{value};
+
+    int64_t parsed = 0;
+
+    if (column == "distance") {
+      iss >> parsed;
+      expectedResults_.editDistances.push_back(parsed);
+    } else if (column == "receiver_message") {
+      expectedResults_.receiverMessages.push_back(value);
+    }
+  }
+}
+
+} // namespace fbpcf::edit_distance

--- a/example/edit_distance/Validator.h
+++ b/example/edit_distance/Validator.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include "./EditDistanceResults.h" // @manual
+
+namespace fbpcf::edit_distance {
+
+class Validator {
+ public:
+  enum {
+    SUCCESS = 0,
+    SIZE_MISMATCH = 1,
+    RESULT_MISMATCH = 2,
+  };
+
+  explicit Validator(
+      std::vector<std::string>& outputSharePaths,
+      std::string expectedOutputPath)
+      : outputPaths_(outputSharePaths),
+        expectedOutputPath_(expectedOutputPath) {}
+
+  int validate();
+
+ private:
+  void appendOutputLine(
+      const std::vector<std::string>& header,
+      const std::vector<std::string>& parts);
+
+  std::vector<std::string> outputPaths_;
+  std::string expectedOutputPath_;
+
+  EditDistanceResults actualResults_;
+  EditDistanceResults expectedResults_;
+};
+
+} // namespace fbpcf::edit_distance

--- a/example/edit_distance/test/ValidatorTest.cpp
+++ b/example/edit_distance/test/ValidatorTest.cpp
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <folly/Format.h>
+#include <gtest/gtest.h>
+#include <fstream>
+#include "folly/Random.h"
+#include "tools/cxx/Resources.h"
+
+#include "../EditDistanceApp.h" // @manual
+#include "../Validator.h" // @manual
+#include "fbpcf/engine/communication/test/AgentFactoryCreationHelper.h"
+#include "fbpcf/test/TestHelper.h"
+
+namespace fbpcf::edit_distance {
+
+static std::string getBaseDirFromPath(const std::string& filePath) {
+  return filePath.substr(0, filePath.rfind("/") + 1);
+}
+
+static void cleanup(std::string file_to_delete) {
+  remove(file_to_delete.c_str());
+}
+
+static std::string randomOutFile() {
+  std::string baseDir = getBaseDirFromPath(__FILE__);
+  return folly::sformat(
+      "{}test_data/edit_distance_output_{}.json",
+      baseDir,
+      folly::Random::secureRand64());
+}
+
+Validator runTest(
+    const char* resultsEnvName,
+    std::string outFilepath1,
+    std::string outFilepath2) {
+  boost::filesystem::path dataFilepath1 =
+      build::getResourcePath(std::getenv("DATA_FILE_PATH_1"));
+
+  boost::filesystem::path dataFilepath2 =
+      build::getResourcePath(std::getenv("DATA_FILE_PATH_2"));
+  boost::filesystem::path paramsFilePath =
+      build::getResourcePath(std::getenv("PARAMS_FILE_PATH"));
+
+  boost::filesystem::path resultsFilePath =
+      build::getResourcePath(std::getenv(resultsEnvName));
+
+  auto factories = engine::communication::getInMemoryAgentFactory(2);
+
+  auto player0App = EditDistanceApp<0>(
+      0,
+      std::move(factories[0]),
+      dataFilepath1.native(),
+      paramsFilePath.native(),
+      outFilepath1);
+
+  auto player1App = EditDistanceApp<1>(
+      1,
+      std::move(factories[1]),
+      dataFilepath2.native(),
+      paramsFilePath.native(),
+      outFilepath2);
+
+  auto future0 = std::async([&player0App]() { player0App.run(); });
+  auto future1 = std::async([&player1App]() { player1App.run(); });
+
+  std::vector<std::string> outpaths = {outFilepath1, outFilepath2};
+
+  future0.get();
+  future1.get();
+
+  Validator validator(outpaths, resultsFilePath.native());
+
+  return validator;
+}
+
+TEST(ValidatorTest, testValidator) {
+  std::string outFilepath1 = randomOutFile();
+  std::string outFilepath2 = randomOutFile();
+  Validator validator =
+      runTest("RESULTS_FILE_PATH", outFilepath1, outFilepath2);
+  EXPECT_EQ(validator.validate(), Validator::SUCCESS);
+  cleanup(outFilepath1);
+  cleanup(outFilepath2);
+}
+
+TEST(ValidatorTest, testValidatorFails) {
+  std::string outFilepath1 = randomOutFile();
+  std::string outFilepath2 = randomOutFile();
+  Validator validator =
+      runTest("INCORRECT_RESULTS_FILE_PATH", outFilepath1, outFilepath2);
+  EXPECT_EQ(validator.validate(), Validator::RESULT_MISMATCH);
+  cleanup(outFilepath1);
+  cleanup(outFilepath2);
+}
+
+TEST(ValidatorTest, testValidatorFailsSize) {
+  std::string outFilepath1 = randomOutFile();
+  std::string outFilepath2 = randomOutFile();
+  Validator validator =
+      runTest("INCORRECT_SIZE_RESULTS_FILE_PATH", outFilepath1, outFilepath2);
+  EXPECT_EQ(validator.validate(), Validator::RESULT_MISMATCH);
+  cleanup(outFilepath1);
+  cleanup(outFilepath2);
+}
+
+TEST(ValidatorTest, testValidatorFailsMessage) {
+  std::string outFilepath1 = randomOutFile();
+  std::string outFilepath2 = randomOutFile();
+  Validator validator = runTest(
+      "INCORRECT_MESSAGE_RESULTS_FILE_PATH", outFilepath1, outFilepath2);
+  EXPECT_EQ(validator.validate(), Validator::SIZE_MISMATCH);
+  cleanup(outFilepath1);
+  cleanup(outFilepath2);
+}
+
+} // namespace fbpcf::edit_distance

--- a/example/edit_distance/test/test_data/edit_distance_incorrect_message_test_results.csv
+++ b/example/edit_distance/test/test_data/edit_distance_incorrect_message_test_results.csv
@@ -1,0 +1,6 @@
+distance,receiver_message
+131,b
+81,soft
+0,hello
+315,
+20,extra

--- a/example/edit_distance/test/test_data/edit_distance_incorrect_size_test_results.csv
+++ b/example/edit_distance/test/test_data/edit_distance_incorrect_size_test_results.csv
@@ -1,0 +1,5 @@
+distance,receiver_message
+131,b
+81,soft
+0,wrong
+315,

--- a/example/edit_distance/test/test_data/edit_distance_incorrect_test_results.csv
+++ b/example/edit_distance/test/test_data/edit_distance_incorrect_test_results.csv
@@ -1,0 +1,5 @@
+distance,receiver_message
+1,jello
+0,jello
+0,jello
+0,jello


### PR DESCRIPTION
Summary:
Adds the validation step of the Edit distance application. The constructor accepts the output file paths of the shares, and then recovers them using the `EditDistanceResults` class. It will then read the ground truth results file and compare the end result.

Side note: The EditDistanceResults class technically surpasses extractIntShare() and openToParty methods which would make more sense as a reveal stage. For now I think this is fine, but if we have different MPC backends to test then we should use the native MPC API's to "reveal" the results to one of the players. I will put this on our backlog as a BE.

Differential Revision: D38260494

