### PR TITLE
Use factories to create Lazy schedulers

### DIFF
--- a/example/billionaire_problem/main.cpp
+++ b/example/billionaire_problem/main.cpp
@@ -8,7 +8,7 @@
 #include <folly/json.h>
 
 #include <gflags/gflags.h>
-#include "fbpcf/scheduler/SchedulerHelper.h"
+#include "fbpcf/scheduler/LazySchedulerFactory.h"
 #include "folly/init/Init.h"
 #include "folly/logging/xlog.h"
 
@@ -40,8 +40,9 @@ int main(int argc, char* argv[]) {
 
   auto game = std::make_unique<
       fbpcf::billionaire_problem::BillionaireProblemGame<0, true>>(
-      fbpcf::scheduler::createLazySchedulerWithRealEngine(
-          FLAGS_party, *factory));
+      fbpcf::scheduler::getLazySchedulerFactoryWithRealEngine(
+          FLAGS_party, *factory)
+          ->create());
 
   const int size = 32;
 

--- a/example/edit_distance/EditDistanceApp_impl.h
+++ b/example/edit_distance/EditDistanceApp_impl.h
@@ -7,15 +7,16 @@
 
 #pragma once
 
-#include <fbpcf/scheduler/SchedulerHelper.h>
+#include <fbpcf/scheduler/LazySchedulerFactory.h>
 #include "./EditDistanceApp.h" // @manual
 
 namespace fbpcf::edit_distance {
 
 template <int schedulerId>
 void EditDistanceApp<schedulerId>::run() {
-  auto scheduler = fbpcf::scheduler::createLazySchedulerWithRealEngine(
-      myRole_, *communicationAgentFactory_);
+  auto scheduler = fbpcf::scheduler::getLazySchedulerFactoryWithRealEngine(
+                       myRole_, *communicationAgentFactory_)
+                       ->create();
 
   XLOG(INFO, "Scheduler created successfully");
   auto editDistanceGame =

--- a/fbpcf/frontend/test/benchmarks/FrontendBenchmark.cpp
+++ b/fbpcf/frontend/test/benchmarks/FrontendBenchmark.cpp
@@ -15,7 +15,7 @@
 #include "fbpcf/frontend/BitString.h"
 #include "fbpcf/frontend/mpcGame.h"
 #include "fbpcf/scheduler/IScheduler.h"
-#include "fbpcf/scheduler/SchedulerHelper.h"
+#include "fbpcf/scheduler/LazySchedulerFactory.h"
 
 namespace fbpcf::frontend {
 
@@ -35,7 +35,8 @@ class FrontendBenchmark : public engine::util::NetworkedBenchmark {
  protected:
   void initSender() override {
     sender_ = std::make_unique<Game0>(
-        scheduler::createLazySchedulerWithRealEngine(0, *agentFactory0_));
+        scheduler::getLazySchedulerFactoryWithRealEngine(0, *agentFactory0_)
+            ->create());
     // scheduler::createPlaintextScheduler<unsafe>(0, *agentFactory0_));
   }
 
@@ -45,7 +46,8 @@ class FrontendBenchmark : public engine::util::NetworkedBenchmark {
 
   void initReceiver() override {
     receiver_ = std::make_unique<Game1>(
-        scheduler::createLazySchedulerWithRealEngine(1, *agentFactory1_));
+        scheduler::getLazySchedulerFactoryWithRealEngine(1, *agentFactory1_)
+            ->create());
     // scheduler::createPlaintextScheduler<unsafe>(1, *agentFactory1_));
   }
 

--- a/fbpcf/mpc_std_lib/compactor/test/benchmarks/CompactorBenchmark.cpp
+++ b/fbpcf/mpc_std_lib/compactor/test/benchmarks/CompactorBenchmark.cpp
@@ -22,7 +22,7 @@
 #include "fbpcf/mpc_std_lib/shuffler/PermuteBasedShufflerFactory.h"
 #include "fbpcf/mpc_std_lib/util/test/util.h"
 #include "fbpcf/scheduler/IScheduler.h"
-#include "fbpcf/scheduler/SchedulerHelper.h"
+#include "fbpcf/scheduler/LazySchedulerFactory.h"
 
 namespace fbpcf::mpc_std_lib::compactor {
 
@@ -48,7 +48,8 @@ class BaseCompactorBenchmark : public engine::util::NetworkedBenchmark {
  protected:
   void initSender() override {
     scheduler::SchedulerKeeper<0>::setScheduler(
-        scheduler::createLazySchedulerWithRealEngine(0, *agentFactory0_));
+        scheduler::getLazySchedulerFactoryWithRealEngine(0, *agentFactory0_)
+            ->create());
     setCompactorFactory();
     compactor0_ = factory0_->create();
   }
@@ -69,7 +70,8 @@ class BaseCompactorBenchmark : public engine::util::NetworkedBenchmark {
 
   void initReceiver() override {
     scheduler::SchedulerKeeper<1>::setScheduler(
-        scheduler::createLazySchedulerWithRealEngine(1, *agentFactory1_));
+        scheduler::getLazySchedulerFactoryWithRealEngine(1, *agentFactory1_)
+            ->create());
     setCompactorFactory();
     compactor1_ = factory1_->create();
   }

--- a/fbpcf/mpc_std_lib/oram/test/benchmarks/OramBenchmark.cpp
+++ b/fbpcf/mpc_std_lib/oram/test/benchmarks/OramBenchmark.cpp
@@ -21,7 +21,7 @@
 #include "fbpcf/mpc_std_lib/oram/WriteOnlyOramFactory.h"
 #include "fbpcf/mpc_std_lib/util/test/util.h"
 #include "fbpcf/scheduler/IScheduler.h"
-#include "fbpcf/scheduler/SchedulerHelper.h"
+#include "fbpcf/scheduler/LazySchedulerFactory.h"
 
 namespace fbpcf::mpc_std_lib::oram {
 
@@ -44,7 +44,8 @@ class DifferenceCalculatorBenchmark : public engine::util::NetworkedBenchmark {
  protected:
   void initSender() override {
     scheduler::SchedulerKeeper<0>::setScheduler(
-        scheduler::createLazySchedulerWithRealEngine(0, *agentFactory0_));
+        scheduler::getLazySchedulerFactoryWithRealEngine(0, *agentFactory0_)
+            ->create());
     DifferenceCalculatorFactory<uint32_t, indicatorWidth, 0> factory(
         true, 0, 1);
     sender_ = factory.create();
@@ -59,7 +60,8 @@ class DifferenceCalculatorBenchmark : public engine::util::NetworkedBenchmark {
 
   void initReceiver() override {
     scheduler::SchedulerKeeper<1>::setScheduler(
-        scheduler::createLazySchedulerWithRealEngine(1, *agentFactory1_));
+        scheduler::getLazySchedulerFactoryWithRealEngine(1, *agentFactory1_)
+            ->create());
     DifferenceCalculatorFactory<uint32_t, indicatorWidth, 1> factory(
         false, 0, 1);
     receiver_ = factory.create();
@@ -114,7 +116,8 @@ class ObliviousDeltaCalculatorBenchmark
  protected:
   void initSender() override {
     scheduler::SchedulerKeeper<0>::setScheduler(
-        scheduler::createLazySchedulerWithRealEngine(0, *agentFactory0_));
+        scheduler::getLazySchedulerFactoryWithRealEngine(0, *agentFactory0_)
+            ->create());
     ObliviousDeltaCalculatorFactory<0> factory(true, 0, 1);
     sender_ = factory.create();
   }
@@ -126,7 +129,8 @@ class ObliviousDeltaCalculatorBenchmark
 
   void initReceiver() override {
     scheduler::SchedulerKeeper<1>::setScheduler(
-        scheduler::createLazySchedulerWithRealEngine(1, *agentFactory1_));
+        scheduler::getLazySchedulerFactoryWithRealEngine(1, *agentFactory1_)
+            ->create());
     ObliviousDeltaCalculatorFactory<1> factory(false, 0, 1);
     receiver_ = factory.create();
   }
@@ -190,7 +194,8 @@ class SinglePointArrayGeneratorBenchmark
  protected:
   void initSender() override {
     scheduler::SchedulerKeeper<0>::setScheduler(
-        scheduler::createLazySchedulerWithRealEngine(0, *agentFactory0_));
+        scheduler::getLazySchedulerFactoryWithRealEngine(0, *agentFactory0_)
+            ->create());
     SinglePointArrayGeneratorFactory factory(
         true, std::make_unique<ObliviousDeltaCalculatorFactory<0>>(true, 0, 1));
     sender_ = factory.create();
@@ -202,7 +207,8 @@ class SinglePointArrayGeneratorBenchmark
 
   void initReceiver() override {
     scheduler::SchedulerKeeper<1>::setScheduler(
-        scheduler::createLazySchedulerWithRealEngine(1, *agentFactory1_));
+        scheduler::getLazySchedulerFactoryWithRealEngine(1, *agentFactory1_)
+            ->create());
     SinglePointArrayGeneratorFactory factory(
         false,
         std::make_unique<ObliviousDeltaCalculatorFactory<1>>(false, 0, 1));
@@ -255,7 +261,8 @@ class BaseWriteOnlyOramBenchmark : public engine::util::NetworkedBenchmark {
  protected:
   void initSender() override {
     scheduler::SchedulerKeeper<0>::setScheduler(
-        scheduler::createLazySchedulerWithRealEngine(0, *agentFactory0_));
+        scheduler::getLazySchedulerFactoryWithRealEngine(0, *agentFactory0_)
+            ->create());
     auto factory = getOramFactory(true);
     sender_ = factory->create(oramSize_);
   }
@@ -266,7 +273,8 @@ class BaseWriteOnlyOramBenchmark : public engine::util::NetworkedBenchmark {
 
   void initReceiver() override {
     scheduler::SchedulerKeeper<1>::setScheduler(
-        scheduler::createLazySchedulerWithRealEngine(1, *agentFactory1_));
+        scheduler::getLazySchedulerFactoryWithRealEngine(1, *agentFactory1_)
+            ->create());
     auto factory = getOramFactory(false);
     receiver_ = factory->create(oramSize_);
   }

--- a/fbpcf/scheduler/test/benchmarks/SchedulerBenchmark.cpp
+++ b/fbpcf/scheduler/test/benchmarks/SchedulerBenchmark.cpp
@@ -12,6 +12,7 @@
 #include "fbpcf/engine/communication/IPartyCommunicationAgentFactory.h"
 #include "fbpcf/engine/util/test/benchmarks/BenchmarkHelper.h"
 #include "fbpcf/engine/util/test/benchmarks/NetworkedBenchmark.h"
+#include "fbpcf/scheduler/EagerSchedulerFactory.h"
 #include "fbpcf/scheduler/SchedulerHelper.h"
 #include "fbpcf/scheduler/test/benchmarks/AllocatorBenchmark.h"
 #include "fbpcf/scheduler/test/benchmarks/WireKeeperBenchmark.h"
@@ -176,8 +177,9 @@ class EagerSchedulerBenchmark : virtual public SchedulerBenchmark {
       int myId,
       engine::communication::IPartyCommunicationAgentFactory&
           communicationAgentFactory) override {
-    return createEagerSchedulerWithInsecureEngine<unsafe>(
-        myId, communicationAgentFactory);
+    return scheduler::getEagerSchedulerFactoryWithInsecureEngine<unsafe>(
+               myId, communicationAgentFactory)
+        ->create();
   }
 };
 

--- a/fbpcf/scheduler/test/benchmarks/SchedulerBenchmark.cpp
+++ b/fbpcf/scheduler/test/benchmarks/SchedulerBenchmark.cpp
@@ -13,7 +13,7 @@
 #include "fbpcf/engine/util/test/benchmarks/BenchmarkHelper.h"
 #include "fbpcf/engine/util/test/benchmarks/NetworkedBenchmark.h"
 #include "fbpcf/scheduler/EagerSchedulerFactory.h"
-#include "fbpcf/scheduler/SchedulerHelper.h"
+#include "fbpcf/scheduler/LazySchedulerFactory.h"
 #include "fbpcf/scheduler/test/benchmarks/AllocatorBenchmark.h"
 #include "fbpcf/scheduler/test/benchmarks/WireKeeperBenchmark.h"
 
@@ -166,8 +166,9 @@ class LazySchedulerBenchmark : virtual public SchedulerBenchmark {
       int myId,
       engine::communication::IPartyCommunicationAgentFactory&
           communicationAgentFactory) override {
-    return createLazySchedulerWithInsecureEngine<unsafe>(
-        myId, communicationAgentFactory);
+    return scheduler::getLazySchedulerFactoryWithInsecureEngine<unsafe>(
+               myId, communicationAgentFactory)
+        ->create();
   }
 };
 

--- a/fbpcf/test/TestHelper.h
+++ b/fbpcf/test/TestHelper.h
@@ -182,7 +182,13 @@ inline SchedulerCreator getSchedulerCreator(SchedulerType schedulerType) {
             ->create();
       };
     case SchedulerType::Lazy:
-      return scheduler::createLazySchedulerWithInsecureEngine<unsafe>;
+      return [](int myId,
+                engine::communication::IPartyCommunicationAgentFactory&
+                    communicationAgentFactory) {
+        return scheduler::getLazySchedulerFactoryWithInsecureEngine<unsafe>(
+                   myId, communicationAgentFactory)
+            ->create();
+      };
   }
 }
 
@@ -251,15 +257,17 @@ void setupRealBackendWithLazyScheduler(
       [](std::reference_wrapper<
           engine::communication::IPartyCommunicationAgentFactory> factory) {
         scheduler::SchedulerKeeper<schedulerId0>::setScheduler(
-            scheduler::createLazySchedulerWithInsecureEngine<unsafe>(
-                0, factory));
+            scheduler::getLazySchedulerFactoryWithInsecureEngine<unsafe>(
+                0, factory)
+                ->create());
       };
   auto task1 =
       [](std::reference_wrapper<
           engine::communication::IPartyCommunicationAgentFactory> factory) {
         scheduler::SchedulerKeeper<schedulerId1>::setScheduler(
-            scheduler::createLazySchedulerWithInsecureEngine<unsafe>(
-                1, factory));
+            scheduler::getLazySchedulerFactoryWithInsecureEngine<unsafe>(
+                1, factory)
+                ->create());
       };
 
   auto future0 = std::async(

--- a/fbpcf/test/TestHelper.h
+++ b/fbpcf/test/TestHelper.h
@@ -174,7 +174,13 @@ inline SchedulerCreator getSchedulerCreator(SchedulerType schedulerType) {
             .create();
       };
     case SchedulerType::Eager:
-      return scheduler::createEagerSchedulerWithInsecureEngine<unsafe>;
+      return [](int myId,
+                engine::communication::IPartyCommunicationAgentFactory&
+                    communicationAgentFactory) {
+        return scheduler::getEagerSchedulerFactoryWithInsecureEngine<unsafe>(
+                   myId, communicationAgentFactory)
+            ->create();
+      };
     case SchedulerType::Lazy:
       return scheduler::createLazySchedulerWithInsecureEngine<unsafe>;
   }
@@ -212,15 +218,17 @@ void setupRealBackend(
       [](std::reference_wrapper<
           engine::communication::IPartyCommunicationAgentFactory> factory) {
         scheduler::SchedulerKeeper<schedulerId0>::setScheduler(
-            scheduler::createEagerSchedulerWithInsecureEngine<unsafe>(
-                0, factory));
+            scheduler::getEagerSchedulerFactoryWithInsecureEngine<unsafe>(
+                0, factory)
+                ->create());
       };
   auto task1 =
       [](std::reference_wrapper<
           engine::communication::IPartyCommunicationAgentFactory> factory) {
         scheduler::SchedulerKeeper<schedulerId1>::setScheduler(
-            scheduler::createEagerSchedulerWithInsecureEngine<unsafe>(
-                1, factory));
+            scheduler::getEagerSchedulerFactoryWithInsecureEngine<unsafe>(
+                1, factory)
+                ->create());
       };
 
   auto future0 = std::async(


### PR DESCRIPTION
Summary: Replace all calls in fbpcf to SchedulerHelper methods to create lazy schedulers to use factories.

Reviewed By: RuiyuZhu

Differential Revision: D38928831

