### PR TITLE
Add a matrix-vector multiplication API with a dummy implementation.

### DIFF
--- a/fbpcf/mpc_std_lib/walr_multiplication/DummyMatrixMultiplication.h
+++ b/fbpcf/mpc_std_lib/walr_multiplication/DummyMatrixMultiplication.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <fbpcf/engine/util/util.h>
+#include <algorithm>
+#include <stdexcept>
+#include "fbpcf/engine/communication/IPartyCommunicationAgent.h"
+#include "fbpcf/mpc_std_lib/walr_multiplication/IWalrMatrixMultiplication.h"
+
+namespace fbpcf::mpc_std_lib::walr::insecure {
+
+/**
+ * An insecure multiplication implementation. It should not be used in
+ * production.
+ */
+template <int schedulerId>
+class DummyMatrixMultiplication final
+    : public IWalrMatrixMultiplication<schedulerId> {
+ public:
+  explicit DummyMatrixMultiplication(
+      int myId,
+      int partnerId,
+      std::unique_ptr<engine::communication::IPartyCommunicationAgent> agent)
+      : myId_(myId), partnerId_(partnerId), agent_(std::move(agent)) {}
+
+  /**
+   * @inherit doc
+   */
+  std::vector<double> matrixVectorMultiplication(
+      const std::vector<std::vector<double>>& features,
+      const frontend::Bit<true, schedulerId, true>& labels) const {
+    // Each features[i] represents a column vector of the feature matrix.
+    // There are `nLabels` such column vectors.
+    size_t nLabels = labels.getBatchSize();
+    if (nLabels != features.size()) {
+      throw std::invalid_argument(
+          "The input sizes are not compatible: "
+          "The number of columns (features.size()) does not equal"
+          "the number of labels.");
+    }
+
+    size_t nFeatures = features[0].size();
+    std::vector<double> rst(nFeatures, 0);
+    auto revealedValues = labels.openToParty(myId_).getValue();
+    for (size_t i = 0; i < nLabels; ++i) {
+      if (features[i].size() != nFeatures) {
+        throw std::invalid_argument(
+            "Columns of the feature matrix have different sizes.");
+      }
+
+      if (revealedValues[i]) {
+        std::transform( // add the column vector to rst
+            rst.cbegin(),
+            rst.cend(),
+            features[i].cbegin(),
+            rst.begin(),
+            std::plus<double>());
+      }
+    }
+
+    // receive the DP noise from the label owner
+    std::vector<double> dpNoise = agent_->receiveT<double>(nFeatures);
+    std::transform( // add the DP noise to rst
+        rst.cbegin(),
+        rst.cend(),
+        dpNoise.cbegin(),
+        rst.begin(),
+        std::plus<double>());
+    return rst;
+  }
+
+  /**
+   * @inherit doc
+   */
+  void matrixVectorMultiplication(
+      const frontend::Bit<true, schedulerId, true>& labels,
+      const std::vector<double>& dpNoise) const {
+    labels.openToParty(partnerId_);
+    agent_->sendT<double>(dpNoise);
+  }
+
+ private:
+  int myId_;
+  int partnerId_;
+  std::unique_ptr<engine::communication::IPartyCommunicationAgent> agent_;
+};
+} // namespace fbpcf::mpc_std_lib::walr::insecure

