### PR TITLE
Add TlsInfo struct variable to SocketPartyCommunicationAgent

### DIFF
--- a/fbpcf/engine/communication/SocketPartyCommunicationAgent.cpp
+++ b/fbpcf/engine/communication/SocketPartyCommunicationAgent.cpp
@@ -219,10 +219,111 @@ void SocketPartyCommunicationAgent::openServerPortWithTls(
   ssl_ = ssl;
 }
 
+void SocketPartyCommunicationAgent::openServerPortWithTls(
+    int sockFd,
+    int portNo,
+    TlsInfo tlsInfo) {
+  LOG(INFO) << "try to connect as server at port " << portNo << " with TLS";
+  const SSL_METHOD* method;
+  SSL_CTX* ctx;
+
+  method = TLS_server_method();
+  ctx = SSL_CTX_new(method);
+
+  // Set passphrase for reading key.pem
+  SSL_CTX_set_default_passwd_cb(ctx, passwordCallback);
+
+  auto passphrase_file = tlsInfo.passphrasePath;
+  std::ifstream file_ptr(passphrase_file);
+  std::string passphrase_string = "";
+  file_ptr >> passphrase_string;
+  file_ptr.close();
+  SSL_CTX_set_default_passwd_cb_userdata(ctx, (void*)passphrase_string.c_str());
+
+  if (ctx == nullptr) {
+    LOG(INFO) << folly::errnoStr(errno);
+    throw std::runtime_error("Could not create tls context");
+  }
+
+  // Load the certificate file
+  if (SSL_CTX_use_certificate_file(
+          ctx, (tlsInfo.certPath).c_str(), SSL_FILETYPE_PEM) <= 0) {
+    LOG(INFO) << folly::errnoStr(errno);
+    throw std::runtime_error("Error using certificate file");
+  }
+
+  // Load the private key file
+  if (SSL_CTX_use_PrivateKey_file(
+          ctx, (tlsInfo.keyPath).c_str(), SSL_FILETYPE_PEM) <= 0) {
+    LOG(INFO) << folly::errnoStr(errno);
+    throw std::runtime_error("Error using private key file");
+  }
+
+  auto acceptedConnection = receiveFromClient(sockFd);
+
+  const auto ssl = SSL_new(ctx);
+  SSL_set_fd(ssl, acceptedConnection);
+
+  // Accept handshake from client
+  if (SSL_accept(ssl) <= 0) {
+    LOG(INFO) << folly::errnoStr(errno);
+    throw std::runtime_error("Error on accepting ssl");
+  }
+
+  LOG(INFO) << "connected as server at port " << portNo << " with TLS";
+
+  ssl_ = ssl;
+}
+
 void SocketPartyCommunicationAgent::openClientPortWithTls(
     const std::string& serverAddress,
     int portNo,
     std::string /* tls_dir */) {
+  XLOGF(
+      INFO,
+      "try to connect as client to {} at port {} with TLS",
+      serverAddress,
+      portNo);
+  const SSL_METHOD* method = TLS_client_method();
+  SSL_CTX* ctx = SSL_CTX_new(method);
+
+  // set cert verification callback for self signed certs
+  // comment above has more information
+  SSL_CTX_set_cert_verify_callback(
+      ctx, callbackToSkipVerificationOfSelfSignedCert_UNSAFE, nullptr);
+
+  if (ctx == nullptr) {
+    LOG(INFO) << folly::errnoStr(errno);
+    throw std::runtime_error("could not create tls context");
+  }
+
+  SSL* ssl = SSL_new(ctx);
+
+  if (ssl == nullptr) {
+    LOG(INFO) << folly::errnoStr(errno);
+    throw std::runtime_error("could not create tls object");
+  }
+
+  const auto sockfd = connectToHost(serverAddress, portNo);
+
+  SSL_set_fd(ssl, sockfd);
+
+  // initiate handshake with server
+  const int status = SSL_connect(ssl);
+  if (status != 1) {
+    LOG(INFO) << folly::errnoStr(errno);
+    throw std::runtime_error("could not complete tls handshake");
+  }
+
+  XLOGF(INFO, "connected as client to {} at port {}", serverAddress, portNo);
+
+  ssl_ = ssl;
+}
+
+void SocketPartyCommunicationAgent::openClientPortWithTls(
+    const std::string& serverAddress,
+    int portNo,
+    TlsInfo tlsInfo) {
   XLOGF(
       INFO,
       "try to connect as client to {} at port {} with TLS",

--- a/fbpcf/engine/communication/SocketPartyCommunicationAgent.cpp
+++ b/fbpcf/engine/communication/SocketPartyCommunicationAgent.cpp
@@ -67,6 +67,19 @@ SocketPartyCommunicationAgent::SocketPartyCommunicationAgent(
 }
 
 SocketPartyCommunicationAgent::SocketPartyCommunicationAgent(
+    int sockFd,
+    int portNo,
+    TlsInfo tlsInfo,
+    std::shared_ptr<PartyCommunicationAgentTrafficRecorder> recorder)
+    : recorder_(recorder), ssl_(nullptr), tlsInfo_(tlsInfo) {
+  if (tlsInfo.useTls) {
+    openServerPortWithTls(sockFd, portNo, tlsInfo);
+  } else {
+    openServerPort(sockFd, portNo);
+  }
+}
+
+SocketPartyCommunicationAgent::SocketPartyCommunicationAgent(
     const std::string& serverAddress,
     int portNo,
     bool useTls,
@@ -75,6 +88,19 @@ SocketPartyCommunicationAgent::SocketPartyCommunicationAgent(
     : recorder_(recorder), ssl_(nullptr) {
   if (useTls) {
     openClientPortWithTls(serverAddress, portNo, tlsDir);
+  } else {
+    openClientPort(serverAddress, portNo);
+  }
+}
+
+SocketPartyCommunicationAgent::SocketPartyCommunicationAgent(
+    const std::string& serverAddress,
+    int portNo,
+    TlsInfo tlsInfo,
+    std::shared_ptr<PartyCommunicationAgentTrafficRecorder> recorder)
+    : recorder_(recorder), ssl_(nullptr), tlsInfo_(tlsInfo) {
+  if (tlsInfo.useTls) {
+    openClientPortWithTls(serverAddress, portNo, tlsInfo);
   } else {
     openClientPort(serverAddress, portNo);
   }

--- a/fbpcf/engine/communication/SocketPartyCommunicationAgent.h
+++ b/fbpcf/engine/communication/SocketPartyCommunicationAgent.h
@@ -37,6 +37,12 @@ class SocketPartyCommunicationAgent final : public IPartyCommunicationAgent {
       std::string tlsDir,
       std::shared_ptr<PartyCommunicationAgentTrafficRecorder> recorder);
 
+  explicit SocketPartyCommunicationAgent(
+      int sockFd,
+      int portNo,
+      TlsInfo tlsInfo,
+      std::shared_ptr<PartyCommunicationAgentTrafficRecorder> recorder);
+
   /**
    * Created as socket client, optionally with TLS.
    */
@@ -45,6 +51,12 @@ class SocketPartyCommunicationAgent final : public IPartyCommunicationAgent {
       int portNo,
       bool useTls,
       std::string tlsDir,
+      std::shared_ptr<PartyCommunicationAgentTrafficRecorder> recorder);
+
+  SocketPartyCommunicationAgent(
+      const std::string& serverAddress,
+      int portNo,
+      TlsInfo tlsInfo,
       std::shared_ptr<PartyCommunicationAgentTrafficRecorder> recorder);
 
   ~SocketPartyCommunicationAgent() override;
@@ -86,6 +98,7 @@ class SocketPartyCommunicationAgent final : public IPartyCommunicationAgent {
   std::shared_ptr<PartyCommunicationAgentTrafficRecorder> recorder_;
 
   SSL* ssl_;
+  TlsInfo tlsInfo_;
 };
 
 } // namespace fbpcf::engine::communication

--- a/fbpcf/engine/communication/SocketPartyCommunicationAgent.h
+++ b/fbpcf/engine/communication/SocketPartyCommunicationAgent.h
@@ -21,6 +21,12 @@ namespace fbpcf::engine::communication {
  */
 class SocketPartyCommunicationAgent final : public IPartyCommunicationAgent {
  public:
+  struct TlsInfo {
+    bool useTls;
+    std::string certPath;
+    std::string keyPath;
+    std::string passphrasePath;
+  };
   /**
    * Create as socket server, optionally with TLS.
    */
@@ -59,10 +65,15 @@ class SocketPartyCommunicationAgent final : public IPartyCommunicationAgent {
   void openClientPort(const std::string& serverAddress, int portNo);
 
   void openServerPortWithTls(int sockFd, int portNo, std::string tlsDir);
+  void openServerPortWithTls(int sockFd, int portNo, TlsInfo tlsInfo);
   void openClientPortWithTls(
       const std::string& serverAddress,
       int portNo,
       std::string tlsDir);
+  void openClientPortWithTls(
+      const std::string& serverAddress,
+      int portNo,
+      TlsInfo tlsInfo);
 
   /*
    * helper functions for shared code between TLS and non-TLS implementations

--- a/fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h
+++ b/fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h
@@ -35,13 +35,6 @@ class SocketPartyCommunicationAgentFactory final
     int portNo;
   };
 
-  struct TlsInfo {
-    bool useTls;
-    std::string certPath;
-    std::string keyPath;
-    std::string passphrasePath;
-  };
-
   /** it's OK if a party with a smaller id doesn't know a party with larger id's
   * ip address, since the party with smaller id will always be the server.
   *@param partyInfos This is a map that contains connection information for all
@@ -79,7 +72,7 @@ establishing multiple connections (>3) between each party pair.
   SocketPartyCommunicationAgentFactory(
       int myId,
       std::map<int, PartyInfo> partyInfos,
-      TlsInfo tlsInfo,
+      SocketPartyCommunicationAgent::TlsInfo tlsInfo,
       std::string myname)
       : IPartyCommunicationAgentFactory(myname),
         myId_(myId),
@@ -117,7 +110,7 @@ establishing multiple connections (>3) between each party pair.
   bool useTls_;
   std::string tlsDir_;
 
-  TlsInfo tlsInfo_;
+  SocketPartyCommunicationAgent::TlsInfo tlsInfo_;
 };
 
 } // namespace fbpcf::engine::communication


### PR DESCRIPTION
Summary: Add TlsInfo struct variable as a member of SocketPartyCommunicationAgent and created two new constructors to reflect this change

Differential Revision: D38758665

