### PR TITLE
Separate default argument into overloaded constructor

### DIFF
--- a/fbpcf/io/api/BufferedReader.h
+++ b/fbpcf/io/api/BufferedReader.h
@@ -27,8 +27,14 @@ class BufferedReader : public IReaderCloser {
  public:
   explicit BufferedReader(
       std::unique_ptr<IReaderCloser> baseReader,
-      const size_t chunkSize = defaultReaderChunkSize)
+      const size_t chunkSize)
       : buffer_{std::vector<char>(chunkSize)},
+        currentPosition_{0},
+        baseReader_{std::move(baseReader)},
+        lastPosition_{0} {}
+
+  explicit BufferedReader(std::unique_ptr<IReaderCloser> baseReader)
+      : buffer_{std::vector<char>(defaultReaderChunkSize)},
         currentPosition_{0},
         baseReader_{std::move(baseReader)},
         lastPosition_{0} {}

--- a/fbpcf/io/api/BufferedWriter.h
+++ b/fbpcf/io/api/BufferedWriter.h
@@ -26,8 +26,13 @@ class BufferedWriter : public IWriterCloser {
  public:
   explicit BufferedWriter(
       std::unique_ptr<IWriterCloser> baseWriter,
-      const size_t chunkSize = defaultWriterChunkSize)
+      const size_t chunkSize)
       : buffer_{std::vector<char>(chunkSize)},
+        currentPosition_{0},
+        baseWriter_{std::move(baseWriter)} {}
+
+  explicit BufferedWriter(std::unique_ptr<IWriterCloser> baseWriter)
+      : buffer_{std::vector<char>(defaultWriterChunkSize)},
         currentPosition_{0},
         baseWriter_{std::move(baseWriter)} {}
 


### PR DESCRIPTION
Summary:
# Context
We want to have more intelligent defaults for the IO APIs. Cloud related upload/downlaod should have a larger buffer size to minimize IO operations, whereas local io should be smaller.

# This Diff
We are just creating a separate constructor that we will modify in the future to be more intelligent

# This Stack
1. **Create separate constructor without chunkSize**
2. Add a filepath member variable to IWriter and IReader
3. Create util functions to determine buffer size
4. Use the new util functions
5. Delete all other references to determining chunk sizes

Differential Revision: D38873747

