### PR TITLE
Migrate last 2 remaining callsites of old constructor and mark it as deprecated

### DIFF
--- a/fbpcf/engine/communication/SocketPartyCommunicationAgent.h
+++ b/fbpcf/engine/communication/SocketPartyCommunicationAgent.h
@@ -30,7 +30,7 @@ class SocketPartyCommunicationAgent final : public IPartyCommunicationAgent {
   /**
    * Create as socket server, optionally with TLS.
    */
-  explicit SocketPartyCommunicationAgent(
+  [[deprecated("Use the constructor with TlsInfo instead.")]] explicit SocketPartyCommunicationAgent(
       int sockFd,
       int portNo,
       bool useTls,
@@ -46,7 +46,7 @@ class SocketPartyCommunicationAgent final : public IPartyCommunicationAgent {
   /**
    * Created as socket client, optionally with TLS.
    */
-  SocketPartyCommunicationAgent(
+  [[deprecated("Use the constructor with TlsInfo instead.")]] SocketPartyCommunicationAgent(
       const std::string& serverAddress,
       int portNo,
       bool useTls,

--- a/fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h
+++ b/fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h
@@ -62,7 +62,7 @@ establishing multiple connections (>3) between each party pair.
     setupInitialConnection(partyInfos);
   }
 
-  SocketPartyCommunicationAgentFactory(
+  [[deprecated("Use the constructor with TlsInfo instead.")]] SocketPartyCommunicationAgentFactory(
       int myId,
       std::map<int, PartyInfo> partyInfos,
       bool useTls,


### PR DESCRIPTION
Summary: We seem to have missed a couple instances in D38926124 (https://github.com/facebookresearch/fbpcf/commit/51f497bb8d512f0c66748e94b484afbaf8ea26ff). See the summary in that diff.

Differential Revision: D39142721

