### PR TITLE
Delete all instances of computing chunk size per-callsite (in fbpcf)

### DIFF
--- a/fbpcf/io/api/FileIOWrappers.cpp
+++ b/fbpcf/io/api/FileIOWrappers.cpp
@@ -19,8 +19,8 @@ namespace fbpcf::io {
 
 std::string FileIOWrappers::readFile(const std::string& srcPath) {
   auto reader = std::make_unique<fbpcf::io::FileReader>(srcPath);
-  auto bufferedReader = std::make_unique<fbpcf::io::BufferedReader>(
-      std::move(reader), kBufferedReaderChunkSize);
+  auto bufferedReader =
+      std::make_unique<fbpcf::io::BufferedReader>(std::move(reader));
   std::string output = "";
   std::string newLine = "\n";
   while (!bufferedReader->eof()) {
@@ -35,8 +35,8 @@ void FileIOWrappers::writeFile(
     const std::string& destPath,
     const std::string& content) {
   auto fileWriter = std::make_unique<fbpcf::io::FileWriter>(destPath);
-  auto bufferedWriter = std::make_unique<fbpcf::io::BufferedWriter>(
-      std::move(fileWriter), kBufferedWriterChunkSize);
+  auto bufferedWriter =
+      std::make_unique<fbpcf::io::BufferedWriter>(std::move(fileWriter));
   bufferedWriter->writeString(content);
   bufferedWriter->close();
 }
@@ -45,12 +45,12 @@ void FileIOWrappers::transferFileInParts(
     const std::string& srcPath,
     const std::string& destPath) {
   auto fileWriter = std::make_unique<fbpcf::io::FileWriter>(destPath);
-  auto bufferedWriter = std::make_unique<fbpcf::io::BufferedWriter>(
-      std::move(fileWriter), kBufferedWriterChunkSize);
+  auto bufferedWriter =
+      std::make_unique<fbpcf::io::BufferedWriter>(std::move(fileWriter));
 
   auto reader = std::make_unique<fbpcf::io::FileReader>(srcPath);
-  auto bufferedReader = std::make_unique<fbpcf::io::BufferedReader>(
-      std::move(reader), kBufferedReaderChunkSize);
+  auto bufferedReader =
+      std::make_unique<fbpcf::io::BufferedReader>(std::move(reader));
 
   std::string newLine = "\n";
   while (!bufferedReader->eof()) {
@@ -70,8 +70,8 @@ bool FileIOWrappers::readCsv(
         readLine,
     std::function<void(const std::vector<std::string>&)> processHeader) {
   auto inlineReader = std::make_unique<fbpcf::io::FileReader>(fileName);
-  auto inlineBufferedReader = std::make_unique<fbpcf::io::BufferedReader>(
-      std::move(inlineReader), kBufferedReaderChunkSize);
+  auto inlineBufferedReader =
+      std::make_unique<fbpcf::io::BufferedReader>(std::move(inlineReader));
 
   std::string line = inlineBufferedReader->readLine();
   auto header = IOUtils::splitByComma(line);

--- a/fbpcf/io/api/FileIOWrappers.h
+++ b/fbpcf/io/api/FileIOWrappers.h
@@ -13,20 +13,6 @@
 
 namespace fbpcf::io {
 
-// This chunk size has to be large enough that we don't make
-// unnecessary trips to cloud storage but small enough that
-// we don't cause OOM issues. This chunk size was chosen based
-// on the size of our containers as well as the expected size
-// of our files to fit the aforementioned constraints.
-constexpr size_t kBufferedReaderChunkSize = 1'073'741'824; // 2^30
-
-// The chunk size for writing to cloud storage (S3 and GCS) must be greater than
-// 5 MB per the AWS and GCS documentation. Otherwise multipart upload will fail.
-// AWS Doc: https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html
-// GCS Doc: https://cloud.google.com/storage/quotas#requests
-// The number below is 5 MB in bytes.
-constexpr size_t kBufferedWriterChunkSize = 5'242'880;
-
 // This class provides wrappers to the raw APIs to
 // do common operations like upload an entire file or
 // retrieve an entire file.


### PR DESCRIPTION
Summary:
# Context
We want to have more intelligent defaults for the IO APIs. Cloud related upload/downlaod should have a larger buffer size to minimize IO operations, whereas local io should be smaller.

# This Diff
We get rid of all instances where a custom chunk size is specified (in fbpcf). This is only necessary if there is something special about the callsite.

# This Stack
1. Create separate constructor without chunkSize
2. Add a filepath member variable to IWriter and IReader
3. Create util functions to determine buffer size
4. Use the new util functions
5. **Delete all other references to determining chunk sizes (in fbpcf)**
6. Delete all other references to determining chunk sizes (in fbpcs)

Differential Revision: D39036764

