### PR TITLE
Using factories to create plaintext schedulers

### DIFF
--- a/fbpcf/scheduler/SchedulerHelper.h
+++ b/fbpcf/scheduler/SchedulerHelper.h
@@ -22,15 +22,6 @@
 namespace fbpcf::scheduler {
 
 template <bool unsafe>
-inline std::unique_ptr<IScheduler> createPlaintextScheduler(
-    int /*myId*/,
-    engine::communication::IPartyCommunicationAgentFactory&
-    /*communicationAgentFactory*/) {
-  return std::make_unique<PlaintextScheduler>(
-      WireKeeper::createWithVectorArena<unsafe>());
-}
-
-template <bool unsafe>
 inline std::unique_ptr<IScheduler> createNetworkPlaintextScheduler(
     int myId,
     engine::communication::IPartyCommunicationAgentFactory&

--- a/fbpcf/test/TestHelper.h
+++ b/fbpcf/test/TestHelper.h
@@ -17,6 +17,7 @@
 #include "fbpcf/engine/SecretShareEngineFactory.h"
 #include "fbpcf/engine/communication/IPartyCommunicationAgentFactory.h"
 #include "fbpcf/scheduler/IScheduler.h"
+#include "fbpcf/scheduler/PlaintextSchedulerFactory.h"
 #include "fbpcf/scheduler/SchedulerHelper.h"
 
 namespace fbpcf {
@@ -86,7 +87,11 @@ template <bool unsafe>
 inline SchedulerCreator getSchedulerCreator(SchedulerType schedulerType) {
   switch (schedulerType) {
     case SchedulerType::Plaintext:
-      return scheduler::createPlaintextScheduler<unsafe>;
+      return [](int myId,
+                engine::communication::IPartyCommunicationAgentFactory&
+                    communicationAgentFactory) {
+        return scheduler::PlaintextSchedulerFactory<unsafe>().create();
+      };
     case SchedulerType::NetworkPlaintext:
       return scheduler::createNetworkPlaintextScheduler<unsafe>;
     case SchedulerType::Eager:


### PR DESCRIPTION
Summary:
Change the callsites of the `createPlaintextScheduler` method to use the method from the PlaintextSchedulerFactory instead

Remove the createPlaintextScheduler method from SchedulerHelper.h

Reviewed By: robotal

Differential Revision: D38715411

