### PR TITLE
Lazy Scheduler support for arithmetic operation

### DIFF
--- a/fbpcf/engine/DummySecretShareEngine.h
+++ b/fbpcf/engine/DummySecretShareEngine.h
@@ -196,11 +196,6 @@ class DummySecretShareEngine final : public ISecretShareEngine {
   /**
    * @inherit doc
    */
-  void executeScheduledAND() override {}
-
-  /**
-   * @inherit doc
-   */
   std::vector<bool> computeBatchANDImmediately(
       const std::vector<bool>& left,
       const std::vector<bool>& right) override {
@@ -338,6 +333,85 @@ class DummySecretShareEngine final : public ISecretShareEngine {
     return input;
   }
 
+  //======== Below are free Mult computation API's: ========
+
+  /**
+   * @inherit doc
+   */
+  uint64_t computeFreeMult(
+      [[maybe_unused]] uint64_t left,
+      [[maybe_unused]] uint64_t right) const override {
+    return 0;
+  }
+
+  /**
+   * @inherit doc
+   */
+  std::vector<uint64_t> computeBatchFreeMult(
+      const std::vector<uint64_t>& left,
+      const std::vector<uint64_t>& right) const override {
+    if (left.size() != right.size()) {
+      throw std::invalid_argument("The input sizes are not the same.");
+    }
+    return left;
+  }
+
+  //======== Below are API's to schedule non-free Mult's: ========
+
+  /**
+   * @inherit doc
+   */
+  uint32_t scheduleMult(
+      [[maybe_unused]] uint64_t left,
+      [[maybe_unused]] uint64_t right) override {
+    return 0;
+  }
+
+  /**
+   * @inherit doc
+   */
+  uint32_t scheduleBatchMult(
+      const std::vector<uint64_t>& left,
+      const std::vector<uint64_t>& right) override {
+    if (left.size() != right.size()) {
+      throw std::runtime_error("Batch Mult's must have the same length");
+    }
+    dummyBatchMultResults_.push_back(left);
+    return dummyBatchMultResults_.size() - 1;
+  }
+
+  //======== Below are API's to execute non free Mult's: ========
+
+  /**
+   * @inherit doc
+   */
+  std::vector<uint64_t> computeBatchMultImmediately(
+      const std::vector<uint64_t>& left,
+      const std::vector<uint64_t>& right) override {
+    if (left.size() != right.size()) {
+      throw std::runtime_error("Left and right must have equal length");
+    }
+    return left;
+  }
+
+  //======== Below are API's to retrieve non-free Mult results: ========
+
+  /**
+   * @inherit doc
+   */
+  uint64_t getMultExecutionResult(
+      [[maybe_unused]] uint32_t index) const override {
+    return 0;
+  }
+
+  /**
+   * @inherit doc
+   */
+  const std::vector<uint64_t>& getBatchMultExecutionResult(
+      uint32_t index) const override {
+    return dummyBatchMultResults_.at(index);
+  }
+
   /**
    * @inherit doc
    */
@@ -347,10 +421,18 @@ class DummySecretShareEngine final : public ISecretShareEngine {
     return output;
   }
 
+  //======== Below are API's to execute non free AND's and Mult's: ========
+  /**
+   * @inherit doc
+   */
+  void executeScheduledOperations() override {}
+
  private:
   std::vector<std::vector<bool>> dummyBatchANDResults_;
   std::vector<std::vector<bool>> dummyCompositeANDResults_;
   std::vector<std::vector<std::vector<bool>>> dummyCompositeBatchANDResults_;
+
+  std::vector<std::vector<uint64_t>> dummyBatchMultResults_;
 
   int myId_;
 };

--- a/fbpcf/engine/DummySecretShareEngine.h
+++ b/fbpcf/engine/DummySecretShareEngine.h
@@ -284,6 +284,63 @@ class DummySecretShareEngine final : public ISecretShareEngine {
   /**
    * @inherit doc
    */
+  uint64_t computeSymmetricPlus(
+      [[maybe_unused]] uint64_t left,
+      [[maybe_unused]] uint64_t right) const override {
+    return 0;
+  }
+
+  /**
+   * @inherit doc
+   */
+  std::vector<uint64_t> computeBatchSymmetricPlus(
+      const std::vector<uint64_t>& left,
+      const std::vector<uint64_t>& right) const override {
+    if (left.size() != right.size()) {
+      throw std::invalid_argument("The input sizes are not the same.");
+    }
+    return left;
+  }
+
+  /**
+   * @inherit doc
+   */
+  uint64_t computeAsymmetricPlus(
+      [[maybe_unused]] uint64_t left,
+      [[maybe_unused]] uint64_t right) const override {
+    return 0;
+  }
+
+  /**
+   * @inherit doc
+   */
+  std::vector<uint64_t> computeBatchAsymmetricPlus(
+      const std::vector<uint64_t>& left,
+      const std::vector<uint64_t>& right) const override {
+    if (left.size() != right.size()) {
+      throw std::invalid_argument("The input sizes are not the same.");
+    }
+    return left;
+  }
+
+  /**
+   * @inherit doc
+   */
+  uint64_t computeSymmetricNeg([[maybe_unused]] uint64_t input) const override {
+    return 0;
+  }
+
+  /**
+   * @inherit doc
+   */
+  std::vector<uint64_t> computeBatchSymmetricNeg(
+      const std::vector<uint64_t>& input) const override {
+    return input;
+  }
+
+  /**
+   * @inherit doc
+   */
   std::vector<uint64_t> revealToParty(
       int /* id*/,
       const std::vector<uint64_t>& output) const override {

--- a/fbpcf/engine/DummySecretShareEngine.h
+++ b/fbpcf/engine/DummySecretShareEngine.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <fmt/format.h>
+#include <cstdint>
 #include <stdexcept>
 #include <vector>
 
@@ -256,6 +257,37 @@ class DummySecretShareEngine final : public ISecretShareEngine {
    */
   std::pair<uint64_t, uint64_t> getTrafficStatistics() const override {
     return {0, 0};
+  }
+
+  /**
+   * @inherit doc
+   */
+  uint64_t setIntegerInput(int id, std::optional<uint64_t> v) override {
+    if (id == myId_ && (!v.has_value())) {
+      throw std::invalid_argument("needs to provide input value");
+    }
+    return 0;
+  }
+
+  /**
+   * @inherit doc
+   */
+  std::vector<uint64_t> setBatchIntegerInput(
+      int id,
+      const std::vector<uint64_t>& v) override {
+    if (id == myId_ && v.size() == 0) {
+      throw std::invalid_argument("empty input!");
+    }
+    return v;
+  }
+
+  /**
+   * @inherit doc
+   */
+  std::vector<uint64_t> revealToParty(
+      int /* id*/,
+      const std::vector<uint64_t>& output) const override {
+    return output;
   }
 
  private:

--- a/fbpcf/engine/ISecretShareEngine.h
+++ b/fbpcf/engine/ISecretShareEngine.h
@@ -86,6 +86,31 @@ class ISecretShareEngine {
       const std::vector<bool>& right) const = 0;
 
   /**
+   * Compute an Plus gate with two private or two public values. This operation
+   * requires all parties to Plus their shares/values (That's why it is
+   * symmetric). This computation can be done locally, without any interaction
+   * with other parties.
+   * @param left the value on left input wire
+   * @param right the value on right input wire
+   * @return the value of the result
+   */
+  virtual uint64_t computeSymmetricPlus(uint64_t left, uint64_t right)
+      const = 0;
+
+  /**
+   * Compute a batch of Plus gates with two private or two public values. This
+   * operation requires all parties to Plus their shares/values (That's why it
+   * is symmetric). This computation can be done locally, without any
+   * interaction with other parties.
+   * @param left the value on left input wire
+   * @param right the value on right input wire
+   * @return the value of the result
+   */
+  virtual std::vector<uint64_t> computeBatchSymmetricPlus(
+      const std::vector<uint64_t>& left,
+      const std::vector<uint64_t>& right) const = 0;
+
+  /**
    * Compute an XOR gate between a private and a public value. This operation
    * requires only one party to XOR his/her share/value (That's why it is
    * asymmetric), others only needs to output left wire value. This computation
@@ -111,6 +136,33 @@ class ISecretShareEngine {
       const std::vector<bool>& right) const = 0;
 
   /**
+   * Compute an Plus gate between a private and a public value. This operation
+   * requires only one party to Plus his/her share/value (That's why it is
+   * asymmetric), others only needs to output left wire value. This computation
+   * can be done locally, without any interaction with other parties.
+   * @param privateValue the value that is private
+   * @param publicValue the value that is public
+   * @return the value of the result
+   */
+  virtual uint64_t computeAsymmetricPlus(
+      uint64_t privateValue,
+      uint64_t publicValue) const = 0;
+
+  /**
+   * Compute a batch of Plus gates with a private and a public values.  This
+   * operation requires only one party to Plus his/her share/value (That's why
+   * it is asymmetric), others only needs to output left wire value. This
+   * computation can be done locally, without any interaction with other
+   * parties.
+   * @param left the value that is private
+   * @param right the value that is public
+   * @return the value of the result
+   */
+  virtual std::vector<uint64_t> computeBatchAsymmetricPlus(
+      const std::vector<uint64_t>& privateValue,
+      const std::vector<uint64_t>& publicValue) const = 0;
+
+  /**
    * Compute a NOT gate on public values, This operation
    * requires all party to flip their shares/values (That's why it is
    * symmetric). This computation can be done locally,
@@ -130,6 +182,27 @@ class ISecretShareEngine {
    */
   virtual std::vector<bool> computeBatchSymmetricNOT(
       const std::vector<bool>& input) const = 0;
+
+  /**
+   * Compute a Neg gate on public values, This operation
+   * requires all party to flip their shares/values (That's why it is
+   * symmetric). This computation can be done locally,
+   * without any interaction with other parties.
+   * @param input the value on left input wire
+   * @return the value of the result
+   */
+  virtual uint64_t computeSymmetricNeg(uint64_t input) const = 0;
+
+  /**
+   * Compute a batch of Neg gate on public values, This operation
+   * requires all party to flip their shares/values (That's why it is
+   * symmetric). This computation can be done locally,
+   * without any interaction with other parties.
+   * @param input the value on left input wire
+   * @return the value of the result
+   */
+  virtual std::vector<uint64_t> computeBatchSymmetricNeg(
+      const std::vector<uint64_t>& input) const = 0;
 
   /**
    * Compute a NOT gate on private values, This operation

--- a/fbpcf/engine/ISecretShareEngine.h
+++ b/fbpcf/engine/ISecretShareEngine.h
@@ -29,6 +29,17 @@ class ISecretShareEngine {
   virtual bool setInput(int id, std::optional<bool> v = std::nullopt) = 0;
 
   /**
+   * Generate a private input wire carring party id's input
+   * @param id the party that own v
+   * @param v the plaintext input, this value can be std::nullopt if this
+   * party doesn't own v
+   * @return the ciphertext form
+   */
+  virtual uint64_t setIntegerInput(
+      int id,
+      std::optional<uint64_t> v = std::nullopt) = 0;
+
+  /**
    * Generate a batch of private input wires carring party id's inputs
    * @param id the party that own v
    * @param v the plaintext inputs, the optional bools in this vector can be
@@ -38,6 +49,17 @@ class ISecretShareEngine {
   virtual std::vector<bool> setBatchInput(
       int id,
       const std::vector<bool>& v) = 0;
+
+  /**
+   * Generate a batch of private input wires carring party id's inputs
+   * @param id the party that own v
+   * @param v the plaintext inputs, the optional integers in this vector can be
+   * any value if this party doesn't own v
+   * @return the ciphertext form
+   */
+  virtual std::vector<uint64_t> setBatchIntegerInput(
+      int id,
+      const std::vector<uint64_t>& v) = 0;
 
   /**
    * Compute an XOR gate with two private or two public values. This operation
@@ -266,6 +288,16 @@ class ISecretShareEngine {
   virtual std::vector<bool> revealToParty(
       int id,
       const std::vector<bool>& output) const = 0;
+
+  /**
+   * reveal a vector of shared secret to a designated party
+   * @param Id the identity of the plaintext receiver
+   * @param output the plaintext output, false if this party is not the
+   * receiver
+   */
+  virtual std::vector<uint64_t> revealToParty(
+      int id,
+      const std::vector<uint64_t>& output) const = 0;
 
   /**
    * Get the total amount of traffic transmitted.

--- a/fbpcf/engine/SecretShareEngine.cpp
+++ b/fbpcf/engine/SecretShareEngine.cpp
@@ -176,6 +176,57 @@ std::vector<bool> SecretShareEngine::computeBatchAsymmetricXOR(
   }
 }
 
+uint64_t SecretShareEngine::computeSymmetricPlus(uint64_t left, uint64_t right)
+    const {
+  return left + right;
+}
+
+std::vector<uint64_t> SecretShareEngine::computeBatchSymmetricPlus(
+    const std::vector<uint64_t>& left,
+    const std::vector<uint64_t>& right) const {
+  if (left.size() != right.size()) {
+    throw std::invalid_argument("The input sizes are not the same.");
+  }
+  if (left.size() == 0) {
+    return std::vector<uint64_t>();
+  }
+  std::vector<uint64_t> rst(left.size());
+  for (size_t i = 0; i < left.size(); i++) {
+    rst.at(i) = left.at(i) + right.at(i);
+  }
+  return rst;
+}
+
+uint64_t SecretShareEngine::computeAsymmetricPlus(
+    uint64_t privateValue,
+    uint64_t publicValue) const {
+  if (myId_ == 0) {
+    return privateValue + publicValue;
+  } else {
+    return privateValue;
+  }
+}
+
+std::vector<uint64_t> SecretShareEngine::computeBatchAsymmetricPlus(
+    const std::vector<uint64_t>& privateValue,
+    const std::vector<uint64_t>& publicValue) const {
+  if (privateValue.size() != publicValue.size()) {
+    throw std::invalid_argument("The input sizes are not the same.");
+  }
+  if (privateValue.size() == 0) {
+    return std::vector<uint64_t>();
+  }
+  if (myId_ == 0) {
+    std::vector<uint64_t> rst(privateValue.size());
+    for (size_t i = 0; i < privateValue.size(); i++) {
+      rst.at(i) = privateValue.at(i) + publicValue.at(i);
+    }
+    return rst;
+  } else {
+    return privateValue;
+  }
+}
+
 bool SecretShareEngine::computeSymmetricNOT(bool input) const {
   return !input;
 }
@@ -211,6 +262,22 @@ std::vector<bool> SecretShareEngine::computeBatchAsymmetricNOT(
   std::vector<bool> rst(input.size());
   for (size_t i = 0; i < input.size(); i++) {
     rst[i] = !input[i];
+  }
+  return rst;
+}
+
+uint64_t SecretShareEngine::computeSymmetricNeg(uint64_t input) const {
+  return -input;
+}
+
+std::vector<uint64_t> SecretShareEngine::computeBatchSymmetricNeg(
+    const std::vector<uint64_t>& input) const {
+  if (input.size() == 0) {
+    return std::vector<uint64_t>();
+  }
+  std::vector<uint64_t> rst(input.size());
+  for (size_t i = 0; i < rst.size(); i++) {
+    rst[i] = -input[i];
   }
   return rst;
 }

--- a/fbpcf/engine/SecretShareEngine.h
+++ b/fbpcf/engine/SecretShareEngine.h
@@ -489,14 +489,28 @@ class SecretShareEngine final : public ISecretShareEngine {
       std::vector<ScheduledBatchAND>& batchAnds,
       std::vector<ScheduledCompositeAND>& compositeAnds,
       std::vector<ScheduledBatchCompositeAND>& batchCompositeAnds,
+      std::vector<ScheduledMult>& mults,
+      std::vector<ScheduledBatchMult>& batchMults,
       std::vector<bool>& openedSecrets,
-      std::vector<tuple_generator::ITupleGenerator::BooleanTuple>& tuples);
+      std::vector<uint64_t>& openedIntegerSecrets,
+      std::vector<tuple_generator::ITupleGenerator::BooleanTuple>& tuples,
+      std::vector<tuple_generator::ITupleGenerator::IntegerTuple>&
+          integerTuples);
 
   std::vector<uint64_t> computeSecretSharesToOpen(
       std::vector<ScheduledMult>& mults,
       std::vector<ScheduledBatchMult>& batchMults,
       std::vector<tuple_generator::ITupleGenerator::IntegerTuple>& tuples,
       size_t openedSecretCount);
+
+  void computeMultExecutionResultsFromOpenedShares(
+      std::vector<ScheduledMult>& mults,
+      std::vector<uint64_t>& multResults,
+      std::vector<ScheduledBatchMult>& batchMults,
+      std::vector<std::vector<uint64_t>>& batchMultResults,
+      std::vector<uint64_t>& openedIntegerSecrets,
+      std::vector<tuple_generator::ITupleGenerator::IntegerTuple>&
+          integerTuples);
 
   std::unique_ptr<tuple_generator::ITupleGenerator> tupleGenerator_;
   std::unique_ptr<communication::ISecretShareEngineCommunicationAgent>

--- a/fbpcf/engine/SecretShareEngine.h
+++ b/fbpcf/engine/SecretShareEngine.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <vector>
 
@@ -167,6 +168,25 @@ class SecretShareEngine final : public ISecretShareEngine {
    */
   std::vector<bool> revealToParty(int id, const std::vector<bool>& output)
       const override;
+
+  /**
+   * @inherit doc
+   */
+  uint64_t setIntegerInput(int id, std::optional<uint64_t> v) override;
+
+  /**
+   * @inherit doc
+   */
+  std::vector<uint64_t> setBatchIntegerInput(
+      int id,
+      const std::vector<uint64_t>& v) override;
+
+  /**
+   * @inherit doc
+   */
+  std::vector<uint64_t> revealToParty(
+      int id,
+      const std::vector<uint64_t>& output) const override;
 
   /**
    * @inherit doc

--- a/fbpcf/engine/SecretShareEngine.h
+++ b/fbpcf/engine/SecretShareEngine.h
@@ -184,6 +184,42 @@ class SecretShareEngine final : public ISecretShareEngine {
   /**
    * @inherit doc
    */
+  uint64_t computeSymmetricPlus(uint64_t left, uint64_t right) const override;
+
+  /**
+   * @inherit doc
+   */
+  std::vector<uint64_t> computeBatchSymmetricPlus(
+      const std::vector<uint64_t>& left,
+      const std::vector<uint64_t>& right) const override;
+
+  /**
+   * @inherit doc
+   */
+  uint64_t computeAsymmetricPlus(uint64_t privateValue, uint64_t publicValue)
+      const override;
+
+  /**
+   * @inherit doc
+   */
+  std::vector<uint64_t> computeBatchAsymmetricPlus(
+      const std::vector<uint64_t>& privateValue,
+      const std::vector<uint64_t>& publicValue) const override;
+
+  /**
+   * @inherit doc
+   */
+  uint64_t computeSymmetricNeg(uint64_t input) const override;
+
+  /**
+   * @inherit doc
+   */
+  std::vector<uint64_t> computeBatchSymmetricNeg(
+      const std::vector<uint64_t>& input) const override;
+
+  /**
+   * @inherit doc
+   */
   std::vector<uint64_t> revealToParty(
       int id,
       const std::vector<uint64_t>& output) const override;

--- a/fbpcf/engine/communication/SecretShareEngineCommunicationAgent.cpp
+++ b/fbpcf/engine/communication/SecretShareEngineCommunicationAgent.cpp
@@ -7,6 +7,7 @@
 
 #include <emmintrin.h>
 #include <string.h>
+#include <cstdint>
 #include <stdexcept>
 
 #include "fbpcf/engine/communication/SecretShareEngineCommunicationAgent.h"
@@ -24,6 +25,9 @@ std::map<int, __m128i> SecretShareEngineCommunicationAgent::exchangeKeys(
 
 std::vector<bool> SecretShareEngineCommunicationAgent::openSecretsToAll(
     const std::vector<bool>& secretShares) {
+  if (secretShares.empty()) {
+    return std::vector<bool>();
+  }
   std::vector<bool> rst = secretShares;
   std::vector<bool> receivedShares;
 
@@ -45,6 +49,9 @@ std::vector<bool> SecretShareEngineCommunicationAgent::openSecretsToAll(
 
 std::vector<uint64_t> SecretShareEngineCommunicationAgent::openSecretsToAll(
     const std::vector<uint64_t>& secretShares) {
+  if (secretShares.empty()) {
+    return std::vector<uint64_t>();
+  }
   std::vector<uint64_t> rst = secretShares;
   std::vector<uint64_t> receivedShares;
 

--- a/fbpcf/engine/communication/SecretShareEngineCommunicationAgent.cpp
+++ b/fbpcf/engine/communication/SecretShareEngineCommunicationAgent.cpp
@@ -74,6 +74,9 @@ std::vector<uint64_t> SecretShareEngineCommunicationAgent::openSecretsToAll(
 std::vector<bool> SecretShareEngineCommunicationAgent::openSecretsToParty(
     int id,
     const std::vector<bool>& secretShares) {
+  if (!secretShares.size())
+    return std::vector<bool>();
+
   if (id == myId_) {
     std::vector<bool> rst = secretShares;
     for (auto& iter : agentMap_) {
@@ -92,6 +95,9 @@ std::vector<bool> SecretShareEngineCommunicationAgent::openSecretsToParty(
 std::vector<uint64_t> SecretShareEngineCommunicationAgent::openSecretsToParty(
     int id,
     const std::vector<uint64_t>& secretShares) {
+  if (!secretShares.size())
+    return std::vector<uint64_t>();
+
   if (id == myId_) {
     std::vector<uint64_t> rst = secretShares;
     for (auto& iter : agentMap_) {

--- a/fbpcf/engine/test/SecretShareEngineTest.cpp
+++ b/fbpcf/engine/test/SecretShareEngineTest.cpp
@@ -746,7 +746,7 @@ std::pair<std::vector<bool>, std::vector<std::vector<bool>>> ANDTestBody(
   auto batchCompositeIndex2 =
       engine.scheduleBatchCompositeAND(leftComposite3, rightComposite3);
 
-  engine.executeScheduledAND();
+  engine.executeScheduledOperations();
 
   // Regular AND
   std::vector<bool> andResult(size / 2);

--- a/fbpcf/engine/test/benchmarks/SecretShareEngineBenchmark.cpp
+++ b/fbpcf/engine/test/benchmarks/SecretShareEngineBenchmark.cpp
@@ -241,7 +241,7 @@ class ComputeNonFreeANDBenchmark final : public BaseSecretShareEngineBenchmark {
  protected:
   virtual void runMethod(std::unique_ptr<ISecretShareEngine>& engine) override {
     auto index = engine->scheduleAND(input0_, input1_);
-    engine->executeScheduledAND();
+    engine->executeScheduledOperations();
     engine->getANDExecutionResult(index);
   }
 };
@@ -256,7 +256,7 @@ class ComputeBatchNonFreeANDBenchmark final
  protected:
   virtual void runMethod(std::unique_ptr<ISecretShareEngine>& engine) override {
     auto index = engine->scheduleBatchAND(batchInput0_, batchInput1_);
-    engine->executeScheduledAND();
+    engine->executeScheduledOperations();
     engine->getBatchANDExecutionResult(index);
   }
 };
@@ -271,7 +271,7 @@ class ComputeCompositeANDBenchmark final
  protected:
   virtual void runMethod(std::unique_ptr<ISecretShareEngine>& engine) override {
     auto index = engine->scheduleCompositeAND(input0_, batchInput0_);
-    engine->executeScheduledAND();
+    engine->executeScheduledOperations();
     engine->getCompositeANDExecutionResult(index);
   }
 };
@@ -287,7 +287,7 @@ class ComputeBatchCompositeANDBenchmark final
   virtual void runMethod(std::unique_ptr<ISecretShareEngine>& engine) override {
     auto index = engine->scheduleBatchCompositeAND(
         batchInput0_, std::vector<std::vector<bool>>(batchSize_, batchInput1_));
-    engine->executeScheduledAND();
+    engine->executeScheduledOperations();
     engine->getBatchCompositeANDExecutionResult(index);
   }
 };

--- a/fbpcf/engine/tuple_generator/ITupleGenerator.h
+++ b/fbpcf/engine/tuple_generator/ITupleGenerator.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <cstdint>
 #include <map>
 #include <stdexcept>
 #include <vector>
@@ -93,6 +94,35 @@ class ITupleGenerator {
    private:
     bool a_;
     std::vector<bool> b_, c_;
+  };
+
+  /**
+   * This is a integer version multiplicative triple. This object represents the
+   * shares hold by one party, e.g. the share of a, b and their product c.
+   */
+  class IntegerTuple {
+   public:
+    IntegerTuple() {}
+
+    IntegerTuple(uint64_t a, uint64_t b, uint64_t c) : a_(a), b_(b), c_(c) {}
+
+    // get the first share
+    uint64_t getA() const {
+      return a_;
+    }
+
+    // get the second share
+    uint64_t getB() const {
+      return b_;
+    }
+
+    // get the third share
+    uint64_t getC() const {
+      return c_;
+    }
+
+   private:
+    uint64_t a_, b_, c_;
   };
 
   /**

--- a/fbpcf/scheduler/EagerScheduler.cpp
+++ b/fbpcf/scheduler/EagerScheduler.cpp
@@ -114,7 +114,7 @@ IScheduler::WireId<IScheduler::Boolean> EagerScheduler::privateAndPrivate(
   nonFreeGates_++;
   auto index = engine_->scheduleAND(
       wireKeeper_->getBooleanValue(left), wireKeeper_->getBooleanValue(right));
-  engine_->executeScheduledAND();
+  engine_->executeScheduledOperations();
   return wireKeeper_->allocateBooleanValue(
       engine_->getANDExecutionResult(index));
 }
@@ -176,7 +176,7 @@ EagerScheduler::privateAndPrivateComposite(
   }
   auto index = engine_->scheduleCompositeAND(
       wireKeeper_->getBooleanValue(left), rightValues);
-  engine_->executeScheduledAND();
+  engine_->executeScheduledOperations();
   auto result = engine_->getCompositeANDExecutionResult(index);
   std::vector<IScheduler::WireId<IScheduler::Boolean>> outputWires(
       result.size());
@@ -198,7 +198,7 @@ EagerScheduler::privateAndPrivateCompositeBatch(
   }
 
   auto index = engine_->scheduleBatchCompositeAND(leftValues, rightValues);
-  engine_->executeScheduledAND();
+  engine_->executeScheduledOperations();
   auto result = engine_->getBatchCompositeANDExecutionResult(index);
   std::vector<IScheduler::WireId<IScheduler::Boolean>> outputWires(
       result.size());

--- a/fbpcf/scheduler/EagerScheduler.h
+++ b/fbpcf/scheduler/EagerScheduler.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "fbpcf/engine/ISecretShareEngine.h"
+#include "fbpcf/scheduler/IArithmeticScheduler.h"
 #include "fbpcf/scheduler/IScheduler.h"
 #include "fbpcf/scheduler/IWireKeeper.h"
 #include "fbpcf/util/MetricCollector.h"
@@ -19,7 +20,7 @@ namespace fbpcf::scheduler {
  * request. It is cryptographically secure if the underlying secret
  * sharing engine is.
  */
-class EagerScheduler final : public IScheduler {
+class EagerScheduler final : public IArithmeticScheduler {
  public:
   explicit EagerScheduler(
       std::unique_ptr<engine::ISecretShareEngine> engine,
@@ -99,6 +100,81 @@ class EagerScheduler final : public IScheduler {
    */
   std::vector<bool> getBooleanValueBatch(
       WireId<IScheduler::Boolean> id) override;
+
+  //======== Below are integer input processing APIs: ========
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privateIntegerInput(uint64_t v, int partyId)
+      override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privateIntegerInputBatch(
+      const std::vector<uint64_t>& v,
+      int partyId) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> publicIntegerInput(uint64_t v) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> publicIntegerInputBatch(
+      const std::vector<uint64_t>& v) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> recoverIntegerWire(uint64_t v) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> recoverIntegerWireBatch(
+      const std::vector<uint64_t>& v) override;
+
+  //======== Below are integer output processing APIs: ========
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> openIntegerValueToParty(
+      WireId<IScheduler::Arithmetic> src,
+      int partyId) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> openIntegerValueToPartyBatch(
+      WireId<IScheduler::Arithmetic> src,
+      int partyId) override;
+
+  /**
+   * @inherit doc
+   */
+  uint64_t extractIntegerSecretShare(
+      WireId<IScheduler::Arithmetic> id) override;
+
+  /**
+   * @inherit doc
+   */
+  std::vector<uint64_t> extractIntegerSecretShareBatch(
+      WireId<IScheduler::Arithmetic> id) override;
+
+  /**
+   * @inherit doc
+   */
+  uint64_t getIntegerValue(WireId<IScheduler::Arithmetic> id) override;
+
+  /**
+   * @inherit doc
+   */
+  std::vector<uint64_t> getIntegerValueBatch(
+      WireId<IScheduler::Arithmetic> id) override;
 
   //======== Below are computation APIs: ========
 
@@ -260,6 +336,122 @@ class EagerScheduler final : public IScheduler {
   WireId<IScheduler::Boolean> notPublicBatch(
       WireId<IScheduler::Boolean> src) override;
 
+  //======== Below are arithmetic computation APIs: ========
+
+  // ------ Mult gates ------
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privateMultPrivate(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privateMultPrivateBatch(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privateMultPublic(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privateMultPublicBatch(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> publicMultPublic(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> publicMultPublicBatch(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right) override;
+
+  // ------ Plus gates ------
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privatePlusPrivate(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privatePlusPrivateBatch(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privatePlusPublic(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privatePlusPublicBatch(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> publicPlusPublic(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> publicPlusPublicBatch(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right) override;
+
+  // ------ Neg gates ------
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> negPrivate(
+      WireId<IScheduler::Arithmetic> src) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> negPrivateBatch(
+      WireId<IScheduler::Arithmetic> src) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> negPublic(
+      WireId<IScheduler::Arithmetic> src) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> negPublicBatch(
+      WireId<IScheduler::Arithmetic> src) override;
+
   //======== Below are wire management APIs: ========
 
   /**
@@ -281,6 +473,26 @@ class EagerScheduler final : public IScheduler {
    * @inherit doc
    */
   void decreaseReferenceCountBatch(WireId<IScheduler::Boolean> id) override;
+
+  /**
+   * @inherit doc
+   */
+  void increaseReferenceCount(WireId<IScheduler::Arithmetic> src) override;
+
+  /**
+   * @inherit doc
+   */
+  void increaseReferenceCountBatch(WireId<IScheduler::Arithmetic> src) override;
+
+  /**
+   * @inherit doc
+   */
+  void decreaseReferenceCount(WireId<IScheduler::Arithmetic> id) override;
+
+  /**
+   * @inherit doc
+   */
+  void decreaseReferenceCountBatch(WireId<IScheduler::Arithmetic> id) override;
 
   //======== Below are rebatching APIs: ========
 

--- a/fbpcf/scheduler/LazyScheduler.cpp
+++ b/fbpcf/scheduler/LazyScheduler.cpp
@@ -15,6 +15,7 @@
 
 #include <fbpcf/scheduler/gate_keeper/GateKeeper.h>
 #include <fbpcf/scheduler/gate_keeper/INormalGate.h>
+#include <sys/types.h>
 #include "fbpcf/scheduler/IScheduler.h"
 #include "fbpcf/scheduler/gate_keeper/IGate.h"
 #include "fbpcf/scheduler/gate_keeper/INormalGate.h"
@@ -107,6 +108,89 @@ bool LazyScheduler::getBooleanValue(WireId<IScheduler::Boolean> id) {
 
 std::vector<bool> LazyScheduler::getBooleanValueBatch(
     WireId<IScheduler::Boolean> id) {
+  return forceWire<true>(id);
+}
+
+IScheduler::WireId<IScheduler::Arithmetic> LazyScheduler::privateIntegerInput(
+    uint64_t v,
+    int partyId) {
+  auto id = gateKeeper_->inputGate(engine_->setIntegerInput(partyId, v));
+  maybeExecuteGates();
+  return id;
+}
+
+IScheduler::WireId<IScheduler::Arithmetic>
+LazyScheduler::privateIntegerInputBatch(
+    const std::vector<uint64_t>& v,
+    int partyId) {
+  auto id =
+      gateKeeper_->inputGateBatch(engine_->setBatchIntegerInput(partyId, v));
+  maybeExecuteGates();
+  return id;
+}
+
+IScheduler::WireId<IScheduler::Arithmetic> LazyScheduler::publicIntegerInput(
+    uint64_t v) {
+  auto id = gateKeeper_->inputGate(v);
+  maybeExecuteGates();
+  return id;
+}
+
+IScheduler::WireId<IScheduler::Arithmetic>
+LazyScheduler::publicIntegerInputBatch(const std::vector<uint64_t>& v) {
+  auto id = gateKeeper_->inputGateBatch(v);
+  maybeExecuteGates();
+  return id;
+}
+
+IScheduler::WireId<IScheduler::Arithmetic> LazyScheduler::recoverIntegerWire(
+    uint64_t v) {
+  auto id = gateKeeper_->inputGate(v);
+  maybeExecuteGates();
+  return id;
+}
+
+IScheduler::WireId<IScheduler::Arithmetic>
+LazyScheduler::recoverIntegerWireBatch(const std::vector<uint64_t>& v) {
+  auto id = gateKeeper_->inputGateBatch(v);
+  maybeExecuteGates();
+  return id;
+}
+
+IScheduler::WireId<IScheduler::Arithmetic>
+LazyScheduler::openIntegerValueToParty(
+    WireId<IScheduler::Arithmetic> src,
+    int partyId) {
+  auto id = gateKeeper_->outputGate(src, partyId);
+  maybeExecuteGates();
+  return id;
+}
+
+IScheduler::WireId<IScheduler::Arithmetic>
+LazyScheduler::openIntegerValueToPartyBatch(
+    WireId<IScheduler::Arithmetic> src,
+    int partyId) {
+  auto id = gateKeeper_->outputGateBatch(src, partyId);
+  maybeExecuteGates();
+  return id;
+}
+
+uint64_t LazyScheduler::extractIntegerSecretShare(
+    WireId<IScheduler::Arithmetic> id) {
+  return forceWire<false>(id);
+}
+
+std::vector<uint64_t> LazyScheduler::extractIntegerSecretShareBatch(
+    WireId<IScheduler::Arithmetic> id) {
+  return forceWire<true>(id);
+}
+
+uint64_t LazyScheduler::getIntegerValue(WireId<IScheduler::Arithmetic> id) {
+  return forceWire<false>(id);
+}
+
+std::vector<uint64_t> LazyScheduler::getIntegerValueBatch(
+    WireId<IScheduler::Arithmetic> id) {
   return forceWire<true>(id);
 }
 
@@ -308,6 +392,148 @@ IScheduler::WireId<IScheduler::Boolean> LazyScheduler::notPublicBatch(
   return id;
 }
 
+IScheduler::WireId<IScheduler::Arithmetic> LazyScheduler::privateMultPrivate(
+    WireId<IScheduler::Arithmetic> left,
+    WireId<IScheduler::Arithmetic> right) {
+  auto id = gateKeeper_->arithmeticGate(
+      IArithmeticGate::GateType::NonFreeMult, left, right);
+  maybeExecuteGates();
+  return id;
+}
+
+IScheduler::WireId<IScheduler::Arithmetic>
+LazyScheduler::privateMultPrivateBatch(
+    WireId<IScheduler::Arithmetic> left,
+    WireId<IScheduler::Arithmetic> right) {
+  auto id = gateKeeper_->arithmeticGateBatch(
+      IArithmeticGate::GateType::NonFreeMult, left, right);
+  maybeExecuteGates();
+  return id;
+}
+
+IScheduler::WireId<IScheduler::Arithmetic> LazyScheduler::privateMultPublic(
+    WireId<IScheduler::Arithmetic> left,
+    WireId<IScheduler::Arithmetic> right) {
+  auto id = gateKeeper_->arithmeticGate(
+      IArithmeticGate::GateType::FreeMult, left, right);
+  maybeExecuteGates();
+  return id;
+}
+
+IScheduler::WireId<IScheduler::Arithmetic>
+LazyScheduler::privateMultPublicBatch(
+    WireId<IScheduler::Arithmetic> left,
+    WireId<IScheduler::Arithmetic> right) {
+  auto id = gateKeeper_->arithmeticGateBatch(
+      IArithmeticGate::GateType::FreeMult, left, right);
+  maybeExecuteGates();
+  return id;
+}
+
+IScheduler::WireId<IScheduler::Arithmetic> LazyScheduler::publicMultPublic(
+    WireId<IScheduler::Arithmetic> left,
+    WireId<IScheduler::Arithmetic> right) {
+  auto id = gateKeeper_->arithmeticGate(
+      IArithmeticGate::GateType::FreeMult, left, right);
+  maybeExecuteGates();
+  return id;
+}
+
+IScheduler::WireId<IScheduler::Arithmetic> LazyScheduler::publicMultPublicBatch(
+    WireId<IScheduler::Arithmetic> left,
+    WireId<IScheduler::Arithmetic> right) {
+  auto id = gateKeeper_->arithmeticGateBatch(
+      IArithmeticGate::GateType::FreeMult, left, right);
+  maybeExecuteGates();
+  return id;
+}
+
+IScheduler::WireId<IScheduler::Arithmetic> LazyScheduler::privatePlusPrivate(
+    WireId<IScheduler::Arithmetic> left,
+    WireId<IScheduler::Arithmetic> right) {
+  auto id = gateKeeper_->arithmeticGate(
+      IArithmeticGate::GateType::SymmetricPlus, left, right);
+  maybeExecuteGates();
+  return id;
+}
+
+IScheduler::WireId<IScheduler::Arithmetic>
+LazyScheduler::privatePlusPrivateBatch(
+    WireId<IScheduler::Arithmetic> left,
+    WireId<IScheduler::Arithmetic> right) {
+  auto id = gateKeeper_->arithmeticGateBatch(
+      IArithmeticGate::GateType::SymmetricPlus, left, right);
+  maybeExecuteGates();
+  return id;
+}
+
+IScheduler::WireId<IScheduler::Arithmetic> LazyScheduler::privatePlusPublic(
+    WireId<IScheduler::Arithmetic> left,
+    WireId<IScheduler::Arithmetic> right) {
+  auto id = gateKeeper_->arithmeticGate(
+      IArithmeticGate::GateType::AsymmetricPlus, left, right);
+  maybeExecuteGates();
+  return id;
+}
+
+IScheduler::WireId<IScheduler::Arithmetic>
+LazyScheduler::privatePlusPublicBatch(
+    WireId<IScheduler::Arithmetic> left,
+    WireId<IScheduler::Arithmetic> right) {
+  auto id = gateKeeper_->arithmeticGateBatch(
+      IArithmeticGate::GateType::AsymmetricPlus, left, right);
+  maybeExecuteGates();
+  return id;
+}
+
+IScheduler::WireId<IScheduler::Arithmetic> LazyScheduler::publicPlusPublic(
+    WireId<IScheduler::Arithmetic> left,
+    WireId<IScheduler::Arithmetic> right) {
+  auto id = gateKeeper_->arithmeticGate(
+      IArithmeticGate::GateType::SymmetricPlus, left, right);
+  maybeExecuteGates();
+  return id;
+}
+
+IScheduler::WireId<IScheduler::Arithmetic> LazyScheduler::publicPlusPublicBatch(
+    WireId<IScheduler::Arithmetic> left,
+    WireId<IScheduler::Arithmetic> right) {
+  auto id = gateKeeper_->arithmeticGateBatch(
+      IArithmeticGate::GateType::SymmetricPlus, left, right);
+  maybeExecuteGates();
+  return id;
+}
+
+IScheduler::WireId<IScheduler::Arithmetic> LazyScheduler::negPrivate(
+    WireId<IScheduler::Arithmetic> src) {
+  auto id = gateKeeper_->arithmeticGate(IArithmeticGate::GateType::Neg, src);
+  maybeExecuteGates();
+  return id;
+}
+
+IScheduler::WireId<IScheduler::Arithmetic> LazyScheduler::negPrivateBatch(
+    WireId<IScheduler::Arithmetic> src) {
+  auto id =
+      gateKeeper_->arithmeticGateBatch(IArithmeticGate::GateType::Neg, src);
+  maybeExecuteGates();
+  return id;
+}
+
+IScheduler::WireId<IScheduler::Arithmetic> LazyScheduler::negPublic(
+    WireId<IScheduler::Arithmetic> src) {
+  auto id = gateKeeper_->arithmeticGate(IArithmeticGate::GateType::Neg, src);
+  maybeExecuteGates();
+  return id;
+}
+
+IScheduler::WireId<IScheduler::Arithmetic> LazyScheduler::negPublicBatch(
+    WireId<IScheduler::Arithmetic> src) {
+  auto id =
+      gateKeeper_->arithmeticGateBatch(IArithmeticGate::GateType::Neg, src);
+  maybeExecuteGates();
+  return id;
+}
+
 void LazyScheduler::increaseReferenceCount(WireId<IScheduler::Boolean> id) {
   wireKeeper_->increaseReferenceCount(id);
 }
@@ -323,6 +549,24 @@ void LazyScheduler::decreaseReferenceCount(WireId<IScheduler::Boolean> id) {
 
 void LazyScheduler::decreaseReferenceCountBatch(
     WireId<IScheduler::Boolean> id) {
+  wireKeeper_->decreaseBatchReferenceCount(id);
+}
+
+void LazyScheduler::increaseReferenceCount(WireId<IScheduler::Arithmetic> id) {
+  wireKeeper_->increaseReferenceCount(id);
+}
+
+void LazyScheduler::increaseReferenceCountBatch(
+    WireId<IScheduler::Arithmetic> id) {
+  wireKeeper_->increaseBatchReferenceCount(id);
+}
+
+void LazyScheduler::decreaseReferenceCount(WireId<IScheduler::Arithmetic> id) {
+  wireKeeper_->decreaseReferenceCount(id);
+}
+
+void LazyScheduler::decreaseReferenceCountBatch(
+    WireId<IScheduler::Arithmetic> id) {
   wireKeeper_->decreaseBatchReferenceCount(id);
 }
 
@@ -360,6 +604,18 @@ IGateKeeper::BoolType<usingBatch> LazyScheduler::forceWire(
   }
 }
 
+template <bool usingBatch>
+IGateKeeper::IntType<usingBatch> LazyScheduler::forceWire(
+    IScheduler::WireId<IScheduler::Arithmetic> id) {
+  if constexpr (usingBatch) {
+    executeTillLevel(wireKeeper_->getBatchFirstAvailableLevel(id));
+    return wireKeeper_->getBatchIntegerValue(id);
+  } else {
+    executeTillLevel(wireKeeper_->getFirstAvailableLevel(id));
+    return wireKeeper_->getIntegerValue(id);
+  }
+}
+
 void LazyScheduler::maybeExecuteGates() {
   while (gateKeeper_->hasReachedBatchingLimit()) {
     executeOneLevel();
@@ -390,7 +646,6 @@ void LazyScheduler::executeOneLevel() {
   }
 
   if (!isLevelFree) {
-    // Execute AND gates and share secrets
     engine_->executeScheduledOperations();
 
     std::map<int64_t, IGate::Secrets> revealedSecretsByParty;
@@ -399,7 +654,7 @@ void LazyScheduler::executeOneLevel() {
           party,
           IGate::Secrets(
               engine_->revealToParty(party, secretShares.booleanSecrets),
-              std::vector<uint64_t>()));
+              engine_->revealToParty(party, secretShares.integerSecrets)));
     }
 
     // Update non-free gates

--- a/fbpcf/scheduler/LazyScheduler.cpp
+++ b/fbpcf/scheduler/LazyScheduler.cpp
@@ -391,7 +391,7 @@ void LazyScheduler::executeOneLevel() {
 
   if (!isLevelFree) {
     // Execute AND gates and share secrets
-    engine_->executeScheduledAND();
+    engine_->executeScheduledOperations();
 
     std::map<int64_t, IGate::Secrets> revealedSecretsByParty;
     for (auto [party, secretShares] : secretSharesByParty) {

--- a/fbpcf/scheduler/LazyScheduler.h
+++ b/fbpcf/scheduler/LazyScheduler.h
@@ -9,6 +9,7 @@
 
 #include <stdexcept>
 #include "fbpcf/engine/ISecretShareEngine.h"
+#include "fbpcf/scheduler/IArithmeticScheduler.h"
 #include "fbpcf/scheduler/IScheduler.h"
 #include "fbpcf/scheduler/IWireKeeper.h"
 #include "fbpcf/scheduler/gate_keeper/IGateKeeper.h"
@@ -22,7 +23,7 @@ namespace fbpcf::scheduler {
  * and executed lazily to reduce roundtrips. It is cryptographically
  * secure if the underlying secret sharing engine is.
  */
-class LazyScheduler final : public IScheduler {
+class LazyScheduler final : public IArithmeticScheduler {
  public:
   explicit LazyScheduler(
       std::unique_ptr<engine::ISecretShareEngine> engine,
@@ -103,6 +104,80 @@ class LazyScheduler final : public IScheduler {
    */
   std::vector<bool> getBooleanValueBatch(
       WireId<IScheduler::Boolean> id) override;
+
+  //======== Below are integer input processing APIs ========
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privateIntegerInput(uint64_t v, int partyId)
+      override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privateIntegerInputBatch(
+      const std::vector<uint64_t>& v,
+      int partyId) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> publicIntegerInput(uint64_t v) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> publicIntegerInputBatch(
+      const std::vector<uint64_t>& v) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> recoverIntegerWire(uint64_t v) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> recoverIntegerWireBatch(
+      const std::vector<uint64_t>& v) override;
+
+  //======== Below are integer output processing APIs: ========
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> openIntegerValueToParty(
+      WireId<IScheduler::Arithmetic> src,
+      int partyId) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> openIntegerValueToPartyBatch(
+      WireId<IScheduler::Arithmetic> src,
+      int partyId) override;
+
+  /**
+   * @inherit doc
+   */
+  uint64_t extractIntegerSecretShare(
+      WireId<IScheduler::Arithmetic> id) override;
+
+  /**
+   * @inherit doc
+   */
+  std::vector<uint64_t> extractIntegerSecretShareBatch(
+      WireId<IScheduler::Arithmetic> id) override;
+
+  /**
+   * @inherit doc
+   */
+  uint64_t getIntegerValue(WireId<IScheduler::Arithmetic> id) override;
+
+  /**
+   * @inherit doc
+   */
+  std::vector<uint64_t> getIntegerValueBatch(
+      WireId<IScheduler::Arithmetic> id) override;
 
   //======== Below are computation APIs: ========
 
@@ -264,6 +339,122 @@ class LazyScheduler final : public IScheduler {
   WireId<IScheduler::Boolean> notPublicBatch(
       WireId<IScheduler::Boolean> src) override;
 
+  //======== Below are arithmetic computation APIs: ========
+
+  // ------ Mult gates ------
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privateMultPrivate(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privateMultPrivateBatch(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privateMultPublic(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privateMultPublicBatch(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> publicMultPublic(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> publicMultPublicBatch(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right) override;
+
+  // ------ Plus gates ------
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privatePlusPrivate(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privatePlusPrivateBatch(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privatePlusPublic(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> privatePlusPublicBatch(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> publicPlusPublic(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> publicPlusPublicBatch(
+      WireId<IScheduler::Arithmetic> left,
+      WireId<IScheduler::Arithmetic> right) override;
+
+  // ------ Neg gates ------
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> negPrivate(
+      WireId<IScheduler::Arithmetic> src) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> negPrivateBatch(
+      WireId<IScheduler::Arithmetic> src) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> negPublic(
+      WireId<IScheduler::Arithmetic> src) override;
+
+  /**
+   * @inherit doc
+   */
+  WireId<IScheduler::Arithmetic> negPublicBatch(
+      WireId<IScheduler::Arithmetic> src) override;
+
   //======== Below are wire management APIs: ========
 
   /**
@@ -285,6 +476,26 @@ class LazyScheduler final : public IScheduler {
    * @inherit doc
    */
   void decreaseReferenceCountBatch(WireId<IScheduler::Boolean> id) override;
+
+  /**
+   * @inherit doc
+   */
+  void increaseReferenceCount(WireId<IScheduler::Arithmetic> src) override;
+
+  /**
+   * @inherit doc
+   */
+  void increaseReferenceCountBatch(WireId<IScheduler::Arithmetic> src) override;
+
+  /**
+   * @inherit doc
+   */
+  void decreaseReferenceCount(WireId<IScheduler::Arithmetic> id) override;
+
+  /**
+   * @inherit doc
+   */
+  void decreaseReferenceCountBatch(WireId<IScheduler::Arithmetic> id) override;
 
   //======== Below are rebatching APIs: ========
 
@@ -319,6 +530,9 @@ class LazyScheduler final : public IScheduler {
   // Compute the value for the given wire if it hasn't been set already.
   template <bool usingBatch>
   IGateKeeper::BoolType<usingBatch> forceWire(WireId<IScheduler::Boolean> id);
+
+  template <bool usingBatch>
+  IGateKeeper::IntType<usingBatch> forceWire(WireId<IScheduler::Arithmetic> id);
 
   void maybeExecuteGates();
 

--- a/fbpcf/scheduler/SchedulerHelper.h
+++ b/fbpcf/scheduler/SchedulerHelper.h
@@ -169,4 +169,23 @@ inline std::unique_ptr<IScheduler> createLazySchedulerWithInsecureEngine(
       std::make_unique<GateKeeper>(wireKeeper));
 }
 
+// this function creates a lazy scheduler with insecure engine
+template <bool unsafe>
+inline std::unique_ptr<IArithmeticScheduler>
+createArithmeticLazySchedulerWithInsecureEngine(
+    int myId,
+    engine::communication::IPartyCommunicationAgentFactory&
+        communicationAgentFactory) {
+  auto engineFactory = engine::getInsecureEngineFactoryWithDummyTupleGenerator(
+      myId, 2, communicationAgentFactory);
+
+  std::shared_ptr<IWireKeeper> wireKeeper =
+      WireKeeper::createWithVectorArena<unsafe>();
+
+  return std::make_unique<LazyScheduler>(
+      engineFactory->create(),
+      wireKeeper,
+      std::make_unique<GateKeeper>(wireKeeper));
+}
+
 } // namespace fbpcf::scheduler

--- a/fbpcf/scheduler/SchedulerHelper.h
+++ b/fbpcf/scheduler/SchedulerHelper.h
@@ -137,6 +137,20 @@ inline std::unique_ptr<IScheduler> createEagerSchedulerWithInsecureEngine(
       engineFactory->create(), WireKeeper::createWithVectorArena<unsafe>());
 }
 
+// this function creates a eager scheduler with insecure engine
+template <bool unsafe>
+inline std::unique_ptr<IArithmeticScheduler>
+createArithmeticEagerSchedulerWithInsecureEngine(
+    int myId,
+    engine::communication::IPartyCommunicationAgentFactory&
+        communicationAgentFactory) {
+  auto engineFactory = engine::getInsecureEngineFactoryWithDummyTupleGenerator(
+      myId, 2, communicationAgentFactory);
+
+  return std::make_unique<EagerScheduler>(
+      engineFactory->create(), WireKeeper::createWithVectorArena<unsafe>());
+}
+
 // this function creates a lazy scheduler with insecure engine
 template <bool unsafe>
 inline std::unique_ptr<IScheduler> createLazySchedulerWithInsecureEngine(

--- a/fbpcf/scheduler/gate_keeper/BatchArithmeticGate.h
+++ b/fbpcf/scheduler/gate_keeper/BatchArithmeticGate.h
@@ -58,34 +58,73 @@ class BatchArithmeticGate final : public IArithmeticGate {
       std::map<int64_t, IGate::Secrets>& secretSharesByParty) override {
     switch (gateType_) {
         // Free gates
-      case GateType::AsymmetricPlus:
-        throw common::exceptions::NotImplementedError("Unimplemented");
+      case GateType::Neg: {
+        auto values = wireKeeper_.getBatchIntegerValue(left_);
+        numberOfResults_ = values.size();
+        wireKeeper_.setBatchIntegerValue(
+            wireID_, engine.computeBatchSymmetricNeg(values));
         break;
+      }
 
-      case GateType::FreeMult:
-        throw common::exceptions::NotImplementedError("Unimplemented");
+      case GateType::AsymmetricPlus: {
+        auto leftValues = wireKeeper_.getBatchIntegerValue(left_);
+        auto rightValues = wireKeeper_.getBatchIntegerValue(right_);
+        numberOfResults_ = leftValues.size();
+        wireKeeper_.setBatchIntegerValue(
+            wireID_,
+            engine.computeBatchAsymmetricPlus(leftValues, rightValues));
         break;
+      }
+
+      case GateType::FreeMult: {
+        auto leftValues = wireKeeper_.getBatchIntegerValue(left_);
+        auto rightValues = wireKeeper_.getBatchIntegerValue(right_);
+        numberOfResults_ = leftValues.size();
+        wireKeeper_.setBatchIntegerValue(
+            wireID_, engine.computeBatchFreeMult(leftValues, rightValues));
+        break;
+      }
 
       case GateType::Input:
-        throw common::exceptions::NotImplementedError("Unimplemented");
         break;
 
-      case GateType::Neg:
-        throw common::exceptions::NotImplementedError("Unimplemented");
+      case GateType::SymmetricPlus: {
+        auto leftValues = wireKeeper_.getBatchIntegerValue(left_);
+        auto rightValues = wireKeeper_.getBatchIntegerValue(right_);
+        numberOfResults_ = leftValues.size();
+        wireKeeper_.setBatchIntegerValue(
+            wireID_, engine.computeBatchSymmetricPlus(leftValues, rightValues));
         break;
-
-      case GateType::SymmetricPlus:
-        throw common::exceptions::NotImplementedError("Unimplemented");
-        break;
+      }
 
       // Non-free gates
-      case GateType::Output:
-        throw common::exceptions::NotImplementedError("Unimplemented");
-        break;
+      case GateType::Output: {
+        if (secretSharesByParty.find(partyID_) == secretSharesByParty.end()) {
+          secretSharesByParty.emplace(
+              partyID_,
+              IGate::Secrets(std::vector<bool>(), std::vector<uint64_t>()));
+        }
+        auto& secretShares = secretSharesByParty.at(partyID_).integerSecrets;
+        scheduledResultIndex_ = secretShares.size();
 
-      case GateType::NonFreeMult:
-        throw common::exceptions::NotImplementedError("Unimplemented");
+        auto values = wireKeeper_.getBatchIntegerValue(left_);
+        numberOfResults_ = values.size();
+        secretShares.insert(secretShares.end(), values.begin(), values.end());
         break;
+      }
+
+      case GateType::NonFreeMult: {
+        auto leftValues = wireKeeper_.getBatchIntegerValue(left_);
+        auto rightValues = wireKeeper_.getBatchIntegerValue(right_);
+
+        numberOfResults_ = leftValues.size();
+        if (numberOfResults_ == 0) {
+          break;
+        }
+        scheduledResultIndex_ =
+            engine.scheduleBatchMult(leftValues, rightValues);
+        break;
+      }
     }
   }
 
@@ -93,13 +132,20 @@ class BatchArithmeticGate final : public IArithmeticGate {
       engine::ISecretShareEngine& engine,
       std::map<int64_t, IGate::Secrets>& revealedSecretsByParty) override {
     switch (gateType_) {
-      case GateType::NonFreeMult:
-        throw common::exceptions::NotImplementedError("Unimplemented");
+      case GateType::NonFreeMult: {
+        wireKeeper_.setBatchIntegerValue(
+            wireID_, engine.getBatchMultExecutionResult(scheduledResultIndex_));
         break;
+      }
 
-      case GateType::Output:
-        throw common::exceptions::NotImplementedError("Unimplemented");
+      case GateType::Output: {
+        auto iterator =
+            revealedSecretsByParty.at(partyID_).integerSecrets.begin() +
+            scheduledResultIndex_;
+        std::vector<uint64_t> results(iterator, iterator + numberOfResults_);
+        wireKeeper_.setBatchIntegerValue(wireID_, results);
         break;
+      }
 
       default:
         break;

--- a/fbpcf/scheduler/test/SchedulerTest.cpp
+++ b/fbpcf/scheduler/test/SchedulerTest.cpp
@@ -103,7 +103,8 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Values(
         SchedulerType::Plaintext,
         SchedulerType::NetworkPlaintext,
-        SchedulerType::Eager),
+        SchedulerType::Eager,
+        SchedulerType::Lazy),
     [](const testing::TestParamInfo<SchedulerTestFixture::ParamType>& info) {
       return getSchedulerName(info.param);
     });

--- a/fbpcf/scheduler/test/SchedulerTest.cpp
+++ b/fbpcf/scheduler/test/SchedulerTest.cpp
@@ -102,7 +102,8 @@ INSTANTIATE_TEST_SUITE_P(
     ArithmeticSchedulerTestFixture,
     ::testing::Values(
         SchedulerType::Plaintext,
-        SchedulerType::NetworkPlaintext),
+        SchedulerType::NetworkPlaintext,
+        SchedulerType::Eager),
     [](const testing::TestParamInfo<SchedulerTestFixture::ParamType>& info) {
       return getSchedulerName(info.param);
     });

--- a/fbpcf/test/TestHelper.h
+++ b/fbpcf/test/TestHelper.h
@@ -114,7 +114,7 @@ inline ArithmeticSchedulerCreator getArithmeticSchedulerCreator(
       return scheduler::createArithmeticEagerSchedulerWithInsecureEngine<
           unsafe>;
     case SchedulerType::Lazy:
-      throw std::runtime_error("unimplemented");
+      return scheduler::createArithmeticLazySchedulerWithInsecureEngine<unsafe>;
   }
 }
 

--- a/fbpcf/test/TestHelper.h
+++ b/fbpcf/test/TestHelper.h
@@ -111,7 +111,8 @@ inline ArithmeticSchedulerCreator getArithmeticSchedulerCreator(
     case SchedulerType::NetworkPlaintext:
       return scheduler::createArithmeticNetworkPlaintextScheduler<unsafe>;
     case SchedulerType::Eager:
-      throw std::runtime_error("unimplemented");
+      return scheduler::createArithmeticEagerSchedulerWithInsecureEngine<
+          unsafe>;
     case SchedulerType::Lazy:
       throw std::runtime_error("unimplemented");
   }


### PR DESCRIPTION
Summary:
Implement integer input/output, integer wire recover/extract, and plus, mult, neg operations in the lazy scheduler.

Reuse test cases added for the plaintext scheduler.

Differential Revision: D38435983

