### PR TITLE
Use recorders in tuple generators

### DIFF
--- a/fbpcf/engine/tuple_generator/TupleGenerator.h
+++ b/fbpcf/engine/tuple_generator/TupleGenerator.h
@@ -32,6 +32,7 @@ class TupleGenerator final : public ITupleGenerator {
       std::map<int, std::unique_ptr<IProductShareGenerator>>&&
           productShareGeneratorMap,
       std::unique_ptr<util::IPrg> prg,
+      std::shared_ptr<TuplesMetricRecorder> recorder,
       uint64_t bufferSize = kDefaultBufferSize);
 
   /**
@@ -68,6 +69,7 @@ class TupleGenerator final : public ITupleGenerator {
       productShareGeneratorMap_;
   std::unique_ptr<util::IPrg> prg_;
 
+  std::shared_ptr<TuplesMetricRecorder> recorder_;
   util::AsyncBuffer<BooleanTuple> asyncBuffer_;
 };
 

--- a/fbpcf/engine/tuple_generator/TupleGeneratorFactory.h
+++ b/fbpcf/engine/tuple_generator/TupleGeneratorFactory.h
@@ -45,9 +45,11 @@ class TupleGeneratorFactory final : public ITupleGeneratorFactory {
         productShareGeneratorMap.emplace(i, productShareFactory_->create(i));
       }
     }
+    auto recorder = std::make_shared<TuplesMetricRecorder>();
     return std::make_unique<TupleGenerator>(
         std::move(productShareGeneratorMap),
         prgFactory_->create(util::getRandomM128iFromSystemNoise()),
+        recorder,
         bufferSize_);
   }
 

--- a/fbpcf/engine/tuple_generator/TwoPartyTupleGenerator.h
+++ b/fbpcf/engine/tuple_generator/TwoPartyTupleGenerator.h
@@ -28,6 +28,7 @@ class TwoPartyTupleGenerator final : public ITupleGenerator {
       std::unique_ptr<oblivious_transfer::IRandomCorrelatedObliviousTransfer>
           receiverRcot,
       __m128i delta,
+      std::shared_ptr<TuplesMetricRecorder> recorder,
       uint64_t bufferSize = kDefaultBufferSize);
 
   /**
@@ -88,6 +89,8 @@ class TwoPartyTupleGenerator final : public ITupleGenerator {
   std::unique_ptr<oblivious_transfer::IRandomCorrelatedObliviousTransfer>
       receiverRcot_;
   __m128i delta_;
+
+  std::shared_ptr<TuplesMetricRecorder> recorder_;
 
   std::mutex scheduleMutex_;
   std::condition_variable cv_;

--- a/fbpcf/engine/tuple_generator/TwoPartyTupleGeneratorFactory.h
+++ b/fbpcf/engine/tuple_generator/TwoPartyTupleGeneratorFactory.h
@@ -60,9 +60,14 @@ class TwoPartyTupleGeneratorFactory final : public ITupleGeneratorFactory {
           agentFactory_.create(
               otherId, "two_party_tuple_generator_traffic_as_ot_sender"));
     }
+    auto recorder = std::make_shared<TuplesMetricRecorder>();
 
     return std::make_unique<TwoPartyTupleGenerator>(
-        std::move(senderRcot), std::move(receiverRcot), delta, bufferSize_);
+        std::move(senderRcot),
+        std::move(receiverRcot),
+        delta,
+        recorder,
+        bufferSize_);
   }
 
  private:


### PR DESCRIPTION
Summary:
We use the TuplesMetricRecorder in the TupleGenerator and TwoPartyTupleGenerators.

NOTE: we don't cover the DummyTupleGenerator. Also the exact count of composite tuples are not recorded.

Differential Revision: D38766107

