### PR TITLE
Use factories to create Eager schedulers

### DIFF
--- a/fbpcf/scheduler/test/benchmarks/SchedulerBenchmark.cpp
+++ b/fbpcf/scheduler/test/benchmarks/SchedulerBenchmark.cpp
@@ -12,6 +12,7 @@
 #include "fbpcf/engine/communication/IPartyCommunicationAgentFactory.h"
 #include "fbpcf/engine/util/test/benchmarks/BenchmarkHelper.h"
 #include "fbpcf/engine/util/test/benchmarks/NetworkedBenchmark.h"
+#include "fbpcf/scheduler/EagerSchedulerFactory.h"
 #include "fbpcf/scheduler/SchedulerHelper.h"
 #include "fbpcf/scheduler/test/benchmarks/AllocatorBenchmark.h"
 #include "fbpcf/scheduler/test/benchmarks/WireKeeperBenchmark.h"
@@ -176,8 +177,9 @@ class EagerSchedulerBenchmark : virtual public SchedulerBenchmark {
       int myId,
       engine::communication::IPartyCommunicationAgentFactory&
           communicationAgentFactory) override {
-    return createEagerSchedulerWithInsecureEngine<unsafe>(
-        myId, communicationAgentFactory);
+    return scheduler::getEagerSchedulerFactoryWithInsecureEngine<unsafe>(
+               myId, communicationAgentFactory)
+        ->create();
   }
 };
 

--- a/fbpcf/test/TestHelper.h
+++ b/fbpcf/test/TestHelper.h
@@ -174,7 +174,13 @@ inline SchedulerCreator getSchedulerCreator(SchedulerType schedulerType) {
             .create();
       };
     case SchedulerType::Eager:
-      return scheduler::createEagerSchedulerWithInsecureEngine<unsafe>;
+      return [](int myId,
+                engine::communication::IPartyCommunicationAgentFactory&
+                    communicationAgentFactory) {
+        return scheduler::getEagerSchedulerFactoryWithInsecureEngine<unsafe>(
+                   myId, communicationAgentFactory)
+            ->create();
+      };
     case SchedulerType::Lazy:
       return scheduler::createLazySchedulerWithInsecureEngine<unsafe>;
   }
@@ -212,15 +218,17 @@ void setupRealBackend(
       [](std::reference_wrapper<
           engine::communication::IPartyCommunicationAgentFactory> factory) {
         scheduler::SchedulerKeeper<schedulerId0>::setScheduler(
-            scheduler::createEagerSchedulerWithInsecureEngine<unsafe>(
-                0, factory));
+            scheduler::getEagerSchedulerFactoryWithInsecureEngine<unsafe>(
+                0, factory)
+                ->create());
       };
   auto task1 =
       [](std::reference_wrapper<
           engine::communication::IPartyCommunicationAgentFactory> factory) {
         scheduler::SchedulerKeeper<schedulerId1>::setScheduler(
-            scheduler::createEagerSchedulerWithInsecureEngine<unsafe>(
-                1, factory));
+            scheduler::getEagerSchedulerFactoryWithInsecureEngine<unsafe>(
+                1, factory)
+                ->create());
       };
 
   auto future0 = std::async(


### PR DESCRIPTION
Summary:
Replace all calls in fbpcf to SchedulerHelper methods to create eager schedulers to use factories.

Next diff will replace calls for lazy schedulers.

Reviewed By: robotal

Differential Revision: D38928007

