### PR TITLE
Add backward compatibility for TlsInfo variable in SocketPartyCommunicationAgentFactory

### DIFF
--- a/fbpcf/engine/communication/SocketPartyCommunicationAgent.cpp
+++ b/fbpcf/engine/communication/SocketPartyCommunicationAgent.cpp
@@ -67,6 +67,19 @@ SocketPartyCommunicationAgent::SocketPartyCommunicationAgent(
 }
 
 SocketPartyCommunicationAgent::SocketPartyCommunicationAgent(
+    int sockFd,
+    int portNo,
+    TlsInfo tlsInfo,
+    std::shared_ptr<PartyCommunicationAgentTrafficRecorder> recorder)
+    : recorder_(recorder), ssl_(nullptr), tlsInfo_(tlsInfo) {
+  if (tlsInfo.useTls) {
+    openServerPortWithTls(sockFd, portNo, tlsInfo);
+  } else {
+    openServerPort(sockFd, portNo);
+  }
+}
+
+SocketPartyCommunicationAgent::SocketPartyCommunicationAgent(
     const std::string& serverAddress,
     int portNo,
     bool useTls,
@@ -75,6 +88,19 @@ SocketPartyCommunicationAgent::SocketPartyCommunicationAgent(
     : recorder_(recorder), ssl_(nullptr) {
   if (useTls) {
     openClientPortWithTls(serverAddress, portNo, tlsDir);
+  } else {
+    openClientPort(serverAddress, portNo);
+  }
+}
+
+SocketPartyCommunicationAgent::SocketPartyCommunicationAgent(
+    const std::string& serverAddress,
+    int portNo,
+    TlsInfo tlsInfo,
+    std::shared_ptr<PartyCommunicationAgentTrafficRecorder> recorder)
+    : recorder_(recorder), ssl_(nullptr), tlsInfo_(tlsInfo) {
+  if (tlsInfo.useTls) {
+    openClientPortWithTls(serverAddress, portNo, tlsInfo);
   } else {
     openClientPort(serverAddress, portNo);
   }

--- a/fbpcf/engine/communication/SocketPartyCommunicationAgent.h
+++ b/fbpcf/engine/communication/SocketPartyCommunicationAgent.h
@@ -37,6 +37,12 @@ class SocketPartyCommunicationAgent final : public IPartyCommunicationAgent {
       std::string tlsDir,
       std::shared_ptr<PartyCommunicationAgentTrafficRecorder> recorder);
 
+  explicit SocketPartyCommunicationAgent(
+      int sockFd,
+      int portNo,
+      TlsInfo tlsInfo,
+      std::shared_ptr<PartyCommunicationAgentTrafficRecorder> recorder);
+
   /**
    * Created as socket client, optionally with TLS.
    */
@@ -45,6 +51,12 @@ class SocketPartyCommunicationAgent final : public IPartyCommunicationAgent {
       int portNo,
       bool useTls,
       std::string tlsDir,
+      std::shared_ptr<PartyCommunicationAgentTrafficRecorder> recorder);
+
+  SocketPartyCommunicationAgent(
+      const std::string& serverAddress,
+      int portNo,
+      TlsInfo tlsInfo,
       std::shared_ptr<PartyCommunicationAgentTrafficRecorder> recorder);
 
   ~SocketPartyCommunicationAgent() override;
@@ -86,6 +98,7 @@ class SocketPartyCommunicationAgent final : public IPartyCommunicationAgent {
   std::shared_ptr<PartyCommunicationAgentTrafficRecorder> recorder_;
 
   SSL* ssl_;
+  TlsInfo tlsInfo_;
 };
 
 } // namespace fbpcf::engine::communication

--- a/fbpcf/engine/communication/SocketPartyCommunicationAgent.h
+++ b/fbpcf/engine/communication/SocketPartyCommunicationAgent.h
@@ -21,6 +21,12 @@ namespace fbpcf::engine::communication {
  */
 class SocketPartyCommunicationAgent final : public IPartyCommunicationAgent {
  public:
+  struct TlsInfo {
+    bool useTls;
+    std::string certPath;
+    std::string keyPath;
+    std::string passphrasePath;
+  };
   /**
    * Create as socket server, optionally with TLS.
    */
@@ -59,10 +65,15 @@ class SocketPartyCommunicationAgent final : public IPartyCommunicationAgent {
   void openClientPort(const std::string& serverAddress, int portNo);
 
   void openServerPortWithTls(int sockFd, int portNo, std::string tlsDir);
+  void openServerPortWithTls(int sockFd, int portNo, TlsInfo tlsInfo);
   void openClientPortWithTls(
       const std::string& serverAddress,
       int portNo,
       std::string tlsDir);
+  void openClientPortWithTls(
+      const std::string& serverAddress,
+      int portNo,
+      TlsInfo tlsInfo);
 
   /*
    * helper functions for shared code between TLS and non-TLS implementations

--- a/fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h
+++ b/fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h
@@ -35,13 +35,6 @@ class SocketPartyCommunicationAgentFactory final
     int portNo;
   };
 
-  struct TlsInfo {
-    bool useTls;
-    std::string certPath;
-    std::string keyPath;
-    std::string passphrasePath;
-  };
-
   /** it's OK if a party with a smaller id doesn't know a party with larger id's
   * ip address, since the party with smaller id will always be the server.
   *@param partyInfos This is a map that contains connection information for all
@@ -79,7 +72,7 @@ establishing multiple connections (>3) between each party pair.
   SocketPartyCommunicationAgentFactory(
       int myId,
       std::map<int, PartyInfo> partyInfos,
-      TlsInfo tlsInfo,
+      SocketPartyCommunicationAgent::TlsInfo tlsInfo,
       std::string myname)
       : IPartyCommunicationAgentFactory(myname),
         myId_(myId),
@@ -117,7 +110,7 @@ establishing multiple connections (>3) between each party pair.
   bool useTls_;
   std::string tlsDir_;
 
-  TlsInfo tlsInfo_;
+  SocketPartyCommunicationAgent::TlsInfo tlsInfo_;
 };
 
 } // namespace fbpcf::engine::communication

--- a/fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h
+++ b/fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h
@@ -54,6 +54,12 @@ establishing multiple connections (>3) between each party pair.
         useTls_(false),
         tlsDir_("") {
     setupInitialConnection(partyInfos);
+    SocketPartyCommunicationAgent::TlsInfo tlsInfo;
+    tlsInfo.useTls = false;
+    tlsInfo.certPath = "";
+    tlsInfo.keyPath = "";
+    tlsInfo.passphrasePath = "";
+    tlsInfo_ = tlsInfo;
   }
 
   SocketPartyCommunicationAgentFactory(
@@ -67,6 +73,12 @@ establishing multiple connections (>3) between each party pair.
         useTls_(useTls),
         tlsDir_(tlsDir) {
     setupInitialConnection(partyInfos);
+    SocketPartyCommunicationAgent::TlsInfo tlsInfo;
+    tlsInfo.useTls = useTls;
+    tlsInfo.certPath = tlsDir + "/cert.pem";
+    tlsInfo.keyPath = tlsDir + "/key.pem";
+    tlsInfo.passphrasePath = tlsDir + "/passphrase.pem";
+    tlsInfo_ = tlsInfo;
   }
 
   SocketPartyCommunicationAgentFactory(


### PR DESCRIPTION
Summary: For backwards compatibility, modified the two old constructors in SocketPartyCommunicationAgentFactory to create an instance of the struct using the information provided. Set member variable to be the new struct

Differential Revision: D38764577