--- a/fbpcf/mpc_std_lib/walr_multiplication/DummyMatrixMultiplicationFactory.h
+++ b/fbpcf/mpc_std_lib/walr_multiplication/DummyMatrixMultiplicationFactory.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "fbpcf/engine/communication/IPartyCommunicationAgentFactory.h"
+#include "fbpcf/mpc_std_lib/walr_multiplication/DummyMatrixMultiplication.h"
+#include "fbpcf/mpc_std_lib/walr_multiplication/IWalrMatrixMultiplication.h"
+#include "fbpcf/mpc_std_lib/walr_multiplication/IWalrMatrixMultiplicationFactory.h"
+
+namespace fbpcf::mpc_std_lib::walr::insecure {
+
+template <int schedulerId>
+class DummyMatrixMultiplicationFactory final
+    : public IWalrMatrixMultiplicationFactory<schedulerId> {
+ public:
+  explicit DummyMatrixMultiplicationFactory(
+      int myId,
+      int partnerId,
+      engine::communication::IPartyCommunicationAgentFactory& agentFactory)
+      : myId_(myId), partnerId_(partnerId), agentFactory_(agentFactory) {}
+
+  std::unique_ptr<IWalrMatrixMultiplication<schedulerId>> create() override {
+    return std::make_unique<DummyMatrixMultiplication<schedulerId>>(
+        myId_,
+        partnerId_,
+        agentFactory_.create(
+            partnerId_,
+            "walr_matrix_multiplication_traffic_to_party " +
+                std::to_string(partnerId_)));
+  }
+
+ private:
+  int myId_;
+  int partnerId_;
+  engine::communication::IPartyCommunicationAgentFactory& agentFactory_;
+};
+
+} // namespace fbpcf::mpc_std_lib::walr::insecure

--- a/fbpcf/mpc_std_lib/walr_multiplication/IWalrMatrixMultiplication.h
+++ b/fbpcf/mpc_std_lib/walr_multiplication/IWalrMatrixMultiplication.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <vector>
+
+#include "fbpcf/frontend/Bit.h"
+
+namespace fbpcf::mpc_std_lib::walr {
+
+template <int schedulerId>
+class IWalrMatrixMultiplication {
+  using FixedPointType = uint64_t;
+
+ public:
+  virtual ~IWalrMatrixMultiplication() = default;
+  /**
+   * The API for the caller with features and label shares.
+   * @param features: the feature matrix. Each element is a column vector of the
+   * feature matrix.
+   * @param labels: the label vector represented as a batch of Bits,
+   * consisting of only (secret) boolean labels.
+   * To make the shape compatible, one must have features.size() ==
+   * labels.getBatchSize().
+   * @return the product of feature matrix and the label vector.
+   */
+  virtual std::vector<double> matrixVectorMultiplication(
+      const std::vector<std::vector<double>>& features,
+      const frontend::Bit<true, schedulerId, true>& labels) const = 0;
+
+  /**
+   * The API for the caller with only label shares.
+   * @param labels: the label vector consisting of only (secret) boolean labels.
+   * @param dpNoise: the dp noise that would be imposed on the output.
+   */
+  virtual void matrixVectorMultiplication(
+      const frontend::Bit<true, schedulerId, true>& labels,
+      const std::vector<double>& dpNoise) const = 0;
+};
+
+} // namespace fbpcf::mpc_std_lib::walr

--- a/fbpcf/mpc_std_lib/walr_multiplication/IWalrMatrixMultiplicationFactory.h
+++ b/fbpcf/mpc_std_lib/walr_multiplication/IWalrMatrixMultiplicationFactory.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "fbpcf/mpc_std_lib/walr_multiplication/IWalrMatrixMultiplication.h"
+namespace fbpcf::mpc_std_lib::walr {
+
+template <int schedulerId>
+class IWalrMatrixMultiplicationFactory {
+ public:
+  virtual ~IWalrMatrixMultiplicationFactory() = default;
+  virtual std::unique_ptr<IWalrMatrixMultiplication<schedulerId>> create() = 0;
+};
+
+} // namespace fbpcf::mpc_std_lib::walr

