### PR TITLE
Use the new util functions for more intelligent defaults

### DIFF
--- a/fbpcf/io/api/BufferedReader.h
+++ b/fbpcf/io/api/BufferedReader.h
@@ -37,10 +37,13 @@ class BufferedReader : public IReaderCloser {
   }
 
   explicit BufferedReader(std::unique_ptr<IReaderCloser> baseReader)
-      : buffer_{std::vector<char>(defaultReaderChunkSize)},
-        currentPosition_{0},
-        baseReader_{std::move(baseReader)},
-        lastPosition_{0} {}
+      : currentPosition_{0}, lastPosition_{0} {
+    auto defaultChunkSizeForFile =
+        IOUtils::getDefaultReaderChunkSizeForFile(baseReader->getFilePath());
+    filepath_ = baseReader->getFilePath();
+    buffer_ = std::vector<char>(defaultChunkSizeForFile);
+    baseReader_ = std::move(baseReader);
+  }
 
   int close() override;
   size_t read(std::vector<char>& buf) override;

--- a/fbpcf/io/api/BufferedWriter.h
+++ b/fbpcf/io/api/BufferedWriter.h
@@ -34,10 +34,12 @@ class BufferedWriter : public IWriterCloser {
   }
 
   explicit BufferedWriter(std::unique_ptr<IWriterCloser> baseWriter)
-      : buffer_{std::vector<char>(defaultWriterChunkSize)},
-        currentPosition_{0} {
+      : currentPosition_{0} {
+    auto defaultChunkSizeForFile =
+        IOUtils::getDefaultWriterChunkSizeForFile(baseWriter->getFilePath());
     filepath_ = baseWriter->getFilePath();
     baseWriter_ = std::move(baseWriter);
+    buffer_ = std::vector<char>(defaultChunkSizeForFile);
   }
 
   int close() override;

--- a/fbpcf/io/api/test/BufferedReaderTest.cpp
+++ b/fbpcf/io/api/test/BufferedReaderTest.cpp
@@ -14,13 +14,9 @@
 
 namespace fbpcf::io {
 
-inline void runBufferedReaderTestForReadLineOnly(size_t chunkSize) {
+inline void runBufferedReaderTestForReadLineOnly(
+    std::unique_ptr<BufferedReader> bufferedReader) {
   // this more accurately resembles a production style usage
-  auto fileReader = std::make_unique<fbpcf::io::FileReader>(
-      IOTestHelper::getBaseDirFromPath(__FILE__) +
-      "data/buffered_reader_test_file.txt");
-  auto bufferedReader = std::make_unique<fbpcf::io::BufferedReader>(
-      std::move(fileReader), chunkSize);
 
   auto expectedLines = std::vector<std::string>{
       "this is a simple first line",
@@ -50,13 +46,8 @@ inline void runBufferedReaderTestForReadLineOnly(size_t chunkSize) {
   }
 }
 
-inline void runBufferedReaderTestForReadAndReadLine(size_t chunkSize) {
-  auto fileReader = std::make_unique<fbpcf::io::FileReader>(
-      IOTestHelper::getBaseDirFromPath(__FILE__) +
-      "data/buffered_reader_test_file.txt");
-  auto bufferedReader = std::make_unique<fbpcf::io::BufferedReader>(
-      std ::move(fileReader), chunkSize);
-
+inline void runBufferedReaderTestForReadAndReadLine(
+    std::unique_ptr<BufferedReader> bufferedReader) {
   auto firstLine = bufferedReader->readLine();
 
   EXPECT_EQ(firstLine, "this is a simple first line");
@@ -116,13 +107,45 @@ class BufferedReaderTest
 TEST_P(BufferedReaderTest, testBufferedReaderWithReadLineOnly) {
   auto chunkSize = GetParam();
 
-  runBufferedReaderTestForReadLineOnly(chunkSize);
+  auto fileReader = std::make_unique<fbpcf::io::FileReader>(
+      IOTestHelper::getBaseDirFromPath(__FILE__) +
+      "data/buffered_reader_test_file.txt");
+  auto bufferedReader = std::make_unique<fbpcf::io::BufferedReader>(
+      std::move(fileReader), chunkSize);
+
+  runBufferedReaderTestForReadLineOnly(std::move(bufferedReader));
 }
 
 TEST_P(BufferedReaderTest, testBufferedReaderWithReadAndReadLine) {
   auto chunkSize = GetParam();
 
-  runBufferedReaderTestForReadAndReadLine(chunkSize);
+  auto fileReader = std::make_unique<fbpcf::io::FileReader>(
+      IOTestHelper::getBaseDirFromPath(__FILE__) +
+      "data/buffered_reader_test_file.txt");
+  auto bufferedReader = std::make_unique<fbpcf::io::BufferedReader>(
+      std::move(fileReader), chunkSize);
+
+  runBufferedReaderTestForReadAndReadLine(std::move(bufferedReader));
+}
+
+TEST(BufferedReaderTest, testBufferedReaderWithReadLineOnlyNoChunkSize) {
+  auto fileReader = std::make_unique<fbpcf::io::FileReader>(
+      IOTestHelper::getBaseDirFromPath(__FILE__) +
+      "data/buffered_reader_test_file.txt");
+  auto bufferedReader =
+      std::make_unique<fbpcf::io::BufferedReader>(std::move(fileReader));
+
+  runBufferedReaderTestForReadAndReadLine(std::move(bufferedReader));
+}
+
+TEST(BufferedReaderTest, testBufferedReaderWithReadAndReadLineNoChunkSize) {
+  auto fileReader = std::make_unique<fbpcf::io::FileReader>(
+      IOTestHelper::getBaseDirFromPath(__FILE__) +
+      "data/buffered_reader_test_file.txt");
+  auto bufferedReader =
+      std::make_unique<fbpcf::io::BufferedReader>(std::move(fileReader));
+
+  runBufferedReaderTestForReadAndReadLine(std::move(bufferedReader));
 }
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
Summary:
# Context
We want to have more intelligent defaults for the IO APIs. Cloud related upload/downlaod should have a larger buffer size to minimize IO operations, whereas local io should be smaller.

# This Diff
We modify the overloaded constructor to use the new intelligent utils. This constructor is currently unused.

# This Stack
1. Create separate constructor without chunkSize
2. Add a filepath member variable to IWriter and IReader
3. Create util functions to determine buffer size
4. **Use the new util functions**
5. Delete all other references to determining chunk sizes**

Reviewed By: chualynn

Differential Revision: D38873886

