### PR TITLE
Hook up arithmetic tuple generator to secret share engine

### DIFF
--- a/fbpcf/engine/SecretShareEngineFactory.h
+++ b/fbpcf/engine/SecretShareEngineFactory.h
@@ -25,6 +25,7 @@
 #include "fbpcf/engine/tuple_generator/IArithmeticTupleGeneratorFactory.h"
 #include "fbpcf/engine/tuple_generator/ITupleGeneratorFactory.h"
 #include "fbpcf/engine/tuple_generator/NullArithmeticTupleGeneratorFactory.h"
+#include "fbpcf/engine/tuple_generator/NullTupleGeneratorFactory.h"
 #include "fbpcf/engine/tuple_generator/ProductShareGenerator.h"
 #include "fbpcf/engine/tuple_generator/ProductShareGeneratorFactory.h"
 #include "fbpcf/engine/tuple_generator/TupleGeneratorFactory.h"
@@ -90,7 +91,7 @@ class SecretShareEngineFactory final : public ISecretShareEngineFactory {
 };
 
 inline std::unique_ptr<SecretShareEngineFactory>
-getEngineFactoryWithTupleGeneratorFactory(
+getEngineFactoryWithTupleGeneratorFactories(
     int myId,
     int numberOfParty,
     communication::IPartyCommunicationAgentFactory& communicationAgentFactory,
@@ -109,9 +110,12 @@ getEngineFactoryWithTupleGeneratorFactory(
       numberOfParty);
 }
 
+/**
+ * Creates a secret share engine that supports XOR, NOT, AND operations
+ **/
 template <class T>
 inline std::unique_ptr<SecretShareEngineFactory>
-getSecureEngineFactoryWithRcotFactory(
+getSecureEngineFactoryWithBooleanOnlyTupleGenerator(
     int myId,
     int numberOfParty,
     communication::IPartyCommunicationAgentFactory& communicationAgentFactory,
@@ -153,7 +157,7 @@ getSecureEngineFactoryWithRcotFactory(
   arithmeticTupleGeneratorFactory =
       std::make_unique<tuple_generator::NullArithmeticTupleGeneratorFactory>();
 
-  return getEngineFactoryWithTupleGeneratorFactory(
+  return getEngineFactoryWithTupleGeneratorFactories(
       myId,
       numberOfParty,
       communicationAgentFactory,
@@ -161,6 +165,72 @@ getSecureEngineFactoryWithRcotFactory(
       std::move(arithmeticTupleGeneratorFactory));
 }
 
+/**
+ * Creates a secret share engine that supports PlUS, NEG, MULT operations
+ * If withBooleanTupleGenerator is true, the secret share engine will also
+ * support XOR, NOT, AND operations
+ */
+template <class T>
+inline std::unique_ptr<SecretShareEngineFactory>
+getSecureEngineFactoryWithIntegerTupleGenerator(
+    int myId,
+    int numberOfParty,
+    communication::IPartyCommunicationAgentFactory& communicationAgentFactory,
+    std::shared_ptr<tuple_generator::oblivious_transfer::
+                        IRandomCorrelatedObliviousTransferFactory> rcotFactory,
+    bool withBooleanTupleGenerator) {
+  size_t bufferSize = 40000;
+
+  std::unique_ptr<tuple_generator::ITupleGeneratorFactory>
+      tupleGeneratorFactory;
+  std::unique_ptr<tuple_generator::IArithmeticTupleGeneratorFactory>
+      arithmeticTupleGeneratorFactory;
+
+  auto biDirectionOtFactory =
+      std::make_unique<tuple_generator::oblivious_transfer::
+                           RcotBasedBidirectionObliviousTransferFactory>(
+          myId, communicationAgentFactory, rcotFactory);
+
+  // use OT for tuple generation
+  auto productShareGeneratorFactory =
+      std::make_shared<tuple_generator::ProductShareGeneratorFactory<T>>(
+          std::make_unique<util::AesPrgFactory>(bufferSize),
+          std::move(biDirectionOtFactory));
+
+  arithmeticTupleGeneratorFactory =
+      std::make_unique<tuple_generator::ArithmeticTupleGeneratorFactory>(
+          productShareGeneratorFactory,
+          std::make_unique<util::AesPrgFactory>(),
+          bufferSize,
+          myId,
+          numberOfParty);
+
+  if (withBooleanTupleGenerator) {
+    if (numberOfParty == 2) {
+      tupleGeneratorFactory =
+          std::make_unique<tuple_generator::TwoPartyTupleGeneratorFactory>(
+              rcotFactory, communicationAgentFactory, myId, bufferSize);
+    } else {
+      tupleGeneratorFactory =
+          std::make_unique<tuple_generator::TupleGeneratorFactory>(
+              productShareGeneratorFactory,
+              std::make_unique<util::AesPrgFactory>(),
+              bufferSize,
+              myId,
+              numberOfParty);
+    }
+  } else {
+    tupleGeneratorFactory =
+        std::make_unique<tuple_generator::NullTupleGeneratorFactory>();
+  }
+
+  return getEngineFactoryWithTupleGeneratorFactories(
+      myId,
+      numberOfParty,
+      communicationAgentFactory,
+      std::move(tupleGeneratorFactory),
+      std::move(arithmeticTupleGeneratorFactory));
+}
 /**
  * create a secure engine that utilizes FERRET protocol
  * this function must be called by all parties at the same time since it
@@ -172,13 +242,40 @@ getSecureEngineFactoryWithFERRET(
     int myId,
     int numberOfParty,
     communication::IPartyCommunicationAgentFactory& communicationAgentFactory) {
-  return getSecureEngineFactoryWithRcotFactory<T>(
+  return getSecureEngineFactoryWithBooleanOnlyTupleGenerator<T>(
       myId,
       numberOfParty,
       communicationAgentFactory,
       tuple_generator::oblivious_transfer::createFerretRcotFactory());
 }
 
+template <class T>
+inline std::unique_ptr<SecretShareEngineFactory>
+getSecureEngineFactoryWithBooleanAndIntegerTupleGenerator(
+    int myId,
+    int numberOfParty,
+    communication::IPartyCommunicationAgentFactory& communicationAgentFactory) {
+  return getSecureEngineFactoryWithIntegerTupleGenerator<T>(
+      myId,
+      numberOfParty,
+      communicationAgentFactory,
+      tuple_generator::oblivious_transfer::createFerretRcotFactory(),
+      true);
+}
+
+template <class T>
+inline std::unique_ptr<SecretShareEngineFactory>
+getSecureEngineFactoryWithIntegerOnlyTupleGenerator(
+    int myId,
+    int numberOfParty,
+    communication::IPartyCommunicationAgentFactory& communicationAgentFactory) {
+  return getSecureEngineFactoryWithIntegerTupleGenerator<T>(
+      myId,
+      numberOfParty,
+      communicationAgentFactory,
+      tuple_generator::oblivious_transfer::createFerretRcotFactory(),
+      false);
+}
 /**
  * create a secure engine that utilizes classic OT protocol
  * this function must be called by all parties at the same time since it
@@ -190,7 +287,7 @@ getSecureEngineFactoryWithClassicOt(
     int myId,
     int numberOfParty,
     communication::IPartyCommunicationAgentFactory& communicationAgentFactory) {
-  return getSecureEngineFactoryWithRcotFactory<T>(
+  return getSecureEngineFactoryWithBooleanOnlyTupleGenerator<T>(
       myId,
       numberOfParty,
       communicationAgentFactory,
@@ -208,7 +305,7 @@ getInsecureEngineFactoryWithDummyTupleGenerator(
     int myId,
     int numberOfParty,
     communication::IPartyCommunicationAgentFactory& communicationAgentFactory) {
-  return getEngineFactoryWithTupleGeneratorFactory(
+  return getEngineFactoryWithTupleGeneratorFactories(
       myId,
       numberOfParty,
       communicationAgentFactory,

--- a/fbpcf/engine/test/SecretShareEngineTest.cpp
+++ b/fbpcf/engine/test/SecretShareEngineTest.cpp
@@ -989,7 +989,29 @@ INSTANTIATE_TEST_SUITE_P(
                 communication::IPartyCommunicationAgentFactory& agentFactory)>>(
             "InsecureEngineWithDummyTupleGenerator",
             4,
-            getInsecureEngineFactoryWithDummyTupleGenerator)),
+            getInsecureEngineFactoryWithDummyTupleGenerator),
+        std::make_tuple<
+            std::string,
+            size_t,
+            std::function<std::unique_ptr<SecretShareEngineFactory>(
+                int myId,
+                int numberOfParty,
+                communication::IPartyCommunicationAgentFactory& agentFactory)>>(
+            "SecureEngineWithFerret",
+            2,
+            getSecureEngineFactoryWithBooleanAndIntegerTupleGenerator<
+                uint64_t>),
+        std::make_tuple<
+            std::string,
+            size_t,
+            std::function<std::unique_ptr<SecretShareEngineFactory>(
+                int myId,
+                int numberOfParty,
+                communication::IPartyCommunicationAgentFactory& agentFactory)>>(
+            "SecureEngineWithFerret",
+            3,
+            getSecureEngineFactoryWithBooleanAndIntegerTupleGenerator<
+                uint64_t>)),
     [](const testing::TestParamInfo<NonFreeMultTestFixture::ParamType>& info) {
       return std::get<0>(info.param) + '_' +
           std::to_string(std::get<1>(info.param)) + "Party";

--- a/fbpcf/engine/tuple_generator/NullTupleGenerator.h
+++ b/fbpcf/engine/tuple_generator/NullTupleGenerator.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+#include "fbpcf/engine/tuple_generator/ITupleGenerator.h"
+
+namespace fbpcf::engine::tuple_generator {
+
+/**
+ A null boolean tuple generator, throws exception when the secret share engine
+ tries to generate boolean tuples with this generator
+ */
+class NullTupleGenerator final : public ITupleGenerator {
+ public:
+  std::vector<BooleanTuple> getBooleanTuple(uint32_t size) override {
+    if (size == 0) {
+      return std::vector<BooleanTuple>();
+    }
+    throw std::runtime_error(
+        "The secret share engine is not configured with boolean tuple generator.");
+  }
+
+  /**
+   * @inherit doc
+   */
+  std::map<size_t, std::vector<CompositeBooleanTuple>> getCompositeTuple(
+      const std::map<size_t, uint32_t>& tupleSizes) override {
+    if (tupleSizes.empty()) {
+      return std::map<size_t, std::vector<CompositeBooleanTuple>>();
+    }
+    throw std::runtime_error(
+        "The secret share engine is not configured with boolean tuple generator.");
+  }
+
+  /**
+   * @inherit doc
+   */
+  std::pair<
+      std::vector<BooleanTuple>,
+      std::map<size_t, std::vector<CompositeBooleanTuple>>>
+  getNormalAndCompositeBooleanTuples(
+      uint32_t tupleSizes,
+      const std::map<size_t, uint32_t>& compositeTupleSizes) override {
+    if (tupleSizes == 0 && compositeTupleSizes.empty()) {
+      return std::pair<
+          std::vector<BooleanTuple>,
+          std::map<size_t, std::vector<CompositeBooleanTuple>>>();
+    }
+    throw std::runtime_error(
+        "The secret share engine is not configured with boolean tuple generator.");
+  }
+
+  /**
+   * @inherit doc
+   */
+  bool supportsCompositeTupleGeneration() override {
+    return false;
+  }
+
+  std::pair<uint64_t, uint64_t> getTrafficStatistics() const override {
+    throw std::runtime_error(
+        "The secret share engine is not configured with boolean tuple generator.");
+  }
+};
+
+} // namespace fbpcf::engine::tuple_generator

--- a/fbpcf/engine/tuple_generator/NullTupleGeneratorFactory.h
+++ b/fbpcf/engine/tuple_generator/NullTupleGeneratorFactory.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+#include "fbpcf/engine/tuple_generator/ITupleGeneratorFactory.h"
+#include "fbpcf/engine/tuple_generator/NullTupleGenerator.h"
+
+namespace fbpcf::engine::tuple_generator {
+
+/**
+ * This factory creates null tuple generators
+ */
+
+class NullTupleGeneratorFactory final : public ITupleGeneratorFactory {
+ public:
+  /**
+   * Create a null tuple generator;
+   */
+  std::unique_ptr<ITupleGenerator> create() override {
+    return std::make_unique<NullTupleGenerator>();
+  }
+};
+
+} // namespace fbpcf::engine::tuple_generator


### PR DESCRIPTION
Summary:
Replace the stub implementation from milestone 1 in the secret share engine to utilize actual arithmetic tuples.

Create nullTupleGenerator so we could pass it in without initializing FERRET whenever AND operation is unused in the circuit. Use the nullTupleGenerator when testing non-free MULT.

getSecureEngineFactoryWithFERRET():configure the secret share engine with only the boolean tuple generator.

getSecureEngineFactoryWithIntegerTupleGenerator(): configure the secret share engine with only the integer tuple generator.

getSecureEngineFactoryWithBooleanAndIntegerTupleGenerator(): configure the secret share engine with both a boolean tuple generator and an arithmetic tuple generator.

Differential Revision: D38999537

