### PR TITLE
Add getFilePath() function to all readers and writers

### DIFF
--- a/fbpcf/io/api/BufferedReader.h
+++ b/fbpcf/io/api/BufferedReader.h
@@ -11,6 +11,7 @@
 #include <memory>
 #include <vector>
 
+#include "fbpcf/io/api/IOUtils.h"
 #include "fbpcf/io/api/IReaderCloser.h"
 
 namespace fbpcf::io {
@@ -30,8 +31,10 @@ class BufferedReader : public IReaderCloser {
       const size_t chunkSize)
       : buffer_{std::vector<char>(chunkSize)},
         currentPosition_{0},
-        baseReader_{std::move(baseReader)},
-        lastPosition_{0} {}
+        lastPosition_{0} {
+    filepath_ = baseReader->getFilePath();
+    baseReader_ = std::move(baseReader);
+  }
 
   explicit BufferedReader(std::unique_ptr<IReaderCloser> baseReader)
       : buffer_{std::vector<char>(defaultReaderChunkSize)},

--- a/fbpcf/io/api/BufferedReader.h
+++ b/fbpcf/io/api/BufferedReader.h
@@ -27,8 +27,14 @@ class BufferedReader : public IReaderCloser {
  public:
   explicit BufferedReader(
       std::unique_ptr<IReaderCloser> baseReader,
-      const size_t chunkSize = defaultReaderChunkSize)
+      const size_t chunkSize)
       : buffer_{std::vector<char>(chunkSize)},
+        currentPosition_{0},
+        baseReader_{std::move(baseReader)},
+        lastPosition_{0} {}
+
+  explicit BufferedReader(std::unique_ptr<IReaderCloser> baseReader)
+      : buffer_{std::vector<char>(defaultReaderChunkSize)},
         currentPosition_{0},
         baseReader_{std::move(baseReader)},
         lastPosition_{0} {}

--- a/fbpcf/io/api/BufferedWriter.h
+++ b/fbpcf/io/api/BufferedWriter.h
@@ -11,6 +11,7 @@
 #include <memory>
 #include <vector>
 
+#include "fbpcf/io/api/IOUtils.h"
 #include "fbpcf/io/api/IWriterCloser.h"
 
 namespace fbpcf::io {
@@ -27,14 +28,17 @@ class BufferedWriter : public IWriterCloser {
   explicit BufferedWriter(
       std::unique_ptr<IWriterCloser> baseWriter,
       const size_t chunkSize)
-      : buffer_{std::vector<char>(chunkSize)},
-        currentPosition_{0},
-        baseWriter_{std::move(baseWriter)} {}
+      : buffer_{std::vector<char>(chunkSize)}, currentPosition_{0} {
+    filepath_ = baseWriter->getFilePath();
+    baseWriter_ = std::move(baseWriter);
+  }
 
   explicit BufferedWriter(std::unique_ptr<IWriterCloser> baseWriter)
       : buffer_{std::vector<char>(defaultWriterChunkSize)},
-        currentPosition_{0},
-        baseWriter_{std::move(baseWriter)} {}
+        currentPosition_{0} {
+    filepath_ = baseWriter->getFilePath();
+    baseWriter_ = std::move(baseWriter);
+  }
 
   int close() override;
   size_t write(std::vector<char>& buf) override;

--- a/fbpcf/io/api/BufferedWriter.h
+++ b/fbpcf/io/api/BufferedWriter.h
@@ -26,8 +26,13 @@ class BufferedWriter : public IWriterCloser {
  public:
   explicit BufferedWriter(
       std::unique_ptr<IWriterCloser> baseWriter,
-      const size_t chunkSize = defaultWriterChunkSize)
+      const size_t chunkSize)
       : buffer_{std::vector<char>(chunkSize)},
+        currentPosition_{0},
+        baseWriter_{std::move(baseWriter)} {}
+
+  explicit BufferedWriter(std::unique_ptr<IWriterCloser> baseWriter)
+      : buffer_{std::vector<char>(defaultWriterChunkSize)},
         currentPosition_{0},
         baseWriter_{std::move(baseWriter)} {}
 

--- a/fbpcf/io/api/CloudFileReader.h
+++ b/fbpcf/io/api/CloudFileReader.h
@@ -32,6 +32,8 @@ class CloudFileReader : public IReaderCloser {
     }
     fileLength_ = cloudFileReader_->getFileContentLength(filePath);
     XLOG(INFO) << "Total file length is: " << fileLength_;
+
+    filepath_ = filePath;
   }
 
   int close() override;

--- a/fbpcf/io/api/CloudFileWriter.h
+++ b/fbpcf/io/api/CloudFileWriter.h
@@ -26,6 +26,7 @@ class CloudFileWriter : public IWriterCloser {
   explicit CloudFileWriter(const std::string& filePath) : filePath_{filePath} {
     cloudFileUploader_ = fbpcf::cloudio::getCloudFileUploader(filePath_);
     isClosed_ = false;
+    filepath_ = filePath;
   }
 
   int close() override;

--- a/fbpcf/io/api/FileReader.cpp
+++ b/fbpcf/io/api/FileReader.cpp
@@ -22,6 +22,8 @@ FileReader::FileReader(std::string filePath) {
   } else {
     childReader_ = std::make_unique<LocalFileReader>(filePath);
   }
+
+  filepath_ = filePath;
 }
 
 FileReader::~FileReader() {

--- a/fbpcf/io/api/FileWriter.cpp
+++ b/fbpcf/io/api/FileWriter.cpp
@@ -21,6 +21,8 @@ FileWriter::FileWriter(std::string filePath) {
   } else {
     childWriter_ = std::make_unique<LocalFileWriter>(filePath);
   }
+
+  filepath_ = filePath;
 }
 
 FileWriter::~FileWriter() {

--- a/fbpcf/io/api/IReader.h
+++ b/fbpcf/io/api/IReader.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <cstddef>
+#include <string>
 #include <vector>
 
 namespace fbpcf::io {
@@ -30,7 +31,18 @@ class IReader {
    * data left in the file
    */
   virtual bool eof() = 0;
+
+  /*
+   * returns the path of the file being read
+   */
+  std::string& getFilePath() {
+    return filepath_;
+  }
+
   virtual ~IReader() = default;
+
+ protected:
+  std::string filepath_;
 };
 
 } // namespace fbpcf::io

--- a/fbpcf/io/api/IWriter.h
+++ b/fbpcf/io/api/IWriter.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <cstddef>
+#include <string>
 #include <vector>
 
 namespace fbpcf::io {
@@ -25,7 +26,18 @@ class IWriter {
    * n bytes of the entire provided buffer.
    */
   virtual size_t write(std::vector<char>& buf) = 0;
+
+  /*
+   * returns the path of the file being written to
+   */
+  std::string& getFilePath() {
+    return filepath_;
+  }
+
   virtual ~IWriter() = default;
+
+ protected:
+  std::string filepath_;
 };
 
 } // namespace fbpcf::io

--- a/fbpcf/io/api/LocalFileReader.cpp
+++ b/fbpcf/io/api/LocalFileReader.cpp
@@ -21,6 +21,8 @@ LocalFileReader::LocalFileReader(std::string filePath) {
     throw std::runtime_error("Couldn't open local file.");
   }
   isClosed_ = false;
+
+  filepath_ = filePath;
 }
 
 int LocalFileReader::close() {

--- a/fbpcf/io/api/LocalFileWriter.cpp
+++ b/fbpcf/io/api/LocalFileWriter.cpp
@@ -28,6 +28,8 @@ LocalFileWriter::LocalFileWriter(std::string filePathStr) {
     XLOGF(ERR, "Error when opening file: {}", strerror(errno));
     throw std::runtime_error("Couldn't open local file.");
   }
+
+  filepath_ = filePathStr;
 }
 
 int LocalFileWriter::close() {

--- a/fbpcf/io/api/test/LocalFileReaderTest.cpp
+++ b/fbpcf/io/api/test/LocalFileReaderTest.cpp
@@ -14,8 +14,9 @@
 
 namespace fbpcf::io {
 
-inline void runBaseReaderTests(IReaderCloser& reader) {
+inline void runBaseReaderTests(IReaderCloser& reader, std::string fileToRead) {
   EXPECT_FALSE(reader.eof());
+  EXPECT_EQ(fileToRead, reader.getFilePath());
 
   /*
     CASE 1A
@@ -58,19 +59,19 @@ inline void runBaseReaderTests(IReaderCloser& reader) {
 }
 
 TEST(LocalFileReaderTest, testReadingFromFile) {
-  auto reader = fbpcf::io::LocalFileReader(
-      IOTestHelper::getBaseDirFromPath(__FILE__) +
-      "data/local_file_reader_test_file.txt");
+  auto fileToRead = IOTestHelper::getBaseDirFromPath(__FILE__) +
+      "data/local_file_reader_test_file.txt";
+  auto reader = fbpcf::io::LocalFileReader(fileToRead);
 
-  runBaseReaderTests(reader);
+  runBaseReaderTests(reader, fileToRead);
 }
 
 TEST(LocalFileReaderTest, testLocalFileReaderThroughFileReader) {
-  auto reader = fbpcf::io::FileReader(
-      IOTestHelper::getBaseDirFromPath(__FILE__) +
-      "data/local_file_reader_test_file.txt");
+  auto fileToRead = IOTestHelper::getBaseDirFromPath(__FILE__) +
+      "data/local_file_reader_test_file.txt";
+  auto reader = fbpcf::io::FileReader(fileToRead);
 
-  runBaseReaderTests(reader);
+  runBaseReaderTests(reader, fileToRead);
 }
 
 TEST(LocalFileReaderTest, testLocalFileReaderWithMissingFile) {

--- a/fbpcf/io/api/test/LocalFileWriterTest.cpp
+++ b/fbpcf/io/api/test/LocalFileWriterTest.cpp
@@ -22,6 +22,8 @@ inline void runBaseWriterTests(
     IWriterCloser& writer,
     std::string fileToWriteTo,
     std::string expectedFile) {
+  EXPECT_EQ(fileToWriteTo, writer.getFilePath());
+
   /*
     CASE 1
     Write simple string to file


### PR DESCRIPTION
Summary:
# Context
We want to have more intelligent defaults for the IO APIs. Cloud related upload/downlaod should have a larger buffer size to minimize IO operations, whereas local io should be smaller.

# This Diff
We are exposing a `getFilePath` function in all writers and readers so that we can then use it in the future for determining a default buffer size

# This Stack
1. Create separate constructor without chunkSize
2. **Add a filepath member variable to IWriter and IReader**
3. Create util functions to determine buffer size
4. Use the new util functions
5. Delete all other references to determining chunk sizes

Reviewed By: chualynn

Differential Revision: D38873574

