### PR TITLE
Using factories to create network plaintext schedulers

### DIFF
--- a/example/billionaire_problem/test/BillionaireProblemGameTest.cpp
+++ b/example/billionaire_problem/test/BillionaireProblemGameTest.cpp
@@ -96,7 +96,8 @@ void testWithScheduler(SchedulerCreator schedulerCreator) {
 }
 
 TEST(BillionaireProblemTest, testWithNetworkPlaintextScheduler) {
-  testWithScheduler(scheduler::createNetworkPlaintextScheduler<unsafe>);
+  testWithScheduler(fbpcf::getSchedulerCreator<unsafe>(
+      fbpcf::SchedulerType::NetworkPlaintext));
 }
 
 TEST(BillionaireProblemTest, testWithEagerScheduler) {
@@ -151,10 +152,7 @@ std::pair<std::vector<bool>, std::vector<uint64_t>> runBatchWithScheduler(
   return {mpcResult, myTotalAssets};
 }
 
-void testBatchBillionaireProblem(
-    std::unique_ptr<scheduler::IScheduler> schedulerCreator(
-        int,
-        engine::communication::IPartyCommunicationAgentFactory&)) {
+void testBatchBillionaireProblem(fbpcf::SchedulerCreator schedulerCreator) {
   auto factories = engine::communication::getInMemoryAgentFactory(2);
 
   int size = 16384;
@@ -189,8 +187,8 @@ void testBatchBillionaireProblem(
 }
 
 TEST(BillionaireProblemTest, testBatchWithNetworkPlaintextScheduler) {
-  testBatchBillionaireProblem(
-      scheduler::createNetworkPlaintextScheduler<unsafe>);
+  testBatchBillionaireProblem(fbpcf::getSchedulerCreator<unsafe>(
+      fbpcf::SchedulerType::NetworkPlaintext));
 }
 
 TEST(BillionaireProblemTest, testBatchWithEagerSchedulerAndFERRET) {

--- a/fbpcf/scheduler/SchedulerHelper.h
+++ b/fbpcf/scheduler/SchedulerHelper.h
@@ -22,19 +22,6 @@
 namespace fbpcf::scheduler {
 
 template <bool unsafe>
-inline std::unique_ptr<IScheduler> createNetworkPlaintextScheduler(
-    int myId,
-    engine::communication::IPartyCommunicationAgentFactory&
-        communicationAgentFactory) {
-  auto numberOfParties = 2;
-  auto agentMap = engine::communication::getAgentMap(
-      numberOfParties, myId, communicationAgentFactory);
-
-  return std::make_unique<NetworkPlaintextScheduler>(
-      myId, std::move(agentMap), WireKeeper::createWithVectorArena<unsafe>());
-}
-
-template <bool unsafe>
 inline std::unique_ptr<IArithmeticScheduler> createArithmeticPlaintextScheduler(
     int /*myId*/,
     engine::communication::IPartyCommunicationAgentFactory&

--- a/fbpcf/test/TestHelper.h
+++ b/fbpcf/test/TestHelper.h
@@ -17,6 +17,7 @@
 #include "fbpcf/engine/SecretShareEngineFactory.h"
 #include "fbpcf/engine/communication/IPartyCommunicationAgentFactory.h"
 #include "fbpcf/scheduler/IScheduler.h"
+#include "fbpcf/scheduler/NetworkPlaintextSchedulerFactory.h"
 #include "fbpcf/scheduler/PlaintextSchedulerFactory.h"
 #include "fbpcf/scheduler/SchedulerHelper.h"
 
@@ -93,7 +94,13 @@ inline SchedulerCreator getSchedulerCreator(SchedulerType schedulerType) {
         return scheduler::PlaintextSchedulerFactory<unsafe>().create();
       };
     case SchedulerType::NetworkPlaintext:
-      return scheduler::createNetworkPlaintextScheduler<unsafe>;
+      return [](int myId,
+                engine::communication::IPartyCommunicationAgentFactory&
+                    communicationAgentFactory) {
+        return scheduler::NetworkPlaintextSchedulerFactory<unsafe>(
+                   myId, communicationAgentFactory)
+            .create();
+      };
     case SchedulerType::Eager:
       return scheduler::createEagerSchedulerWithInsecureEngine<unsafe>;
     case SchedulerType::Lazy:


### PR DESCRIPTION
Summary:
Change the callsites of the `createNetworkPlaintextScheduler` method to use the method from the NetworkPlaintextSchedulerFactory instead

- [x] TestHelper.h
- [x] BillionaireProblemGameTest.cpp
- [x] ShardCombinerApp.h
- [x] InputProcessorTest.cpp
- [x] AggregationGameTest.cpp
- [x] AggregationApp.h
- [x] AttributorTest.cpp
- [x] AggregatorTest.cpp
- [x] CalculatorApp_impl.h

Finally, will remove the createNetworkPlaintextScheduler method from SchedulerHelper.h

Differential Revision: D38724193

