### PR TITLE
Back out "Delete all instances of computing chunk size per-callsite"

### DIFF
--- a/fbpcf/io/api/FileIOWrappers.cpp
+++ b/fbpcf/io/api/FileIOWrappers.cpp
@@ -19,8 +19,8 @@ namespace fbpcf::io {
 
 std::string FileIOWrappers::readFile(const std::string& srcPath) {
   auto reader = std::make_unique<fbpcf::io::FileReader>(srcPath);
-  auto bufferedReader =
-      std::make_unique<fbpcf::io::BufferedReader>(std::move(reader));
+  auto bufferedReader = std::make_unique<fbpcf::io::BufferedReader>(
+      std::move(reader), kBufferedReaderChunkSize);
   std::string output = "";
   std::string newLine = "\n";
   while (!bufferedReader->eof()) {
@@ -35,8 +35,8 @@ void FileIOWrappers::writeFile(
     const std::string& destPath,
     const std::string& content) {
   auto fileWriter = std::make_unique<fbpcf::io::FileWriter>(destPath);
-  auto bufferedWriter =
-      std::make_unique<fbpcf::io::BufferedWriter>(std::move(fileWriter));
+  auto bufferedWriter = std::make_unique<fbpcf::io::BufferedWriter>(
+      std::move(fileWriter), kBufferedWriterChunkSize);
   bufferedWriter->writeString(content);
   bufferedWriter->close();
 }
@@ -45,12 +45,12 @@ void FileIOWrappers::transferFileInParts(
     const std::string& srcPath,
     const std::string& destPath) {
   auto fileWriter = std::make_unique<fbpcf::io::FileWriter>(destPath);
-  auto bufferedWriter =
-      std::make_unique<fbpcf::io::BufferedWriter>(std::move(fileWriter));
+  auto bufferedWriter = std::make_unique<fbpcf::io::BufferedWriter>(
+      std::move(fileWriter), kBufferedWriterChunkSize);
 
   auto reader = std::make_unique<fbpcf::io::FileReader>(srcPath);
-  auto bufferedReader =
-      std::make_unique<fbpcf::io::BufferedReader>(std::move(reader));
+  auto bufferedReader = std::make_unique<fbpcf::io::BufferedReader>(
+      std::move(reader), kBufferedReaderChunkSize);
 
   std::string newLine = "\n";
   while (!bufferedReader->eof()) {
@@ -70,8 +70,8 @@ bool FileIOWrappers::readCsv(
         readLine,
     std::function<void(const std::vector<std::string>&)> processHeader) {
   auto inlineReader = std::make_unique<fbpcf::io::FileReader>(fileName);
-  auto inlineBufferedReader =
-      std::make_unique<fbpcf::io::BufferedReader>(std::move(inlineReader));
+  auto inlineBufferedReader = std::make_unique<fbpcf::io::BufferedReader>(
+      std::move(inlineReader), kBufferedReaderChunkSize);
 
   std::string line = inlineBufferedReader->readLine();
   auto header = IOUtils::splitByComma(line);

--- a/fbpcf/io/api/FileIOWrappers.h
+++ b/fbpcf/io/api/FileIOWrappers.h
@@ -13,6 +13,20 @@
 
 namespace fbpcf::io {
 
+// This chunk size has to be large enough that we don't make
+// unnecessary trips to cloud storage but small enough that
+// we don't cause OOM issues. This chunk size was chosen based
+// on the size of our containers as well as the expected size
+// of our files to fit the aforementioned constraints.
+constexpr size_t kBufferedReaderChunkSize = 1'073'741'824; // 2^30
+
+// The chunk size for writing to cloud storage (S3 and GCS) must be greater than
+// 5 MB per the AWS and GCS documentation. Otherwise multipart upload will fail.
+// AWS Doc: https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html
+// GCS Doc: https://cloud.google.com/storage/quotas#requests
+// The number below is 5 MB in bytes.
+constexpr size_t kBufferedWriterChunkSize = 5'242'880;
+
 // This class provides wrappers to the raw APIs to
 // do common operations like upload an entire file or
 // retrieve an entire file.


### PR DESCRIPTION
Summary:
Original commit changeset: e433164d2e24

Original Phabricator Diff: D38954973 (https://github.com/facebookresearch/fbpcf/commit/c338e8604fa2631aacff506e27575f22a43f2a93)

There was an error with the ci/cd pipeline: https://github.com/facebookresearch/fbpcf/actions/runs/2929046071

Reviewed By: RuiyuZhu

Differential Revision: D39031780

