### PR TITLE
Adding methods in AggMetrics to support threshold checking

### DIFF
--- a/fbpcf/exception/exceptions.h
+++ b/fbpcf/exception/exceptions.h
@@ -129,6 +129,22 @@ class NotImplementedError : virtual public std::exception {
 
 /**
  * When to use:
+ *  - throw when a method/procedure is/will no longer be supported.
+ */
+class NotSupportedError : virtual public std::exception {
+ public:
+  explicit NotSupportedError(std::string msg) : msg_{msg} {}
+
+  const char* what() const throw() override {
+    return msg_.c_str();
+  }
+
+ private:
+  std::string msg_;
+};
+
+/**
+ * When to use:
  *  - When we are trying to access an illegal variable.
  *    - Example: when a AggMetric<AggMetricType::kPlaintext> object tries to
  *      access getSecValueXor().


### PR DESCRIPTION
Summary:
# context
Add supporting methods for threshold checking.

## whats needed?
0. we want to read a public threshold value in the mpc game.
1. a function that lets us check if a metrics is >= to something.
2. if the above condition fails we need a mux to replace the metric with a sentinel value (like -1).

Reviewed By: chualynn, anthonyzhang25

Differential Revision: D38173049

