### PR TITLE
Create a getBatchSize() method in Scheduler

### DIFF
--- a/fbpcf/frontend/test/schedulerMock.h
+++ b/fbpcf/frontend/test/schedulerMock.h
@@ -345,6 +345,16 @@ class schedulerMock final : public scheduler::IScheduler {
     return {0, 0};
   }
 
+  size_t getBatchSize(
+      IScheduler::WireId<IScheduler::Boolean> /*id*/) const override {
+    return 0;
+  }
+
+  size_t getBatchSize(
+      IScheduler::WireId<IScheduler::Arithmetic> /*id*/) const override {
+    return 0;
+  }
+
  private:
   int wireId = 1;
 };

--- a/fbpcf/scheduler/EagerScheduler.cpp
+++ b/fbpcf/scheduler/EagerScheduler.cpp
@@ -32,7 +32,7 @@ EagerScheduler::privateBooleanInputBatch(
     int partyId) {
   freeGates_ += v.size();
   return wireKeeper_->allocateBatchBooleanValue(
-      engine_->setBatchInput(partyId, v));
+      engine_->setBatchInput(partyId, v), v.size());
 }
 
 IScheduler::WireId<IScheduler::Boolean> EagerScheduler::publicBooleanInput(
@@ -44,7 +44,7 @@ IScheduler::WireId<IScheduler::Boolean> EagerScheduler::publicBooleanInput(
 IScheduler::WireId<IScheduler::Boolean> EagerScheduler::publicBooleanInputBatch(
     const std::vector<bool>& v) {
   freeGates_ += v.size();
-  return wireKeeper_->allocateBatchBooleanValue(v);
+  return wireKeeper_->allocateBatchBooleanValue(v, v.size());
 }
 
 IScheduler::WireId<IScheduler::Boolean> EagerScheduler::recoverBooleanWire(
@@ -56,7 +56,7 @@ IScheduler::WireId<IScheduler::Boolean> EagerScheduler::recoverBooleanWire(
 IScheduler::WireId<IScheduler::Boolean> EagerScheduler::recoverBooleanWireBatch(
     const std::vector<bool>& v) {
   freeGates_ += v.size();
-  return wireKeeper_->allocateBatchBooleanValue(v);
+  return wireKeeper_->allocateBatchBooleanValue(v, v.size());
 }
 
 IScheduler::WireId<IScheduler::Boolean> EagerScheduler::openBooleanValueToParty(
@@ -82,7 +82,8 @@ EagerScheduler::openBooleanValueToPartyBatch(
   auto revealedSecrets = engine_->revealToParty(partyId, secretShares);
 
   if (revealedSecrets.size() == secretShares.size()) {
-    return wireKeeper_->allocateBatchBooleanValue(revealedSecrets);
+    return wireKeeper_->allocateBatchBooleanValue(
+        revealedSecrets, secretShares.size());
   } else {
     throw std::runtime_error(
         "Unexpected number of revealed secrets " +
@@ -122,7 +123,7 @@ EagerScheduler::privateIntegerInputBatch(
     int partyId) {
   freeGates_ += v.size();
   return wireKeeper_->allocateBatchIntegerValue(
-      engine_->setBatchIntegerInput(partyId, v));
+      engine_->setBatchIntegerInput(partyId, v), v.size());
 }
 
 IScheduler::WireId<IScheduler::Arithmetic> EagerScheduler::publicIntegerInput(
@@ -134,7 +135,7 @@ IScheduler::WireId<IScheduler::Arithmetic> EagerScheduler::publicIntegerInput(
 IScheduler::WireId<IScheduler::Arithmetic>
 EagerScheduler::publicIntegerInputBatch(const std::vector<uint64_t>& v) {
   freeGates_ += v.size();
-  return wireKeeper_->allocateBatchIntegerValue(v);
+  return wireKeeper_->allocateBatchIntegerValue(v, v.size());
 }
 
 IScheduler::WireId<IScheduler::Arithmetic> EagerScheduler::recoverIntegerWire(
@@ -146,7 +147,7 @@ IScheduler::WireId<IScheduler::Arithmetic> EagerScheduler::recoverIntegerWire(
 IScheduler::WireId<IScheduler::Arithmetic>
 EagerScheduler::recoverIntegerWireBatch(const std::vector<uint64_t>& v) {
   freeGates_ += v.size();
-  return wireKeeper_->allocateBatchIntegerValue(v);
+  return wireKeeper_->allocateBatchIntegerValue(v, v.size());
 }
 
 IScheduler::WireId<IScheduler::Arithmetic>
@@ -173,7 +174,8 @@ EagerScheduler::openIntegerValueToPartyBatch(
   auto revealedSecrets = engine_->revealToParty(partyId, secretShares);
 
   if (revealedSecrets.size() == secretShares.size()) {
-    return wireKeeper_->allocateBatchIntegerValue(revealedSecrets);
+    return wireKeeper_->allocateBatchIntegerValue(
+        revealedSecrets, secretShares.size());
   } else {
     throw std::runtime_error(
         "Unexpected number of revealed secrets " +
@@ -218,7 +220,8 @@ IScheduler::WireId<IScheduler::Boolean> EagerScheduler::privateAndPrivateBatch(
   auto rightValue = wireKeeper_->getBatchBooleanValue(right);
   nonFreeGates_ += leftValue.size();
   return wireKeeper_->allocateBatchBooleanValue(
-      engine_->computeBatchANDImmediately(leftValue, rightValue));
+      engine_->computeBatchANDImmediately(leftValue, rightValue),
+      leftValue.size());
 }
 
 IScheduler::WireId<IScheduler::Boolean> EagerScheduler::privateAndPublic(
@@ -236,7 +239,7 @@ IScheduler::WireId<IScheduler::Boolean> EagerScheduler::privateAndPublicBatch(
   auto rightValue = wireKeeper_->getBatchBooleanValue(right);
   freeGates_ += leftValue.size();
   return wireKeeper_->allocateBatchBooleanValue(
-      engine_->computeBatchFreeAND(leftValue, rightValue));
+      engine_->computeBatchFreeAND(leftValue, rightValue), leftValue.size());
 }
 
 IScheduler::WireId<IScheduler::Boolean> EagerScheduler::publicAndPublic(
@@ -254,7 +257,7 @@ IScheduler::WireId<IScheduler::Boolean> EagerScheduler::publicAndPublicBatch(
   auto rightValue = wireKeeper_->getBatchBooleanValue(right);
   freeGates_ += leftValue.size();
   return wireKeeper_->allocateBatchBooleanValue(
-      engine_->computeBatchFreeAND(leftValue, rightValue));
+      engine_->computeBatchFreeAND(leftValue, rightValue), leftValue.size());
 }
 
 std::vector<IScheduler::WireId<IScheduler::Boolean>>
@@ -294,8 +297,9 @@ EagerScheduler::privateAndPrivateCompositeBatch(
   auto result = engine_->getBatchCompositeANDExecutionResult(index);
   std::vector<IScheduler::WireId<IScheduler::Boolean>> outputWires(
       result.size());
-  for (size_t i = 0; i < result.size(); i++) {
-    outputWires[i] = wireKeeper_->allocateBatchBooleanValue(result[i]);
+  for (size_t i = 0; i < result.size() && i < outputWires.size(); i++) {
+    outputWires[i] =
+        wireKeeper_->allocateBatchBooleanValue(result[i], result[i].size());
   }
   return outputWires;
 }
@@ -323,10 +327,11 @@ EagerScheduler::privateAndPublicCompositeBatch(
   freeGates_ += leftValues.size() * rights.size();
   std::vector<IScheduler::WireId<IScheduler::Boolean>> outputWires(
       rights.size());
-  for (size_t i = 0; i < rights.size(); i++) {
-    outputWires[i] =
-        wireKeeper_->allocateBatchBooleanValue((engine_->computeBatchFreeAND(
-            leftValues, wireKeeper_->getBatchBooleanValue(rights[i]))));
+  for (size_t i = 0; i < rights.size() && i < outputWires.size(); i++) {
+    outputWires[i] = wireKeeper_->allocateBatchBooleanValue(
+        engine_->computeBatchFreeAND(
+            leftValues, wireKeeper_->getBatchBooleanValue(rights[i])),
+        leftValues.size());
   }
   return outputWires;
 }
@@ -360,7 +365,8 @@ IScheduler::WireId<IScheduler::Boolean> EagerScheduler::privateXorPrivateBatch(
   auto rightValue = wireKeeper_->getBatchBooleanValue(right);
   freeGates_ += leftValue.size();
   return wireKeeper_->allocateBatchBooleanValue(
-      engine_->computeBatchSymmetricXOR(leftValue, rightValue));
+      engine_->computeBatchSymmetricXOR(leftValue, rightValue),
+      leftValue.size());
 }
 
 IScheduler::WireId<IScheduler::Boolean> EagerScheduler::privateXorPublic(
@@ -378,7 +384,8 @@ IScheduler::WireId<IScheduler::Boolean> EagerScheduler::privateXorPublicBatch(
   auto rightValue = wireKeeper_->getBatchBooleanValue(right);
   freeGates_ += leftValue.size();
   return wireKeeper_->allocateBatchBooleanValue(
-      engine_->computeBatchAsymmetricXOR(leftValue, rightValue));
+      engine_->computeBatchAsymmetricXOR(leftValue, rightValue),
+      leftValue.size());
 }
 
 IScheduler::WireId<IScheduler::Boolean> EagerScheduler::publicXorPublic(
@@ -396,7 +403,8 @@ IScheduler::WireId<IScheduler::Boolean> EagerScheduler::publicXorPublicBatch(
   auto rightValue = wireKeeper_->getBatchBooleanValue(right);
   freeGates_ += leftValue.size();
   return wireKeeper_->allocateBatchBooleanValue(
-      engine_->computeBatchSymmetricXOR(leftValue, rightValue));
+      engine_->computeBatchSymmetricXOR(leftValue, rightValue),
+      leftValue.size());
 }
 
 IScheduler::WireId<IScheduler::Boolean> EagerScheduler::notPrivate(
@@ -411,7 +419,7 @@ IScheduler::WireId<IScheduler::Boolean> EagerScheduler::notPrivateBatch(
   auto values = wireKeeper_->getBatchBooleanValue(src);
   freeGates_ += values.size();
   return wireKeeper_->allocateBatchBooleanValue(
-      engine_->computeBatchAsymmetricNOT(values));
+      engine_->computeBatchAsymmetricNOT(values), values.size());
 }
 
 IScheduler::WireId<IScheduler::Boolean> EagerScheduler::notPublic(
@@ -426,7 +434,7 @@ IScheduler::WireId<IScheduler::Boolean> EagerScheduler::notPublicBatch(
   auto values = wireKeeper_->getBatchBooleanValue(src);
   freeGates_ += values.size();
   return wireKeeper_->allocateBatchBooleanValue(
-      engine_->computeBatchSymmetricNOT(values));
+      engine_->computeBatchSymmetricNOT(values), values.size());
 }
 
 IScheduler::WireId<IScheduler::Arithmetic> EagerScheduler::privateMultPrivate(
@@ -448,7 +456,8 @@ EagerScheduler::privateMultPrivateBatch(
   auto rightValue = wireKeeper_->getBatchIntegerValue(right);
   nonFreeGates_ += leftValue.size();
   return wireKeeper_->allocateBatchIntegerValue(
-      engine_->computeBatchMultImmediately(leftValue, rightValue));
+      engine_->computeBatchMultImmediately(leftValue, rightValue),
+      leftValue.size());
 }
 
 IScheduler::WireId<IScheduler::Arithmetic> EagerScheduler::privateMultPublic(
@@ -467,7 +476,7 @@ EagerScheduler::privateMultPublicBatch(
   auto rightValue = wireKeeper_->getBatchIntegerValue(right);
   freeGates_ += leftValue.size();
   return wireKeeper_->allocateBatchIntegerValue(
-      engine_->computeBatchFreeMult(leftValue, rightValue));
+      engine_->computeBatchFreeMult(leftValue, rightValue), leftValue.size());
 }
 
 IScheduler::WireId<IScheduler::Arithmetic> EagerScheduler::publicMultPublic(
@@ -486,7 +495,7 @@ EagerScheduler::publicMultPublicBatch(
   auto rightValue = wireKeeper_->getBatchIntegerValue(right);
   freeGates_ += leftValue.size();
   return wireKeeper_->allocateBatchIntegerValue(
-      engine_->computeBatchFreeMult(leftValue, rightValue));
+      engine_->computeBatchFreeMult(leftValue, rightValue), leftValue.size());
 }
 
 IScheduler::WireId<IScheduler::Arithmetic> EagerScheduler::privatePlusPrivate(
@@ -505,7 +514,8 @@ EagerScheduler::privatePlusPrivateBatch(
   auto rightValue = wireKeeper_->getBatchIntegerValue(right);
   freeGates_ += leftValue.size();
   return wireKeeper_->allocateBatchIntegerValue(
-      engine_->computeBatchSymmetricPlus(leftValue, rightValue));
+      engine_->computeBatchSymmetricPlus(leftValue, rightValue),
+      leftValue.size());
 }
 
 IScheduler::WireId<IScheduler::Arithmetic> EagerScheduler::privatePlusPublic(
@@ -524,7 +534,8 @@ EagerScheduler::privatePlusPublicBatch(
   auto rightValue = wireKeeper_->getBatchIntegerValue(right);
   freeGates_ += leftValue.size();
   return wireKeeper_->allocateBatchIntegerValue(
-      engine_->computeBatchAsymmetricPlus(leftValue, rightValue));
+      engine_->computeBatchAsymmetricPlus(leftValue, rightValue),
+      leftValue.size());
 }
 
 IScheduler::WireId<IScheduler::Arithmetic> EagerScheduler::publicPlusPublic(
@@ -543,7 +554,8 @@ EagerScheduler::publicPlusPublicBatch(
   auto rightValue = wireKeeper_->getBatchIntegerValue(right);
   freeGates_ += leftValue.size();
   return wireKeeper_->allocateBatchIntegerValue(
-      engine_->computeBatchSymmetricPlus(leftValue, rightValue));
+      engine_->computeBatchSymmetricPlus(leftValue, rightValue),
+      leftValue.size());
 }
 
 IScheduler::WireId<IScheduler::Arithmetic> EagerScheduler::negPrivate(
@@ -558,7 +570,7 @@ IScheduler::WireId<IScheduler::Arithmetic> EagerScheduler::negPrivateBatch(
   auto values = wireKeeper_->getBatchIntegerValue(src);
   freeGates_ += values.size();
   return wireKeeper_->allocateBatchIntegerValue(
-      engine_->computeBatchSymmetricNeg(values));
+      engine_->computeBatchSymmetricNeg(values), values.size());
 }
 
 IScheduler::WireId<IScheduler::Arithmetic> EagerScheduler::negPublic(
@@ -573,7 +585,7 @@ IScheduler::WireId<IScheduler::Arithmetic> EagerScheduler::negPublicBatch(
   auto values = wireKeeper_->getBatchIntegerValue(src);
   freeGates_ += values.size();
   return wireKeeper_->allocateBatchIntegerValue(
-      engine_->computeBatchSymmetricNeg(values));
+      engine_->computeBatchSymmetricNeg(values), values.size());
 }
 
 void EagerScheduler::increaseReferenceCount(WireId<IScheduler::Boolean> id) {
@@ -627,7 +639,7 @@ IScheduler::WireId<IScheduler::Boolean> EagerScheduler::batchingUp(
       vector[index++] = batch.at(i);
     }
   }
-  return wireKeeper_->allocateBatchBooleanValue(vector);
+  return wireKeeper_->allocateBatchBooleanValue(vector, batchSize);
 }
 
 // decompose a batch of values into several smaller batches.
@@ -647,13 +659,23 @@ std::vector<IScheduler::WireId<IScheduler::Boolean>> EagerScheduler::unbatching(
     for (size_t j = 0; j < v.size(); j++) {
       v[j] = batch.at(index++);
     }
-    rst[i] = wireKeeper_->allocateBatchBooleanValue(v);
+    rst[i] = wireKeeper_->allocateBatchBooleanValue(v, v.size());
   }
   return rst;
 }
 
 std::pair<uint64_t, uint64_t> EagerScheduler::getTrafficStatistics() const {
   return engine_->getTrafficStatistics();
+}
+
+size_t EagerScheduler::getBatchSize(
+    IScheduler::WireId<IScheduler::Boolean> id) const {
+  return wireKeeper_->getBatchSize(id);
+}
+
+size_t EagerScheduler::getBatchSize(
+    IScheduler::WireId<IScheduler::Arithmetic> id) const {
+  return wireKeeper_->getBatchSize(id);
 }
 
 } // namespace fbpcf::scheduler

--- a/fbpcf/scheduler/EagerScheduler.h
+++ b/fbpcf/scheduler/EagerScheduler.h
@@ -518,6 +518,18 @@ class EagerScheduler final : public IArithmeticScheduler {
     return wireKeeper_->getWireStatistics();
   }
 
+  /**
+   * @inherit doc
+   */
+  size_t getBatchSize(
+      IScheduler::WireId<IScheduler::Boolean> id) const override;
+
+  /**
+   * @inherit doc
+   */
+  size_t getBatchSize(
+      IScheduler::WireId<IScheduler::Arithmetic> id) const override;
+
  private:
   std::unique_ptr<engine::ISecretShareEngine> engine_;
   std::unique_ptr<IWireKeeper> wireKeeper_;

--- a/fbpcf/scheduler/IScheduler.h
+++ b/fbpcf/scheduler/IScheduler.h
@@ -372,6 +372,20 @@ class IScheduler {
    */
   virtual std::pair<uint64_t, uint64_t> getWireStatistics() const = 0;
 
+  /**
+   * Get the batch size of a Boolean wire by inquring the wireKeeper.
+   * @return the batch size of a wire.
+   */
+  virtual size_t getBatchSize(
+      IScheduler::WireId<IScheduler::Boolean> id) const = 0;
+
+  /**
+   * Get the batch size of an Arithmetic wire by inquring the wireKeeper.
+   * @return the batch size of a wire.
+   */
+  virtual size_t getBatchSize(
+      IScheduler::WireId<IScheduler::Arithmetic> id) const = 0;
+
  protected:
   uint64_t nonFreeGates_ = 0;
   uint64_t freeGates_ = 0;

--- a/fbpcf/scheduler/IWireKeeper.h
+++ b/fbpcf/scheduler/IWireKeeper.h
@@ -62,7 +62,7 @@ class IWireKeeper {
       IScheduler::WireId<IScheduler::Boolean> id,
       uint32_t level) = 0;
 
-  // set the level associated with boolean wire with given id.
+  // set the level associated with integer wire with given id.
   virtual void setFirstAvailableLevel(
       IScheduler::WireId<IScheduler::Arithmetic> id,
       uint32_t level) = 0;
@@ -86,24 +86,24 @@ class IWireKeeper {
       IScheduler::WireId<IScheduler::Arithmetic> id) = 0;
 
   // get the batch size of the boolean value on the wire with given id
-  virtual uint64_t getBatchSize(
+  virtual size_t getBatchSize(
       IScheduler::WireId<IScheduler::Boolean> id) const = 0;
 
   // get the batch size of the integer value on the wire with given id
-  virtual uint64_t getBatchSize(
+  virtual size_t getBatchSize(
       IScheduler::WireId<IScheduler::Arithmetic> id) const = 0;
 
   // create a boolean wire with values v, return its wire id.
   virtual IScheduler::WireId<IScheduler::Boolean> allocateBatchBooleanValue(
       const std::vector<bool>& v,
-      uint32_t firstAvailableLevel = 0,
-      size_t expectedBatchSize = 0) = 0;
+      size_t expectedBatchSize,
+      uint32_t firstAvailableLevel = 0) = 0;
 
   // create an integer wire with values v, return its wire id.
   virtual IScheduler::WireId<IScheduler::Arithmetic> allocateBatchIntegerValue(
       const std::vector<uint64_t>& v,
-      uint32_t firstAvailableLevel = 0,
-      size_t expectedBatchSize = 0) = 0;
+      size_t expectedBatchSize,
+      uint32_t firstAvailableLevel = 0) = 0;
 
   // get the batch of value associated with boolean wire with given id.
   virtual const std::vector<bool>& getBatchBooleanValue(
@@ -144,7 +144,7 @@ class IWireKeeper {
       IScheduler::WireId<IScheduler::Boolean> id,
       uint32_t level) = 0;
 
-  // set the level associated with boolean wire with given id.
+  // set the level associated with integer wire with given id.
   virtual void setBatchFirstAvailableLevel(
       IScheduler::WireId<IScheduler::Arithmetic> id,
       uint32_t level) = 0;

--- a/fbpcf/scheduler/LazyScheduler.cpp
+++ b/fbpcf/scheduler/LazyScheduler.cpp
@@ -664,4 +664,14 @@ void LazyScheduler::executeOneLevel() {
   }
 }
 
+size_t LazyScheduler::getBatchSize(
+    IScheduler::WireId<IScheduler::Boolean> id) const {
+  return wireKeeper_->getBatchSize(id);
+}
+
+size_t LazyScheduler::getBatchSize(
+    IScheduler::WireId<IScheduler::Arithmetic> id) const {
+  return wireKeeper_->getBatchSize(id);
+}
+
 } // namespace fbpcf::scheduler

--- a/fbpcf/scheduler/LazyScheduler.h
+++ b/fbpcf/scheduler/LazyScheduler.h
@@ -521,6 +521,18 @@ class LazyScheduler final : public IArithmeticScheduler {
     return wireKeeper_->getWireStatistics();
   }
 
+  /**
+   * @inherit doc
+   */
+  size_t getBatchSize(
+      IScheduler::WireId<IScheduler::Boolean> id) const override;
+
+  /**
+   * @inherit doc
+   */
+  size_t getBatchSize(
+      IScheduler::WireId<IScheduler::Arithmetic> id) const override;
+
  private:
   std::unique_ptr<engine::ISecretShareEngine> engine_;
   std::shared_ptr<IWireKeeper> wireKeeper_;

--- a/fbpcf/scheduler/NetworkPlaintextScheduler.cpp
+++ b/fbpcf/scheduler/NetworkPlaintextScheduler.cpp
@@ -49,10 +49,10 @@ NetworkPlaintextScheduler::privateBooleanInputBatch(
     for (auto& iter : agentMap_) {
       iter.second->sendBool(v);
     }
-    return wireKeeper_->allocateBatchBooleanValue(v);
+    return wireKeeper_->allocateBatchBooleanValue(v, v.size());
   }
   auto otherV = agentMap_.at(partyId)->receiveBool(v.size());
-  return wireKeeper_->allocateBatchBooleanValue(otherV);
+  return wireKeeper_->allocateBatchBooleanValue(otherV, v.size());
 }
 
 IScheduler::WireId<IScheduler::Boolean>
@@ -98,7 +98,7 @@ NetworkPlaintextScheduler::recoverBooleanWireBatch(const std::vector<bool>& v) {
     }
   }
 
-  return wireKeeper_->allocateBatchBooleanValue(result);
+  return wireKeeper_->allocateBatchBooleanValue(result, v.size());
 }
 
 bool NetworkPlaintextScheduler::extractBooleanSecretShare(
@@ -148,10 +148,10 @@ NetworkPlaintextScheduler::privateIntegerInputBatch(
     for (auto& iter : agentMap_) {
       iter.second->sendInt64(v);
     }
-    return wireKeeper_->allocateBatchIntegerValue(v);
+    return wireKeeper_->allocateBatchIntegerValue(v, v.size());
   }
   auto otherV = agentMap_.at(partyId)->receiveInt64(v.size());
-  return wireKeeper_->allocateBatchIntegerValue(otherV);
+  return wireKeeper_->allocateBatchIntegerValue(otherV, v.size());
 }
 
 IScheduler::WireId<IScheduler::Arithmetic>
@@ -198,7 +198,7 @@ NetworkPlaintextScheduler::recoverIntegerWireBatch(
     }
   }
 
-  return wireKeeper_->allocateBatchIntegerValue(result);
+  return wireKeeper_->allocateBatchIntegerValue(result, v.size());
 }
 
 uint64_t NetworkPlaintextScheduler::extractIntegerSecretShare(
@@ -222,6 +222,16 @@ std::vector<uint64_t> NetworkPlaintextScheduler::extractIntegerSecretShareBatch(
   } else {
     return std::vector<uint64_t>(result.size(), 0);
   }
+}
+
+size_t NetworkPlaintextScheduler::getBatchSize(
+    IScheduler::WireId<IScheduler::Boolean> id) const {
+  return wireKeeper_->getBatchSize(id);
+}
+
+size_t NetworkPlaintextScheduler::getBatchSize(
+    IScheduler::WireId<IScheduler::Arithmetic> id) const {
+  return wireKeeper_->getBatchSize(id);
 }
 
 } // namespace fbpcf::scheduler

--- a/fbpcf/scheduler/NetworkPlaintextScheduler.h
+++ b/fbpcf/scheduler/NetworkPlaintextScheduler.h
@@ -123,6 +123,18 @@ class NetworkPlaintextScheduler final : public PlaintextScheduler {
     return {sent, received};
   }
 
+  /**
+   * @inherit doc
+   */
+  size_t getBatchSize(
+      IScheduler::WireId<IScheduler::Boolean> id) const override;
+
+  /**
+   * @inherit doc
+   */
+  size_t getBatchSize(
+      IScheduler::WireId<IScheduler::Arithmetic> id) const override;
+
  private:
   int myId_;
   std::

--- a/fbpcf/scheduler/PlaintextScheduler.cpp
+++ b/fbpcf/scheduler/PlaintextScheduler.cpp
@@ -31,7 +31,7 @@ PlaintextScheduler::privateBooleanInputBatch(
     const std::vector<bool>& v,
     int /*partyId*/) {
   freeGates_ += v.size();
-  return wireKeeper_->allocateBatchBooleanValue(v);
+  return wireKeeper_->allocateBatchBooleanValue(v, v.size());
 }
 
 IScheduler::WireId<IScheduler::Boolean> PlaintextScheduler::publicBooleanInput(
@@ -43,7 +43,7 @@ IScheduler::WireId<IScheduler::Boolean> PlaintextScheduler::publicBooleanInput(
 IScheduler::WireId<IScheduler::Boolean>
 PlaintextScheduler::publicBooleanInputBatch(const std::vector<bool>& v) {
   freeGates_ += v.size();
-  return wireKeeper_->allocateBatchBooleanValue(v);
+  return wireKeeper_->allocateBatchBooleanValue(v, v.size());
 }
 
 IScheduler::WireId<IScheduler::Boolean> PlaintextScheduler::recoverBooleanWire(
@@ -55,7 +55,7 @@ IScheduler::WireId<IScheduler::Boolean> PlaintextScheduler::recoverBooleanWire(
 IScheduler::WireId<IScheduler::Boolean>
 PlaintextScheduler::recoverBooleanWireBatch(const std::vector<bool>& v) {
   freeGates_ += v.size();
-  return wireKeeper_->allocateBatchBooleanValue(v);
+  return wireKeeper_->allocateBatchBooleanValue(v, v.size());
 }
 
 IScheduler::WireId<IScheduler::Boolean>
@@ -72,7 +72,7 @@ PlaintextScheduler::openBooleanValueToPartyBatch(
     int /*partyId*/) {
   auto& v = wireKeeper_->getBatchBooleanValue(src);
   nonFreeGates_ += v.size();
-  return wireKeeper_->allocateBatchBooleanValue(v);
+  return wireKeeper_->allocateBatchBooleanValue(v, v.size());
 }
 
 bool PlaintextScheduler::extractBooleanSecretShare(
@@ -105,7 +105,7 @@ PlaintextScheduler::privateIntegerInputBatch(
     const std::vector<uint64_t>& v,
     int /*partyId*/) {
   freeGates_ += v.size();
-  return wireKeeper_->allocateBatchIntegerValue(v);
+  return wireKeeper_->allocateBatchIntegerValue(v, v.size());
 }
 
 IScheduler::WireId<IScheduler::Arithmetic>
@@ -117,7 +117,7 @@ PlaintextScheduler::publicIntegerInput(uint64_t v) {
 IScheduler::WireId<IScheduler::Arithmetic>
 PlaintextScheduler::publicIntegerInputBatch(const std::vector<uint64_t>& v) {
   freeGates_ += v.size();
-  return wireKeeper_->allocateBatchIntegerValue(v);
+  return wireKeeper_->allocateBatchIntegerValue(v, v.size());
 }
 
 IScheduler::WireId<IScheduler::Arithmetic>
@@ -129,7 +129,7 @@ PlaintextScheduler::recoverIntegerWire(uint64_t v) {
 IScheduler::WireId<IScheduler::Arithmetic>
 PlaintextScheduler::recoverIntegerWireBatch(const std::vector<uint64_t>& v) {
   freeGates_ += v.size();
-  return wireKeeper_->allocateBatchIntegerValue(v);
+  return wireKeeper_->allocateBatchIntegerValue(v, v.size());
 }
 
 IScheduler::WireId<IScheduler::Arithmetic>
@@ -146,7 +146,7 @@ PlaintextScheduler::openIntegerValueToPartyBatch(
     int /*partyId*/) {
   auto& v = wireKeeper_->getBatchIntegerValue(src);
   nonFreeGates_ += v.size();
-  return wireKeeper_->allocateBatchIntegerValue(v);
+  return wireKeeper_->allocateBatchIntegerValue(v, v.size());
 }
 
 uint64_t PlaintextScheduler::extractIntegerSecretShare(
@@ -191,7 +191,7 @@ PlaintextScheduler::privateAndPrivateBatch(
   for (size_t i = 0; i < leftValue.size(); i++) {
     rst[i] = leftValue[i] & rightValue[i];
   }
-  return wireKeeper_->allocateBatchBooleanValue(rst);
+  return wireKeeper_->allocateBatchBooleanValue(rst, leftValue.size());
 }
 
 IScheduler::WireId<IScheduler::Boolean> PlaintextScheduler::privateAndPublic(
@@ -216,7 +216,7 @@ PlaintextScheduler::privateAndPublicBatch(
   for (size_t i = 0; i < leftValue.size(); i++) {
     rst[i] = leftValue.at(i) & rightValue.at(i);
   }
-  return wireKeeper_->allocateBatchBooleanValue(rst);
+  return wireKeeper_->allocateBatchBooleanValue(rst, leftValue.size());
 }
 
 IScheduler::WireId<IScheduler::Boolean> PlaintextScheduler::publicAndPublic(
@@ -296,7 +296,7 @@ PlaintextScheduler::privateXorPrivateBatch(
   for (size_t i = 0; i < leftValue.size(); i++) {
     rst[i] = leftValue[i] ^ rightValue[i];
   }
-  return wireKeeper_->allocateBatchBooleanValue(rst);
+  return wireKeeper_->allocateBatchBooleanValue(rst, leftValue.size());
 }
 
 IScheduler::WireId<IScheduler::Boolean> PlaintextScheduler::privateXorPublic(
@@ -339,7 +339,7 @@ IScheduler::WireId<IScheduler::Boolean> PlaintextScheduler::notPrivateBatch(
   for (size_t i = 0; i < value.size(); i++) {
     rst[i] = !value[i];
   }
-  return wireKeeper_->allocateBatchBooleanValue(rst);
+  return wireKeeper_->allocateBatchBooleanValue(rst, value.size());
 }
 
 IScheduler::WireId<IScheduler::Boolean> PlaintextScheduler::notPublic(
@@ -375,7 +375,7 @@ PlaintextScheduler::privatePlusPrivateBatch(
   for (size_t i = 0; i < leftValue.size(); i++) {
     rst.at(i) = leftValue.at(i) + rightValue.at(i);
   }
-  return wireKeeper_->allocateBatchIntegerValue(rst);
+  return wireKeeper_->allocateBatchIntegerValue(rst, leftValue.size());
 }
 
 IScheduler::WireId<IScheduler::Arithmetic>
@@ -428,7 +428,7 @@ PlaintextScheduler::privateMultPrivateBatch(
   for (size_t i = 0; i < leftValue.size(); i++) {
     rst.at(i) = leftValue.at(i) * rightValue.at(i);
   }
-  return wireKeeper_->allocateBatchIntegerValue(rst);
+  return wireKeeper_->allocateBatchIntegerValue(rst, leftValue.size());
 }
 
 IScheduler::WireId<IScheduler::Arithmetic>
@@ -454,7 +454,7 @@ PlaintextScheduler::privateMultPublicBatch(
   for (size_t i = 0; i < leftValue.size(); i++) {
     rst.at(i) = leftValue.at(i) * rightValue.at(i);
   }
-  return wireKeeper_->allocateBatchIntegerValue(rst);
+  return wireKeeper_->allocateBatchIntegerValue(rst, leftValue.size());
 }
 
 IScheduler::WireId<IScheduler::Arithmetic> PlaintextScheduler::publicMultPublic(
@@ -484,7 +484,7 @@ IScheduler::WireId<IScheduler::Arithmetic> PlaintextScheduler::negPrivateBatch(
   for (size_t i = 0; i < value.size(); i++) {
     rst.at(i) = -value.at(i);
   }
-  return wireKeeper_->allocateBatchIntegerValue(rst);
+  return wireKeeper_->allocateBatchIntegerValue(rst, value.size());
 }
 
 IScheduler::WireId<IScheduler::Arithmetic> PlaintextScheduler::negPublic(
@@ -568,7 +568,7 @@ IScheduler::WireId<IScheduler::Boolean> PlaintextScheduler::batchingUp(
       vector[index++] = v;
     }
   }
-  return wireKeeper_->allocateBatchBooleanValue(vector);
+  return wireKeeper_->allocateBatchBooleanValue(vector, batchSize);
 }
 
 // decompose a batch of values into several smaller batches.
@@ -589,7 +589,8 @@ PlaintextScheduler::unbatching(
     for (size_t j = 0; j < v.size(); j++) {
       v[j] = batch.at(index++);
     }
-    rst[i] = wireKeeper_->allocateBatchBooleanValue(v);
+    rst[i] =
+        wireKeeper_->allocateBatchBooleanValue(v, unbatchingStrategy->at(i));
   }
   return rst;
 }
@@ -610,9 +611,21 @@ PlaintextScheduler::validateAndComputeBatchCompositeAND(
     for (size_t i = 0; i < leftValue.size(); i++) {
       rst.push_back(leftValue[i] & rightValue[i]);
     }
-    returnWires.push_back(wireKeeper_->allocateBatchBooleanValue(rst));
+    returnWires.push_back(
+        wireKeeper_->allocateBatchBooleanValue(rst, leftValue.size()));
   }
   gateCounter += leftValue.size() * rights.size();
   return returnWires;
 }
+
+size_t PlaintextScheduler::getBatchSize(
+    IScheduler::WireId<IScheduler::Boolean> id) const {
+  return wireKeeper_->getBatchSize(id);
+}
+
+size_t PlaintextScheduler::getBatchSize(
+    IScheduler::WireId<IScheduler::Arithmetic> id) const {
+  return wireKeeper_->getBatchSize(id);
+}
+
 } // namespace fbpcf::scheduler

--- a/fbpcf/scheduler/PlaintextScheduler.h
+++ b/fbpcf/scheduler/PlaintextScheduler.h
@@ -522,6 +522,18 @@ class PlaintextScheduler : public IArithmeticScheduler {
     return wireKeeper_->getWireStatistics();
   }
 
+  /**
+   * @inherit doc
+   */
+  size_t getBatchSize(
+      IScheduler::WireId<IScheduler::Boolean> id) const override;
+
+  /**
+   * @inherit doc
+   */
+  size_t getBatchSize(
+      IScheduler::WireId<IScheduler::Arithmetic> id) const override;
+
  protected:
   std::unique_ptr<IWireKeeper> wireKeeper_;
   std::shared_ptr<util::MetricCollector> collector_;

--- a/fbpcf/scheduler/WireKeeper.cpp
+++ b/fbpcf/scheduler/WireKeeper.cpp
@@ -109,20 +109,20 @@ void WireKeeper::decreaseReferenceCount(
   }
 }
 
-uint64_t WireKeeper::getBatchSize(
+size_t WireKeeper::getBatchSize(
     IScheduler::WireId<IScheduler::Boolean> id) const {
   return boolBatchAllocator_->get(id.getId()).expectedBatchSize;
 }
 
-uint64_t WireKeeper::getBatchSize(
+size_t WireKeeper::getBatchSize(
     IScheduler::WireId<IScheduler::Arithmetic> id) const {
   return intBatchAllocator_->get(id.getId()).expectedBatchSize;
 }
 
 IScheduler::WireId<IScheduler::Boolean> WireKeeper::allocateBatchBooleanValue(
     const std::vector<bool>& v,
-    uint32_t firstAvailableLevel,
-    size_t expectedBatchSize) {
+    size_t expectedBatchSize,
+    uint32_t firstAvailableLevel) {
   wiresAllocated_++;
   auto wireID =
       boolBatchAllocator_->allocate(WireRecord<std::vector<bool>, true>{
@@ -137,8 +137,8 @@ IScheduler::WireId<IScheduler::Boolean> WireKeeper::allocateBatchBooleanValue(
 IScheduler::WireId<IScheduler::Arithmetic>
 WireKeeper::allocateBatchIntegerValue(
     const std::vector<uint64_t>& v,
-    uint32_t firstAvailableLevel,
-    size_t expectedBatchSize) {
+    size_t expectedBatchSize,
+    uint32_t firstAvailableLevel) {
   wiresAllocated_++;
   auto wireID =
       intBatchAllocator_->allocate(WireRecord<std::vector<uint64_t>, true>{

--- a/fbpcf/scheduler/WireKeeper.h
+++ b/fbpcf/scheduler/WireKeeper.h
@@ -154,13 +154,13 @@ class WireKeeper final : public IWireKeeper {
   /**
    * @inherit doc
    */
-  uint64_t getBatchSize(
+  size_t getBatchSize(
       IScheduler::WireId<IScheduler::Boolean> id) const override;
 
   /**
    * @inherit doc
    */
-  uint64_t getBatchSize(
+  size_t getBatchSize(
       IScheduler::WireId<IScheduler::Arithmetic> id) const override;
 
   /**
@@ -168,16 +168,16 @@ class WireKeeper final : public IWireKeeper {
    */
   IScheduler::WireId<IScheduler::Boolean> allocateBatchBooleanValue(
       const std::vector<bool>& v,
-      uint32_t firstAvailableLevel = 0,
-      size_t expectedBatchSize = 0) override;
+      size_t expectedBatchSize,
+      uint32_t firstAvailableLevel = 0) override;
 
   /**
    * @inherit doc
    */
   IScheduler::WireId<IScheduler::Arithmetic> allocateBatchIntegerValue(
       const std::vector<uint64_t>& v,
-      uint32_t firstAvailableLevel = 0,
-      size_t expectedBatchSize = 0) override;
+      size_t expectedBatchSize,
+      uint32_t firstAvailableLevel = 0) override;
 
   /**
    * @inherit doc

--- a/fbpcf/scheduler/gate_keeper/GateKeeper.h
+++ b/fbpcf/scheduler/gate_keeper/GateKeeper.h
@@ -204,14 +204,16 @@ class GateKeeper : public IGateKeeper {
 
   inline IScheduler::WireId<IScheduler::Boolean> allocateNewWire(
       const std::vector<bool>& v,
-      uint32_t level) const {
-    return wireKeeper_->allocateBatchBooleanValue(v, level);
+      uint32_t level,
+      size_t expectedBatchSize) const {
+    return wireKeeper_->allocateBatchBooleanValue(v, expectedBatchSize, level);
   }
 
   inline IScheduler::WireId<IScheduler::Arithmetic> allocateNewWire(
       const std::vector<uint64_t>& v,
-      uint32_t level) const {
-    return wireKeeper_->allocateBatchIntegerValue(v, level);
+      uint32_t level,
+      size_t expectedBatchSize) const {
+    return wireKeeper_->allocateBatchIntegerValue(v, expectedBatchSize, level);
   }
 
   inline uint32_t getOutputLevel(bool isGateFree, uint32_t maxInputLevel)

--- a/fbpcf/scheduler/test/WireKeeperTest.cpp
+++ b/fbpcf/scheduler/test/WireKeeperTest.cpp
@@ -41,7 +41,7 @@ void wireKeeperTestAllocateSetAndGet(std::unique_ptr<IWireKeeper> wireKeeper) {
 
   // Batch API: Bool
   std::vector<bool> testValue1(3, true);
-  auto wire7 = wireKeeper->allocateBatchBooleanValue(testValue1, 0, 3);
+  auto wire7 = wireKeeper->allocateBatchBooleanValue(testValue1, 3);
   testVectorEq(wireKeeper->getBatchBooleanValue(wire7), testValue1);
   std::vector<bool> testValue2(3, false);
   wireKeeper->setBatchBooleanValue(wire7, testValue2);
@@ -53,7 +53,7 @@ void wireKeeperTestAllocateSetAndGet(std::unique_ptr<IWireKeeper> wireKeeper) {
   // Batch API: Int
 
   std::vector<uint64_t> testValue3({UINT64_MAX, UINT64_MAX, 0});
-  auto wire9 = wireKeeper->allocateBatchIntegerValue(testValue3, 0, 3);
+  auto wire9 = wireKeeper->allocateBatchIntegerValue(testValue3, 3);
   testVectorEq(wireKeeper->getBatchIntegerValue(wire9), testValue3);
 
   std::vector<uint64_t> testValue4({10, 11, 12});
@@ -95,7 +95,7 @@ void wireKeeperTestAvailableLevel(std::unique_ptr<IWireKeeper> wireKeeper) {
 
   // Batch API: Bool
   auto wire3 = wireKeeper->allocateBatchBooleanValue(
-      {true, false}, /*firstAvailableLevel*/ 9, 2);
+      {true, false}, 2, /*firstAvailableLevel*/ 9);
   EXPECT_EQ(wireKeeper->getBatchFirstAvailableLevel(wire3), 9);
 
   wireKeeper->setBatchFirstAvailableLevel(wire3, 2);
@@ -103,7 +103,7 @@ void wireKeeperTestAvailableLevel(std::unique_ptr<IWireKeeper> wireKeeper) {
 
   // Batch API: Int
   auto wire4 = wireKeeper->allocateBatchIntegerValue(
-      {12, 24}, /* firstAvaialbleLevel*/ 25, 2);
+      {12, 24}, 2, /* firstAvaialbleLevel*/ 25);
   EXPECT_EQ(wireKeeper->getBatchFirstAvailableLevel(wire4), 25);
 
   wireKeeper->setBatchFirstAvailableLevel(wire4, 1337);
@@ -183,8 +183,7 @@ void wireKeeperTestReferenceCount(std::unique_ptr<IWireKeeper> wireKeeper) {
 
   // Batch API: Bool
   std::vector<bool> testBoolValue(true, 3);
-  auto batchBoolWire =
-      wireKeeper->allocateBatchBooleanValue(testBoolValue, 0, 3);
+  auto batchBoolWire = wireKeeper->allocateBatchBooleanValue(testBoolValue, 3);
 
   for (int i = 0; i < 10; i++) {
     if (i % 3 == 2) {
@@ -216,7 +215,7 @@ void wireKeeperTestReferenceCount(std::unique_ptr<IWireKeeper> wireKeeper) {
 
   // Batch API: Int
   std::vector<uint64_t> testIntValue({3, 4, 5});
-  auto batchIntWire = wireKeeper->allocateBatchIntegerValue(testIntValue, 0, 3);
+  auto batchIntWire = wireKeeper->allocateBatchIntegerValue(testIntValue, 3);
 
   for (int i = 0; i < 10; i++) {
     if (i % 3 == 2) {
@@ -260,21 +259,21 @@ TEST(SafeVectorArenaWireKeeperTest, testReferenceCount) {
 void wireKeeperTestExpectedBatchSize(std::unique_ptr<IWireKeeper> wireKeeper) {
   // Batch API: Bool
   std::vector<bool> testValue1(3, true);
-  auto wire1 = wireKeeper->allocateBatchBooleanValue(testValue1, 0, 3);
+  auto wire1 = wireKeeper->allocateBatchBooleanValue(testValue1, 3);
   EXPECT_EQ(wireKeeper->getBatchSize(wire1), 3);
 
   std::vector<bool> testValue2(4, false);
-  auto wire2 = wireKeeper->allocateBatchBooleanValue(testValue2, 0, 4);
+  auto wire2 = wireKeeper->allocateBatchBooleanValue(testValue2, 4);
   EXPECT_EQ(wireKeeper->getBatchSize(wire2), 4);
 
   // Batch API: Int
   std::vector<uint64_t> testValue3(
       {UINT64_MAX, UINT64_MAX, 0, UINT64_MAX, UINT64_MAX});
-  auto wire3 = wireKeeper->allocateBatchIntegerValue(testValue3, 0, 5);
+  auto wire3 = wireKeeper->allocateBatchIntegerValue(testValue3, 5);
   EXPECT_EQ(wireKeeper->getBatchSize(wire3), 5);
 
   std::vector<uint64_t> testValue4({10, 11, 12, 7, 8, 9});
-  auto wire4 = wireKeeper->allocateBatchIntegerValue(testValue4, 0, 6);
+  auto wire4 = wireKeeper->allocateBatchIntegerValue(testValue4, 6);
   EXPECT_EQ(wireKeeper->getBatchSize(wire4), 6);
 }
 


### PR DESCRIPTION
Summary:
This diff focuses on adding a ``getBatchSize()`` method in ``GateKeeper``, ``Scheduler``. For lazy scheduler, gatekeeper will take care of the batch size of new allocated wire. For other schedulers that don't have a gatekeeper, they could get the batch size directly from the input values.

This diff also fixes minor issues in wirekeeper, e.g., default value and inconsistent types of ``expectedBatchSize``, incorrect comments.

This diff also touches ``frontend/test/schedulerMock.h`` to prevent frontend test fails (because we add a new method in scheduler)

Reviewed By: robotal

Differential Revision: D38768080

