### PR TITLE
Add TlsInfo versions of openClientPortWithTls and openServerPortWithTls

### DIFF
--- a/fbpcf/engine/communication/SocketPartyCommunicationAgent.h
+++ b/fbpcf/engine/communication/SocketPartyCommunicationAgent.h
@@ -21,6 +21,12 @@ namespace fbpcf::engine::communication {
  */
 class SocketPartyCommunicationAgent final : public IPartyCommunicationAgent {
  public:
+  struct TlsInfo {
+    bool useTls;
+    std::string certPath;
+    std::string keyPath;
+    std::string passphrasePath;
+  };
   /**
    * Create as socket server, optionally with TLS.
    */
@@ -59,10 +65,15 @@ class SocketPartyCommunicationAgent final : public IPartyCommunicationAgent {
   void openClientPort(const std::string& serverAddress, int portNo);
 
   void openServerPortWithTls(int sockFd, int portNo, std::string tlsDir);
+  void openServerPortWithTls(int sockFd, int portNo, TlsInfo tlsInfo);
   void openClientPortWithTls(
       const std::string& serverAddress,
       int portNo,
       std::string tlsDir);
+  void openClientPortWithTls(
+      const std::string& serverAddress,
+      int portNo,
+      TlsInfo tlsInfo);
 
   /*
    * helper functions for shared code between TLS and non-TLS implementations

--- a/fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h
+++ b/fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h
@@ -35,13 +35,6 @@ class SocketPartyCommunicationAgentFactory final
     int portNo;
   };
 
-  struct TlsInfo {
-    bool useTls;
-    std::string certPath;
-    std::string keyPath;
-    std::string passphrasePath;
-  };
-
   /** it's OK if a party with a smaller id doesn't know a party with larger id's
   * ip address, since the party with smaller id will always be the server.
   *@param partyInfos This is a map that contains connection information for all
@@ -79,7 +72,7 @@ establishing multiple connections (>3) between each party pair.
   SocketPartyCommunicationAgentFactory(
       int myId,
       std::map<int, PartyInfo> partyInfos,
-      TlsInfo tlsInfo,
+      SocketPartyCommunicationAgent::TlsInfo tlsInfo,
       std::string myname)
       : IPartyCommunicationAgentFactory(myname),
         myId_(myId),
@@ -117,7 +110,7 @@ establishing multiple connections (>3) between each party pair.
   bool useTls_;
   std::string tlsDir_;
 
-  TlsInfo tlsInfo_;
+  SocketPartyCommunicationAgent::TlsInfo tlsInfo_;
 };
 
 } // namespace fbpcf::engine::communication


### PR DESCRIPTION
Summary:
Add TlsInfo versions of openClientPortWithTls and openServerPortWithTls in SocketPartyCommunicationAgent.cpp

Moved TlsInfo struct to .SocketPartyCommunicationAgent.h so it can be accessed

Differential Revision: D38757760

