### PR TITLE
implement convertFromWords() and convertToWords()

### DIFF
--- a/fbpcf/mpc_std_lib/aes_circuit/AesCircuit_impl.h
+++ b/fbpcf/mpc_std_lib/aes_circuit/AesCircuit_impl.h
@@ -31,13 +31,41 @@ std::vector<BitType> AesCircuit<BitType>::decrypt_impl(
 template <typename BitType>
 std::vector<std::array<typename AesCircuit<BitType>::WordType, 4>>
 AesCircuit<BitType>::convertToWords(const std::vector<BitType>& src) const {
-  throw std::runtime_error("Not implemented!");
+  if (src.size() % 128 != 0) {
+    throw std::runtime_error("Bit vector must be a multiple of 128");
+  }
+  std::vector<std::array<WordType, 4>> wordVec;
+  size_t blockNo = src.size() / 128;
+  wordVec.reserve(blockNo);
+  for (int i_block = 0; i_block < blockNo; ++i_block) {
+    std::array<typename AesCircuit<BitType>::WordType, 4> wordArray;
+    for (int i = 0; i < 4; ++i) {
+      for (int j = 0; j < 4; ++j) {
+        for (int k = 0; k < 8; ++k) {
+          wordArray[i][j][k] = src[i_block * 128 + i * 32 + j * 8 + k];
+        }
+      }
+    }
+    wordVec.push_back(wordArray);
+  }
+  return wordVec;
 }
 
 template <typename BitType>
 std::vector<BitType> AesCircuit<BitType>::convertFromWords(
     std::vector<std::array<WordType, 4>>& src) const {
-  throw std::runtime_error("Not implemented!");
+  std::vector<BitType> bitVec;
+  bitVec.reserve(src.size() * 128);
+  for (int i = 0; i < src.size(); ++i) {
+    for (int j = 0; j < 4; ++j) {
+      for (int k = 0; k < 4; ++k) {
+        for (int m = 0; m < 8; ++m) {
+          bitVec.push_back(src[i][j][k][m]);
+        }
+      }
+    }
+  }
+  return bitVec;
 }
 
 template <typename BitType>

--- a/fbpcf/mpc_std_lib/aes_circuit/test/AesCircuitTest.cpp
+++ b/fbpcf/mpc_std_lib/aes_circuit/test/AesCircuitTest.cpp
@@ -58,6 +58,30 @@ class AesCircuitTests : public AesCircuit<BitType> {
       }
     }
   }
+
+  void testWordConversion() {
+    using ByteType = std::array<bool, 8>;
+    using WordType = std::array<ByteType, 4>;
+    std::vector<bool> input;
+    size_t blockNo = 5;
+    size_t blockSize = 128;
+    for (int i = 0; i < blockSize * blockNo; ++i) {
+      input.push_back((i % 2) == 0);
+    }
+    std::vector<std::array<WordType, 4>> expectedWords;
+    ByteType sampleByte = {true, false, true, false, true, false, true, false};
+    WordType sampleWord = {sampleByte, sampleByte, sampleByte, sampleByte};
+    std::array<WordType, 4> sampleBlock = {
+        sampleWord, sampleWord, sampleWord, sampleWord};
+    for (int i = 0; i < blockNo; ++i) {
+      expectedWords.push_back(sampleBlock);
+    }
+    auto convertedWords = AesCircuit<bool>::convertToWords(input);
+    testVectorEq(convertedWords, expectedWords);
+
+    auto convertedBits = AesCircuit<bool>::convertFromWords(convertedWords);
+    testVectorEq(convertedBits, input);
+  }
 };
 
 void intToBinaryArray(unsigned int n, std::array<bool, 8>& array) {
@@ -100,6 +124,11 @@ TEST(AesCircuitTest, testShiftRowInPlace) {
   auto plaintext = generateRandomPlaintext();
   AesCircuitTests<bool> test;
   test.testShiftRowInPlace(plaintext);
+}
+
+TEST(AesCircuitTest, testWordConversion) {
+  AesCircuitTests<bool> test;
+  test.testWordConversion();
 }
 
 class AesCircuitSBoxTestSuite


### PR DESCRIPTION
Summary: This diff implemented methods convertFromWords() and convertToWords(), which are used to convert ``Bit`` vector from/to aes cipher blocks.

Reviewed By: robotal

Differential Revision: D38947397

