### PR TITLE
Back out "Using factories to create network plaintext schedulers"

### DIFF
--- a/example/billionaire_problem/test/BillionaireProblemGameTest.cpp
+++ b/example/billionaire_problem/test/BillionaireProblemGameTest.cpp
@@ -96,8 +96,7 @@ void testWithScheduler(SchedulerCreator schedulerCreator) {
 }
 
 TEST(BillionaireProblemTest, testWithNetworkPlaintextScheduler) {
-  testWithScheduler(fbpcf::getSchedulerCreator<unsafe>(
-      fbpcf::SchedulerType::NetworkPlaintext));
+  testWithScheduler(scheduler::createNetworkPlaintextScheduler<unsafe>);
 }
 
 TEST(BillionaireProblemTest, testWithEagerScheduler) {
@@ -152,7 +151,10 @@ std::pair<std::vector<bool>, std::vector<uint64_t>> runBatchWithScheduler(
   return {mpcResult, myTotalAssets};
 }
 
-void testBatchBillionaireProblem(fbpcf::SchedulerCreator schedulerCreator) {
+void testBatchBillionaireProblem(
+    std::unique_ptr<scheduler::IScheduler> schedulerCreator(
+        int,
+        engine::communication::IPartyCommunicationAgentFactory&)) {
   auto factories = engine::communication::getInMemoryAgentFactory(2);
 
   int size = 16384;
@@ -187,8 +189,8 @@ void testBatchBillionaireProblem(fbpcf::SchedulerCreator schedulerCreator) {
 }
 
 TEST(BillionaireProblemTest, testBatchWithNetworkPlaintextScheduler) {
-  testBatchBillionaireProblem(fbpcf::getSchedulerCreator<unsafe>(
-      fbpcf::SchedulerType::NetworkPlaintext));
+  testBatchBillionaireProblem(
+      scheduler::createNetworkPlaintextScheduler<unsafe>);
 }
 
 TEST(BillionaireProblemTest, testBatchWithEagerSchedulerAndFERRET) {

--- a/fbpcf/scheduler/SchedulerHelper.h
+++ b/fbpcf/scheduler/SchedulerHelper.h
@@ -22,6 +22,19 @@
 namespace fbpcf::scheduler {
 
 template <bool unsafe>
+inline std::unique_ptr<IScheduler> createNetworkPlaintextScheduler(
+    int myId,
+    engine::communication::IPartyCommunicationAgentFactory&
+        communicationAgentFactory) {
+  auto numberOfParties = 2;
+  auto agentMap = engine::communication::getAgentMap(
+      numberOfParties, myId, communicationAgentFactory);
+
+  return std::make_unique<NetworkPlaintextScheduler>(
+      myId, std::move(agentMap), WireKeeper::createWithVectorArena<unsafe>());
+}
+
+template <bool unsafe>
 inline std::unique_ptr<IArithmeticScheduler> createArithmeticPlaintextScheduler(
     int /*myId*/,
     engine::communication::IPartyCommunicationAgentFactory&

--- a/fbpcf/test/TestHelper.h
+++ b/fbpcf/test/TestHelper.h
@@ -17,7 +17,6 @@
 #include "fbpcf/engine/SecretShareEngineFactory.h"
 #include "fbpcf/engine/communication/IPartyCommunicationAgentFactory.h"
 #include "fbpcf/scheduler/IScheduler.h"
-#include "fbpcf/scheduler/NetworkPlaintextSchedulerFactory.h"
 #include "fbpcf/scheduler/PlaintextSchedulerFactory.h"
 #include "fbpcf/scheduler/SchedulerHelper.h"
 
@@ -94,13 +93,7 @@ inline SchedulerCreator getSchedulerCreator(SchedulerType schedulerType) {
         return scheduler::PlaintextSchedulerFactory<unsafe>().create();
       };
     case SchedulerType::NetworkPlaintext:
-      return [](int myId,
-                engine::communication::IPartyCommunicationAgentFactory&
-                    communicationAgentFactory) {
-        return scheduler::NetworkPlaintextSchedulerFactory<unsafe>(
-                   myId, communicationAgentFactory)
-            .create();
-      };
+      return scheduler::createNetworkPlaintextScheduler<unsafe>;
     case SchedulerType::Eager:
       return scheduler::createEagerSchedulerWithInsecureEngine<unsafe>;
     case SchedulerType::Lazy:


### PR DESCRIPTION
Summary:
Original commit changeset: c97f4865bed0

Original Phabricator Diff: D38724193 (https://github.com/facebookresearch/fbpcf/commit/66d10c394df5ab5a814d19e724f85628ce91fac2)

Reviewed By: adshastri

Differential Revision: D38842909

