### PR TITLE
Add helper functions to create scheduler factories

### DIFF
--- a/fbpcf/scheduler/EagerSchedulerFactory.h
+++ b/fbpcf/scheduler/EagerSchedulerFactory.h
@@ -8,6 +8,8 @@
 #pragma once
 
 #include "fbpcf/engine/ISecretShareEngineFactory.h"
+#include "fbpcf/engine/SecretShareEngineFactory.h"
+#include "fbpcf/engine/communication/IPartyCommunicationAgentFactory.h"
 #include "fbpcf/scheduler/EagerScheduler.h"
 #include "fbpcf/scheduler/ISchedulerFactory.h"
 #include "fbpcf/scheduler/WireKeeper.h"
@@ -17,16 +19,57 @@ namespace fbpcf::scheduler {
 template <bool unsafe>
 class EagerSchedulerFactory final : public ISchedulerFactory<unsafe> {
  public:
-  EagerSchedulerFactory(engine::ISecretShareEngineFactory& engineFactory)
-      : engineFactory_(engineFactory) {}
+  EagerSchedulerFactory(
+      std::unique_ptr<engine::ISecretShareEngineFactory> engineFactory)
+      : engineFactory_(std::move(engineFactory)) {}
 
   std::unique_ptr<IScheduler> create() override {
     return std::make_unique<EagerScheduler>(
-        engineFactory_.create(), WireKeeper::createWithVectorArena<unsafe>());
+        engineFactory_->create(), WireKeeper::createWithVectorArena<unsafe>());
   }
 
  private:
-  engine::ISecretShareEngineFactory& engineFactory_;
+  std::unique_ptr<engine::ISecretShareEngineFactory> engineFactory_;
 };
+
+template <bool unsafe>
+inline std::unique_ptr<EagerSchedulerFactory<unsafe>>
+getEagerSchedulerFactoryWithInsecureEngine(
+    int myId,
+    engine::communication::IPartyCommunicationAgentFactory&
+        communicationAgentFactory) {
+  std::unique_ptr<engine::ISecretShareEngineFactory> engineFactory =
+      engine::getInsecureEngineFactoryWithDummyTupleGenerator(
+          myId, 2, communicationAgentFactory);
+
+  return std::make_unique<EagerSchedulerFactory<unsafe>>(
+      std::move(engineFactory));
+}
+
+inline std::unique_ptr<EagerSchedulerFactory</* unsafe */ true>>
+getEagerSchedulerFactoryWithClassicOT(
+    int myId,
+    engine::communication::IPartyCommunicationAgentFactory&
+        communicationAgentFactory) {
+  std::unique_ptr<engine::ISecretShareEngineFactory> engineFactory =
+      engine::getSecureEngineFactoryWithClassicOt<bool>(
+          myId, 2, communicationAgentFactory);
+
+  return std::make_unique<EagerSchedulerFactory</* unsafe */ true>>(
+      std::move(engineFactory));
+}
+
+inline std::unique_ptr<EagerSchedulerFactory</* unsafe */ true>>
+getEagerSchedulerFactoryWithRealEngine(
+    int myId,
+    engine::communication::IPartyCommunicationAgentFactory&
+        communicationAgentFactory) {
+  std::unique_ptr<engine::ISecretShareEngineFactory> engineFactory =
+      engine::getSecureEngineFactoryWithFERRET<bool>(
+          myId, 2, communicationAgentFactory);
+
+  return std::make_unique<EagerSchedulerFactory</* unsafe */ true>>(
+      std::move(engineFactory));
+}
 
 } // namespace fbpcf::scheduler

--- a/fbpcf/scheduler/LazySchedulerFactory.h
+++ b/fbpcf/scheduler/LazySchedulerFactory.h
@@ -8,6 +8,8 @@
 #pragma once
 
 #include "fbpcf/engine/ISecretShareEngineFactory.h"
+#include "fbpcf/engine/SecretShareEngineFactory.h"
+#include "fbpcf/engine/communication/IPartyCommunicationAgentFactory.h"
 #include "fbpcf/scheduler/ISchedulerFactory.h"
 #include "fbpcf/scheduler/LazyScheduler.h"
 #include "fbpcf/scheduler/WireKeeper.h"
@@ -18,21 +20,62 @@ namespace fbpcf::scheduler {
 template <bool unsafe>
 class LazySchedulerFactory final : public ISchedulerFactory<unsafe> {
  public:
-  LazySchedulerFactory(engine::ISecretShareEngineFactory& engineFactory)
-      : engineFactory_(engineFactory) {}
+  LazySchedulerFactory(
+      std::unique_ptr<fbpcf::engine::ISecretShareEngineFactory> engineFactory)
+      : engineFactory_(std::move(engineFactory)) {}
 
   std::unique_ptr<IScheduler> create() override {
     std::shared_ptr<IWireKeeper> wireKeeper =
         WireKeeper::createWithVectorArena<unsafe>();
 
     return std::make_unique<LazyScheduler>(
-        engineFactory_.create(),
+        engineFactory_->create(),
         wireKeeper,
         std::make_unique<GateKeeper>(wireKeeper));
   }
 
  private:
-  engine::ISecretShareEngineFactory& engineFactory_;
+  std::unique_ptr<fbpcf::engine::ISecretShareEngineFactory> engineFactory_;
 };
+
+template <bool unsafe>
+inline std::unique_ptr<LazySchedulerFactory<unsafe>>
+getLazySchedulerFactoryWithInsecureEngine(
+    int myId,
+    engine::communication::IPartyCommunicationAgentFactory&
+        communicationAgentFactory) {
+  std::unique_ptr<engine::ISecretShareEngineFactory> engineFactory =
+      engine::getInsecureEngineFactoryWithDummyTupleGenerator(
+          myId, 2, communicationAgentFactory);
+
+  return std::make_unique<LazySchedulerFactory<unsafe>>(
+      std::move(engineFactory));
+}
+
+inline std::unique_ptr<LazySchedulerFactory</* unsafe */ true>>
+getLazySchedulerFactoryWithClassicOT(
+    int myId,
+    engine::communication::IPartyCommunicationAgentFactory&
+        communicationAgentFactory) {
+  std::unique_ptr<engine::ISecretShareEngineFactory> engineFactory =
+      engine::getSecureEngineFactoryWithClassicOt<bool>(
+          myId, 2, communicationAgentFactory);
+
+  return std::make_unique<LazySchedulerFactory</* unsafe */ true>>(
+      std::move(engineFactory));
+}
+
+inline std::unique_ptr<LazySchedulerFactory</* unsafe */ true>>
+getLazySchedulerFactoryWithRealEngine(
+    int myId,
+    engine::communication::IPartyCommunicationAgentFactory&
+        communicationAgentFactory) {
+  std::unique_ptr<engine::ISecretShareEngineFactory> engineFactory =
+      engine::getSecureEngineFactoryWithFERRET<bool>(
+          myId, 2, communicationAgentFactory);
+
+  return std::make_unique<LazySchedulerFactory</* unsafe */ true>>(
+      std::move(engineFactory));
+}
 
 } // namespace fbpcf::scheduler


### PR DESCRIPTION
Summary:
We add helper functions to create scheduler factories, given a scheduler type and a newly added "engine type" enum.

In next diffs, will use these helper functions to gradually replace calls to create.*Scheduler.* methods in the codebase.

Differential Revision: D38799211