--- a/fbpcf/mpc_std_lib/walr_multiplication/test/WalrMatrixMultiplicationTest.cpp
+++ b/fbpcf/mpc_std_lib/walr_multiplication/test/WalrMatrixMultiplicationTest.cpp
@@ -1,0 +1,277 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <future>
+#include <memory>
+#include <random>
+#include <tuple>
+#include <vector>
+
+#include "fbpcf/engine/communication/test/AgentFactoryCreationHelper.h"
+#include "fbpcf/mpc_std_lib/walr_multiplication/DummyMatrixMultiplication.h"
+#include "fbpcf/mpc_std_lib/walr_multiplication/DummyMatrixMultiplicationFactory.h"
+#include "fbpcf/mpc_std_lib/walr_multiplication/IWalrMatrixMultiplication.h"
+#include "fbpcf/mpc_std_lib/walr_multiplication/IWalrMatrixMultiplicationFactory.h"
+#include "fbpcf/test/TestHelper.h"
+
+namespace fbpcf::mpc_std_lib::walr {
+
+std::vector<std::vector<double>> generateRandomFeatures(
+    size_t nFeatures,
+    size_t nLabels,
+    double a = 0.0,
+    double b = 1.0) {
+  std::vector<std::vector<double>> features;
+  std::random_device rd;
+  std::mt19937_64 e(rd());
+  std::uniform_real_distribution<double> dist(a, b);
+  for (int i = 0; i < nLabels; ++i) {
+    std::vector<double> column(nFeatures);
+    std::generate(
+        column.begin(), column.end(), [&dist, &e]() { return dist(e); });
+    features.push_back(column);
+  }
+  return features;
+}
+
+std::vector<bool> generateRandomLabels(size_t nLabels, double p = 0.5) {
+  std::vector<bool> labels(nLabels);
+  std::random_device rd;
+  std::mt19937_64 e(rd());
+  std::bernoulli_distribution dist(p);
+  std::generate(
+      labels.begin(), labels.end(), [&dist, &e]() { return dist(e); });
+  return labels;
+}
+
+std::vector<double>
+generateRandomNoise(size_t n, double a = 0, double b = 1.0) {
+  std::vector<double> noise(n);
+  std::random_device rd;
+  std::mt19937_64 e(rd());
+  std::uniform_real_distribution dist(a, b);
+  std::generate(noise.begin(), noise.end(), [&dist, &e]() { return dist(e); });
+  return noise;
+}
+
+// This should be invoked only after corresponding schedulers are created
+// The secret label is owned by party.
+template <int featureOwnerSchedulerId, int labelOwnerSchedulerId>
+std::pair<
+    frontend::Bit<true, featureOwnerSchedulerId, true>,
+    frontend::Bit<true, labelOwnerSchedulerId, true>>
+generateSecretLabelShares(
+    const std::vector<bool>& labelValues,
+    int labelOwnerPartyId) {
+  frontend::Bit<true, featureOwnerSchedulerId, true> featureOwnerShare(
+      std::vector<bool>(labelValues.size(), true), labelOwnerPartyId);
+  frontend::Bit<true, labelOwnerSchedulerId, true> labelOwnerShare(
+      labelValues, labelOwnerPartyId);
+  return {featureOwnerShare, labelOwnerShare};
+}
+
+std::vector<double> plaintextMatrixVectorMultiplication(
+    const std::vector<std::vector<double>>& features,
+    const std::vector<bool>& labels) {
+  std::vector<double> rst(features.at(0).size());
+  for (int i = 0; i < labels.size(); ++i) {
+    if (labels[i]) {
+      std::transform(
+          rst.cbegin(),
+          rst.cend(),
+          features[i].cbegin(),
+          rst.begin(),
+          std::plus<double>());
+    }
+  }
+  return rst;
+}
+
+// helper function for comparing two double vectors
+void testVectorAlmostEq(
+    const std::vector<double>& vec1,
+    const std::vector<double>& vec2,
+    double absError) {
+  ASSERT_EQ(vec1.size(), vec2.size());
+  for (size_t i = 0; i < vec1.size(); ++i) {
+    // Test if the absolute error is within tolerance
+    EXPECT_NEAR(vec1[i], vec2[i], absError) << "at position: " << i;
+  }
+}
+
+// template test for matrix-vector multiplication
+template <
+    int featureOwnerSchedulerId,
+    int labelOwnerSchedulerId,
+    int featureOwnerId,
+    int labelOwnerId>
+void matrixVectorMultiplicationTestHelper(
+    std::unique_ptr<IWalrMatrixMultiplicationFactory<featureOwnerSchedulerId>>
+        featureOwnerFactory,
+    std::unique_ptr<IWalrMatrixMultiplicationFactory<labelOwnerSchedulerId>>
+        labelOwnerFactory,
+    const std::vector<std::vector<double>>& testFeatures,
+    const std::vector<bool>& testLabelValues,
+    const std::vector<double>& testDpNoise,
+    const std::vector<double>& expectedOutput,
+    double tolerance = 1e-7) {
+  // setup mpc engine and schedulers
+  auto agentFactories = engine::communication::getInMemoryAgentFactory(2);
+  setupRealBackend<featureOwnerSchedulerId, labelOwnerSchedulerId>(
+      *agentFactories[featureOwnerId], *agentFactories[labelOwnerId]);
+
+  frontend::Bit<true, featureOwnerSchedulerId, true> testLabelsShare0;
+  frontend::Bit<true, labelOwnerSchedulerId, true> testLabelsShare1;
+  std::tie(testLabelsShare0, testLabelsShare1) =
+      generateSecretLabelShares<featureOwnerSchedulerId, labelOwnerSchedulerId>(
+          testLabelValues, labelOwnerId);
+
+  auto task0 = [&testFeatures, &testLabelsShare0](
+                   std::unique_ptr<IWalrMatrixMultiplicationFactory<
+                       featureOwnerSchedulerId>> partyFactory) {
+    return partyFactory->create()->matrixVectorMultiplication(
+        testFeatures, testLabelsShare0);
+  };
+  auto task1 = [&testLabelsShare1](
+                   std::unique_ptr<IWalrMatrixMultiplicationFactory<
+                       labelOwnerSchedulerId>> partyFactory,
+                   const std::vector<double>& dpNoise) {
+    partyFactory->create()->matrixVectorMultiplication(
+        testLabelsShare1, dpNoise);
+  };
+
+  auto future0 = std::async(task0, std::move(featureOwnerFactory));
+  auto future1 = std::async(task1, std::move(labelOwnerFactory), testDpNoise);
+  auto rst = future0.get();
+  future1.get();
+
+  testVectorAlmostEq(rst, expectedOutput, tolerance);
+}
+
+template <
+    int featureOwnerSchedulerId,
+    int labelOwnerSchedulerId,
+    int featureOwnerId,
+    int labelOwnerId>
+void matrixVectorMultiplicationNoNoiseTest(
+    std::unique_ptr<IWalrMatrixMultiplicationFactory<featureOwnerSchedulerId>>
+        featureOwnerFactory,
+    std::unique_ptr<IWalrMatrixMultiplicationFactory<labelOwnerSchedulerId>>
+        labelOwnerFactory,
+    double tolerance = 1e-7) {
+  // generate test data
+  size_t nFeatures = 150;
+  size_t nLabels = 200;
+  // Random features and labels
+  auto testFeatures = generateRandomFeatures(nFeatures, nLabels, -2.0, 4.0);
+  auto testLabelValues = generateRandomLabels(nLabels);
+
+  auto expectedOutput =
+      plaintextMatrixVectorMultiplication(testFeatures, testLabelValues);
+
+  matrixVectorMultiplicationTestHelper<
+      featureOwnerSchedulerId,
+      labelOwnerSchedulerId,
+      featureOwnerId,
+      labelOwnerId>(
+      std::move(featureOwnerFactory),
+      std::move(labelOwnerFactory),
+      testFeatures,
+      testLabelValues,
+      std::vector<double>(nFeatures, 0.0), // no DP noise
+      expectedOutput,
+      tolerance);
+}
+
+// (2) Test with uniform random noise
+template <
+    int featureOwnerSchedulerId,
+    int labelOwnerSchedulerId,
+    int featureOwnerId,
+    int labelOwnerId>
+void matrixVectorMultiplicationUniformNoiseTest(
+    std::unique_ptr<IWalrMatrixMultiplicationFactory<featureOwnerSchedulerId>>
+        featureOwnerFactory,
+    std::unique_ptr<IWalrMatrixMultiplicationFactory<labelOwnerSchedulerId>>
+        labelOwnerFactory,
+    double tolerance = 1e-7) {
+  // generate test data
+  size_t nFeatures = 200;
+  size_t nLabels = 150;
+  // Random features and labels
+  auto testFeatures = generateRandomFeatures(nFeatures, nLabels, -2.0, 4.0);
+  auto testLabelValues = generateRandomLabels(nLabels);
+
+  auto expectedOutput =
+      plaintextMatrixVectorMultiplication(testFeatures, testLabelValues);
+  auto magnitude = *std::max_element(
+      expectedOutput.cbegin(), expectedOutput.cend(), [](double a, double b) {
+        return (std::abs(a) < std::abs(b));
+      });
+  magnitude = std::abs(magnitude);
+  auto uniformNoise = generateRandomNoise(nFeatures, -2 * magnitude, magnitude);
+
+  // Add the noise to the expectedOutput
+  std::transform(
+      expectedOutput.cbegin(),
+      expectedOutput.cend(),
+      uniformNoise.cbegin(),
+      expectedOutput.begin(),
+      std::plus<double>());
+
+  matrixVectorMultiplicationTestHelper<
+      featureOwnerSchedulerId,
+      labelOwnerSchedulerId,
+      featureOwnerId,
+      labelOwnerId>(
+      std::move(featureOwnerFactory),
+      std::move(labelOwnerFactory),
+      testFeatures,
+      testLabelValues,
+      uniformNoise,
+      expectedOutput,
+      tolerance);
+}
+
+TEST(matrixVectorMultiplicationNoNoiseTest, testDummyMatrixMultiplication) {
+  auto agentFactories = engine::communication::getInMemoryAgentFactory(2);
+  // feature owner is party 0 and uses scheduler 0
+  // label owner is party 1 and uses scheduler 1
+  auto featureOwnerFactory =
+      std::make_unique<insecure::DummyMatrixMultiplicationFactory<0>>(
+          0, 1, *agentFactories[0]);
+  auto labelOwnerFactory =
+      std::make_unique<insecure::DummyMatrixMultiplicationFactory<1>>(
+          1, 0, *agentFactories[1]);
+
+  matrixVectorMultiplicationNoNoiseTest<0, 1, 0, 1>(
+      std::move(featureOwnerFactory), std::move(labelOwnerFactory), 1e-7);
+}
+
+TEST(
+    matrixVectorMultiplicationUniformNoiseTest,
+    testDummyMatrixMultiplication) {
+  auto agentFactories = engine::communication::getInMemoryAgentFactory(2);
+  // feature owner is party 0 and uses scheduler 0
+  // label owner is party 1 and uses scheduler 1
+  auto featureOwnerFactory =
+      std::make_unique<insecure::DummyMatrixMultiplicationFactory<0>>(
+          0, 1, *agentFactories[0]);
+  auto labelOwnerFactory =
+      std::make_unique<insecure::DummyMatrixMultiplicationFactory<1>>(
+          1, 0, *agentFactories[1]);
+
+  matrixVectorMultiplicationUniformNoiseTest<0, 1, 0, 1>(
+      std::move(featureOwnerFactory), std::move(labelOwnerFactory), 1e-7);
+}
+} // namespace fbpcf::mpc_std_lib::walr


### PR DESCRIPTION
Summary:
This diff creates the API for matrix multiplication in the WALR project. Currently the main goal is to provide functionality to multiply a feature matrix (owned by Meta) with a boolean label vector (owned by our partner). The result is only revealed to Meta.

### Content
* API for classes that provides the matrix-vector multiplication functionality: `IWalrMatrixMultiplication`
* A dummy (insecure) implementation that conduct the multiplication but leaks information: `DummyMatrixMultiplication`.
  * Communication cost of the dummy multiplier: `O(M+N)` where `N` is the size of the label vector and `M` is the size of the DP noise vector.
* Unittest for the dummy multiplier.

Differential Revision: D38760026

