### PR TITLE
Support integer BiDirection Oblivious Transfer

### DIFF
--- a/fbpcf/engine/communication/IPartyCommunicationAgent.h
+++ b/fbpcf/engine/communication/IPartyCommunicationAgent.h
@@ -125,13 +125,14 @@ class IPartyCommunicationAgent {
 
   template <typename T>
   void sendT(const std::vector<T>& src) {
-    send((std::vector<unsigned char>&)src);
+    sendImpl(static_cast<const void*>(src.data()), src.size() * sizeof(T));
   }
 
   template <typename T>
   std::vector<T> receiveT(int size) {
-    auto buf = receive(sizeof(T) * size);
-    return (std::vector<T>&)buf;
+    std::vector<T> rst(size);
+    recvImpl(static_cast<void*>(rst.data()), size * sizeof(T));
+    return rst;
   }
 
   template <typename T>

--- a/fbpcf/engine/util/Masker_impl.h
+++ b/fbpcf/engine/util/Masker_impl.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <emmintrin.h>
+#include <cstdint>
 #include <vector>
 #include "fbpcf/engine/util/util.h"
 
@@ -25,4 +26,16 @@ class Masker<bool> {
   }
 };
 
+template <>
+class Masker<uint64_t> {
+ public:
+  static uint64_t mask(uint64_t src, __m128i key) {
+    return src - getLast64Bits(key);
+  }
+  static uint64_t
+  unmask(__m128i key, bool choice, uint64_t correction0, uint64_t correction1) {
+    return getLast64Bits(key) +
+        (correction0 + choice * (correction1 - correction0));
+  }
+};
 } // namespace fbpcf::engine::util

--- a/fbpcf/engine/util/util.h
+++ b/fbpcf/engine/util/util.h
@@ -29,6 +29,9 @@ inline bool getLsb(__m128i src) {
   return _mm_extract_epi8(src, 0) & 1;
 }
 
+inline uint64_t getLast64Bits(__m128i src) {
+  return _mm_extract_epi64(src, 0);
+}
 /*
  * Extracts the last n bits in a 128 bit integer to the passed in boolean
  * vector. The order of bits will be from least significant to most significant.


### PR DESCRIPTION
Summary:
Modify BiDirectionOT to support integer values. Currently BiDirectionOT only supports sending boolean values even though the biDirectionOT() function has a template class T. The update needs the following two components:

1. Modify the send and receive functions in IPartyCommunicationAgent to support unsigned 64 bit integers.
2. Create a new class Masker<uint64_t> with mask() and unmask() functions.

Differential Revision: D38807982

