### PR TITLE
Implement the Correlated OT with Random Messages.

### DIFF
--- a/fbpcf/mpc_std_lib/walr_multiplication/DummyMatrixMultiplication.h
+++ b/fbpcf/mpc_std_lib/walr_multiplication/DummyMatrixMultiplication.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <fbpcf/engine/util/util.h>
+#include <algorithm>
+#include <stdexcept>
+#include "fbpcf/engine/communication/IPartyCommunicationAgent.h"
+#include "fbpcf/mpc_std_lib/walr_multiplication/IWalrMatrixMultiplication.h"
+
+namespace fbpcf::mpc_std_lib::walr::insecure {
+
+/**
+ * An insecure multiplication implementation. It should not be used in
+ * production.
+ */
+template <int schedulerId>
+class DummyMatrixMultiplication final
+    : public IWalrMatrixMultiplication<schedulerId> {
+ public:
+  explicit DummyMatrixMultiplication(
+      int myId,
+      int partnerId,
+      std::unique_ptr<engine::communication::IPartyCommunicationAgent> agent)
+      : myId_(myId), partnerId_(partnerId), agent_(std::move(agent)) {}
+
+  /**
+   * @inherit doc
+   */
+  std::vector<double> matrixVectorMultiplication(
+      const std::vector<std::vector<double>>& features,
+      const frontend::Bit<true, schedulerId, true>& labels) const {
+    // Each features[i] represents a column vector of the feature matrix.
+    // There are `nLabels` such column vectors.
+    size_t nLabels = labels.getBatchSize();
+    if (nLabels != features.size()) {
+      throw std::invalid_argument(
+          "The input sizes are not compatible: "
+          "The number of columns (features.size()) does not equal"
+          "the number of labels.");
+    }
+
+    size_t nFeatures = features[0].size();
+    std::vector<double> rst(nFeatures, 0);
+    auto revealedValues = labels.openToParty(myId_).getValue();
+    for (size_t i = 0; i < nLabels; ++i) {
+      if (features[i].size() != nFeatures) {
+        throw std::invalid_argument(
+            "Columns of the feature matrix have different sizes.");
+      }
+
+      if (revealedValues[i]) {
+        std::transform( // add the column vector to rst
+            rst.cbegin(),
+            rst.cend(),
+            features[i].cbegin(),
+            rst.begin(),
+            std::plus<double>());
+      }
+    }
+
+    // receive the DP noise from the label owner
+    std::vector<double> dpNoise = agent_->receiveT<double>(nFeatures);
+    std::transform( // add the DP noise to rst
+        rst.cbegin(),
+        rst.cend(),
+        dpNoise.cbegin(),
+        rst.begin(),
+        std::plus<double>());
+    return rst;
+  }
+
+  /**
+   * @inherit doc
+   */
+  void matrixVectorMultiplication(
+      const frontend::Bit<true, schedulerId, true>& labels,
+      const std::vector<double>& dpNoise) const {
+    labels.openToParty(partnerId_);
+    agent_->sendT<double>(dpNoise);
+  }
+
+ private:
+  int myId_;
+  int partnerId_;
+  std::unique_ptr<engine::communication::IPartyCommunicationAgent> agent_;
+};
+} // namespace fbpcf::mpc_std_lib::walr::insecure

--- a/fbpcf/mpc_std_lib/walr_multiplication/DummyMatrixMultiplicationFactory.h
+++ b/fbpcf/mpc_std_lib/walr_multiplication/DummyMatrixMultiplicationFactory.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "fbpcf/engine/communication/IPartyCommunicationAgentFactory.h"
+#include "fbpcf/mpc_std_lib/walr_multiplication/DummyMatrixMultiplication.h"
+#include "fbpcf/mpc_std_lib/walr_multiplication/IWalrMatrixMultiplication.h"
+#include "fbpcf/mpc_std_lib/walr_multiplication/IWalrMatrixMultiplicationFactory.h"
+
+namespace fbpcf::mpc_std_lib::walr::insecure {
+
+template <int schedulerId>
+class DummyMatrixMultiplicationFactory final
+    : public IWalrMatrixMultiplicationFactory<schedulerId> {
+ public:
+  explicit DummyMatrixMultiplicationFactory(
+      int myId,
+      int partnerId,
+      engine::communication::IPartyCommunicationAgentFactory& agentFactory)
+      : myId_(myId), partnerId_(partnerId), agentFactory_(agentFactory) {}
+
+  std::unique_ptr<IWalrMatrixMultiplication<schedulerId>> create() override {
+    return std::make_unique<DummyMatrixMultiplication<schedulerId>>(
+        myId_,
+        partnerId_,
+        agentFactory_.create(
+            partnerId_,
+            "walr_matrix_multiplication_traffic_to_party " +
+                std::to_string(partnerId_)));
+  }
+
+ private:
+  int myId_;
+  int partnerId_;
+  engine::communication::IPartyCommunicationAgentFactory& agentFactory_;
+};
+
+} // namespace fbpcf::mpc_std_lib::walr::insecure

--- a/fbpcf/mpc_std_lib/walr_multiplication/IWalrMatrixMultiplication.h
+++ b/fbpcf/mpc_std_lib/walr_multiplication/IWalrMatrixMultiplication.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <vector>
+
+#include "fbpcf/frontend/Bit.h"
+
+namespace fbpcf::mpc_std_lib::walr {
+
+template <int schedulerId>
+class IWalrMatrixMultiplication {
+  using FixedPointType = uint64_t;
+
+ public:
+  virtual ~IWalrMatrixMultiplication() = default;
+  /**
+   * The API for the caller with features and label shares.
+   * @param features: the feature matrix. Each element is a column vector of the
+   * feature matrix.
+   * @param labels: the label vector represented as a batch of Bits,
+   * consisting of only (secret) boolean labels.
+   * To make the shape compatible, one must have features.size() ==
+   * labels.getBatchSize().
+   * @return the product of feature matrix and the label vector.
+   */
+  virtual std::vector<double> matrixVectorMultiplication(
+      const std::vector<std::vector<double>>& features,
+      const frontend::Bit<true, schedulerId, true>& labels) const = 0;
+
+  /**
+   * The API for the caller with only label shares.
+   * @param labels: the label vector consisting of only (secret) boolean labels.
+   * @param dpNoise: the dp noise that would be imposed on the output.
+   */
+  virtual void matrixVectorMultiplication(
+      const frontend::Bit<true, schedulerId, true>& labels,
+      const std::vector<double>& dpNoise) const = 0;
+};
+
+} // namespace fbpcf::mpc_std_lib::walr

--- a/fbpcf/mpc_std_lib/walr_multiplication/IWalrMatrixMultiplicationFactory.h
+++ b/fbpcf/mpc_std_lib/walr_multiplication/IWalrMatrixMultiplicationFactory.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "fbpcf/mpc_std_lib/walr_multiplication/IWalrMatrixMultiplication.h"
+namespace fbpcf::mpc_std_lib::walr {
+
+template <int schedulerId>
+class IWalrMatrixMultiplicationFactory {
+ public:
+  virtual ~IWalrMatrixMultiplicationFactory() = default;
+  virtual std::unique_ptr<IWalrMatrixMultiplication<schedulerId>> create() = 0;
+};
+
+} // namespace fbpcf::mpc_std_lib::walr

--- a/fbpcf/mpc_std_lib/walr_multiplication/OTBasedMatrixMultiplication.h
+++ b/fbpcf/mpc_std_lib/walr_multiplication/OTBasedMatrixMultiplication.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <emmintrin.h>
+#include <fbpcf/engine/tuple_generator/oblivious_transfer/IRandomCorrelatedObliviousTransferFactory.h>
+#include <fbpcf/engine/util/util.h>
+#include <algorithm>
+#include <cstdint>
+#include <stdexcept>
+#include <type_traits>
+#include "fbpcf/engine/communication/IPartyCommunicationAgent.h"
+#include "fbpcf/engine/communication/IPartyCommunicationAgentFactory.h"
+#include "fbpcf/engine/util/IPrgFactory.h"
+#include "fbpcf/mpc_std_lib/walr_multiplication/IWalrMatrixMultiplication.h"
+#include "fbpcf/mpc_std_lib/walr_multiplication/util/COTWithRandomMessage.h"
+#include "fbpcf/mpc_std_lib/walr_multiplication/util/NumberMapper.h"
+
+namespace fbpcf::mpc_std_lib::walr {
+
+template <int schedulerId, typename FixedPointType>
+class OTBasedMatrixMultiplication final
+    : public IWalrMatrixMultiplication<schedulerId> {
+ public:
+  explicit OTBasedMatrixMultiplication(
+      int myId,
+      int partnerId,
+      bool isFeatureOwner,
+      uint64_t divisor, // The precision loss will be roughly 1 / divisor
+      std::unique_ptr<engine::communication::IPartyCommunicationAgent> agent,
+      std::unique_ptr<engine::util::IPrgFactory> prgFactory,
+      std::unique_ptr<util::COTWithRandomMessage> cotWRM)
+      : myId_(myId),
+        partnerId_(partnerId),
+        isFeatureOwner_(isFeatureOwner),
+        numberMapper_(util::NumberMapper<FixedPointType>(divisor)),
+        agent_(std::move(agent)),
+        prgFactory_(std::move(prgFactory)),
+        cotWRM_(std::move(cotWRM)) {}
+
+  void setDivisor(uint64_t divisor) {
+    numberMapper_.setDivisor(divisor);
+  }
+
+  /**
+   * @inherit doc
+   */
+  std::vector<double> matrixVectorMultiplication(
+      const std::vector<std::vector<double>>& features,
+      const frontend::Bit<true, schedulerId, true>& labels) const;
+
+  /**
+   * @inherit doc
+   */
+  void matrixVectorMultiplication(
+      const frontend::Bit<true, schedulerId, true>& labels,
+      const std::vector<double>& dpNoise) const;
+
+ private:
+  int myId_;
+  int partnerId_;
+  bool isFeatureOwner_;
+  util::NumberMapper<FixedPointType> numberMapper_;
+  std::unique_ptr<engine::communication::IPartyCommunicationAgent> agent_;
+  std::unique_ptr<engine::util::IPrgFactory> prgFactory_;
+  std::unique_ptr<util::COTWithRandomMessage> cotWRM_;
+};
+} // namespace fbpcf::mpc_std_lib::walr
+
+#include "fbpcf/mpc_std_lib/walr_multiplication/OTBasedMatrixMultiplication_impl.h"

--- a/fbpcf/mpc_std_lib/walr_multiplication/OTBasedMatrixMultiplicationFactory.h
+++ b/fbpcf/mpc_std_lib/walr_multiplication/OTBasedMatrixMultiplicationFactory.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <emmintrin.h>
+#include <cstdint>
+#include "fbpcf/engine/communication/IPartyCommunicationAgentFactory.h"
+#include "fbpcf/engine/util/IPrgFactory.h"
+#include "fbpcf/engine/util/util.h"
+#include "fbpcf/mpc_std_lib/walr_multiplication/IWalrMatrixMultiplication.h"
+#include "fbpcf/mpc_std_lib/walr_multiplication/IWalrMatrixMultiplicationFactory.h"
+#include "fbpcf/mpc_std_lib/walr_multiplication/OTBasedMatrixMultiplication.h"
+#include "fbpcf/mpc_std_lib/walr_multiplication/util/COTWithRandomMessage.h"
+#include "fbpcf/mpc_std_lib/walr_multiplication/util/COTWithRandomMessageFactory.h"
+
+namespace fbpcf::mpc_std_lib::walr {
+
+template <int schedulerId, typename FixedPointType>
+class OTBasedMatrixMultiplicationFactory final
+    : public IWalrMatrixMultiplicationFactory<schedulerId> {
+ public:
+  explicit OTBasedMatrixMultiplicationFactory(
+      int myId,
+      int partnerId,
+      bool isFeatureOwner,
+      uint64_t divisor,
+      engine::communication::IPartyCommunicationAgentFactory& agentFactory,
+      std::unique_ptr<engine::util::IPrgFactory> prgFactory,
+      std::unique_ptr<util::COTWithRandomMessageFactory> cotWRMFactory)
+      : myId_(myId),
+        partnerId_(partnerId),
+        isFeatureOwner_(isFeatureOwner),
+        divisor_(divisor),
+        agentFactory_(agentFactory),
+        prgFactory_(std::move(prgFactory)),
+        cotWRMFactory_(std::move(cotWRMFactory)) {}
+
+  std::unique_ptr<IWalrMatrixMultiplication<schedulerId>> create() override {
+    __m128i delta = engine::util::getRandomM128iFromSystemNoise();
+    std::unique_ptr<util::COTWithRandomMessage> cotWRM;
+    auto cotWRMAgent = agentFactory_.create(
+        partnerId_,
+        "walr_matrix_multiplication_cotWRM_traffic_to_party " +
+            std::to_string(partnerId_));
+    auto rcotAgent = agentFactory_.create(
+        partnerId_,
+        "walr_matrix_multiplication_rcot_of_cotWRM_traffic_to_party " +
+            std::to_string(partnerId_));
+    if (isFeatureOwner_) {
+      cotWRM = cotWRMFactory_->create(
+          delta, std::move(cotWRMAgent), std::move(rcotAgent));
+    } else {
+      cotWRM =
+          cotWRMFactory_->create(std::move(cotWRMAgent), std::move(rcotAgent));
+    }
+
+    return std::make_unique<
+        OTBasedMatrixMultiplication<schedulerId, FixedPointType>>(
+        myId_,
+        partnerId_,
+        isFeatureOwner_,
+        divisor_,
+        agentFactory_.create(
+            partnerId_,
+            "walr_matrix_multiplication_traffic_to_party " +
+                std::to_string(partnerId_)),
+        std::move(prgFactory_),
+        std::move(cotWRM));
+  }
+
+ private:
+  int myId_;
+  int partnerId_;
+  bool isFeatureOwner_;
+  uint64_t divisor_;
+  engine::communication::IPartyCommunicationAgentFactory& agentFactory_;
+  std::unique_ptr<engine::util::IPrgFactory> prgFactory_;
+  std::unique_ptr<util::COTWithRandomMessageFactory> cotWRMFactory_;
+};
+
+} // namespace fbpcf::mpc_std_lib::walr

--- a/fbpcf/mpc_std_lib/walr_multiplication/OTBasedMatrixMultiplication_impl.h
+++ b/fbpcf/mpc_std_lib/walr_multiplication/OTBasedMatrixMultiplication_impl.h
@@ -1,0 +1,6 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */

--- a/fbpcf/mpc_std_lib/walr_multiplication/test/WalrMatrixMultiplicationTest.cpp
+++ b/fbpcf/mpc_std_lib/walr_multiplication/test/WalrMatrixMultiplicationTest.cpp
@@ -22,6 +22,8 @@
 #include "fbpcf/mpc_std_lib/walr_multiplication/DummyMatrixMultiplicationFactory.h"
 #include "fbpcf/mpc_std_lib/walr_multiplication/IWalrMatrixMultiplication.h"
 #include "fbpcf/mpc_std_lib/walr_multiplication/IWalrMatrixMultiplicationFactory.h"
+#include "fbpcf/mpc_std_lib/walr_multiplication/OTBasedMatrixMultiplication.h"
+#include "fbpcf/mpc_std_lib/walr_multiplication/OTBasedMatrixMultiplicationFactory.h"
 #include "fbpcf/test/TestHelper.h"
 
 namespace fbpcf::mpc_std_lib::walr {
@@ -282,4 +284,5 @@ TEST(
   matrixVectorMultiplicationUniformNoiseTest<0, 1, 0, 1>(
       std::move(featureOwnerFactory), std::move(labelOwnerFactory), 1e-7);
 }
+
 } // namespace fbpcf::mpc_std_lib::walr

--- a/fbpcf/mpc_std_lib/walr_multiplication/test/WalrMatrixMultiplicationTest.cpp
+++ b/fbpcf/mpc_std_lib/walr_multiplication/test/WalrMatrixMultiplicationTest.cpp
@@ -1,0 +1,285 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <future>
+#include <memory>
+#include <random>
+#include <tuple>
+#include <vector>
+
+#include "fbpcf/engine/communication/test/AgentFactoryCreationHelper.h"
+#include "fbpcf/mpc_std_lib/walr_multiplication/DummyMatrixMultiplication.h"
+#include "fbpcf/mpc_std_lib/walr_multiplication/DummyMatrixMultiplicationFactory.h"
+#include "fbpcf/mpc_std_lib/walr_multiplication/IWalrMatrixMultiplication.h"
+#include "fbpcf/mpc_std_lib/walr_multiplication/IWalrMatrixMultiplicationFactory.h"
+#include "fbpcf/test/TestHelper.h"
+
+namespace fbpcf::mpc_std_lib::walr {
+
+std::vector<std::vector<double>> generateRandomFeatures(
+    size_t nFeatures,
+    size_t nLabels) {
+  std::vector<std::vector<double>> features;
+  std::random_device rd;
+  std::mt19937_64 e(rd());
+  std::uniform_real_distribution<double> dist(0, 1.0);
+  for (int i = 0; i < nLabels; ++i) {
+    std::vector<double> column(nFeatures);
+    std::generate(
+        column.begin(), column.end(), [&dist, &e]() { return dist(e); });
+    features.push_back(column);
+  }
+  return features;
+}
+
+std::vector<bool> generateRandomLabels(size_t nLabels, double p = 0.5) {
+  std::vector<bool> labels(nLabels);
+  std::random_device rd;
+  std::mt19937_64 e(rd());
+  std::bernoulli_distribution dist(p);
+  std::generate(
+      labels.begin(), labels.end(), [&dist, &e]() { return dist(e); });
+  return labels;
+}
+
+std::vector<double>
+generateRandomNoise(size_t n, double a = 0, double b = 1.0) {
+  std::vector<double> noise(n);
+  std::random_device rd;
+  std::mt19937_64 e(rd());
+  std::uniform_real_distribution dist(a, b);
+  std::generate(noise.begin(), noise.end(), [&dist, &e]() { return dist(e); });
+  return noise;
+}
+
+// This should be invoked only after corresponding schedulers are created
+// The secret label is owned by party.
+template <int featureOwnerSchedulerId, int labelOwnerSchedulerId>
+std::pair<
+    frontend::Bit<true, featureOwnerSchedulerId, true>,
+    frontend::Bit<true, labelOwnerSchedulerId, true>>
+generateSecretLabelShares(
+    const std::vector<bool>& labelValues,
+    int labelOwnerPartyId) {
+  frontend::Bit<true, featureOwnerSchedulerId, true> featureOwnerShare(
+      std::vector<bool>(labelValues.size(), true), labelOwnerPartyId);
+  frontend::Bit<true, labelOwnerSchedulerId, true> labelOwnerShare(
+      labelValues, labelOwnerPartyId);
+  return {featureOwnerShare, labelOwnerShare};
+}
+
+std::vector<double> plaintextMatrixVectorMultiplication(
+    const std::vector<std::vector<double>>& features,
+    const std::vector<bool>& labels) {
+  std::vector<double> rst(features.at(0).size());
+  for (int i = 0; i < labels.size(); ++i) {
+    if (labels[i]) {
+      std::transform(
+          rst.cbegin(),
+          rst.cend(),
+          features[i].cbegin(),
+          rst.begin(),
+          std::plus<double>());
+    }
+  }
+  return rst;
+}
+
+// helper function for comparing two double vectors
+void testVectorAlmostEq(
+    const std::vector<double>& vec1,
+    const std::vector<double>& vec2,
+    double absError) {
+  ASSERT_EQ(vec1.size(), vec2.size());
+  for (size_t i = 0; i < vec1.size(); ++i) {
+    // Test if the absolute error is within tolerance
+    EXPECT_NEAR(vec1[i], vec2[i], absError) << "at position: " << i;
+  }
+}
+
+// template test for matrix-vector multiplication
+template <
+    int featureOwnerSchedulerId,
+    int labelOwnerSchedulerId,
+    int featureOwnerId,
+    int labelOwnerId>
+void matrixVectorMultiplicationTestHelper(
+    std::unique_ptr<IWalrMatrixMultiplicationFactory<featureOwnerSchedulerId>>
+        featureOwnerFactory,
+    std::unique_ptr<IWalrMatrixMultiplicationFactory<labelOwnerSchedulerId>>
+        labelOwnerFactory,
+    const std::vector<std::vector<double>>& testFeatures,
+    const std::vector<bool>& testLabelValues,
+    const std::vector<double>& testDpNoise,
+    const std::vector<double>& expectedOutput,
+    double tolerance = 1e-7) {
+  // setup mpc engine and schedulers
+  auto agentFactories = engine::communication::getInMemoryAgentFactory(2);
+  setupRealBackend<featureOwnerSchedulerId, labelOwnerSchedulerId>(
+      *agentFactories[featureOwnerId], *agentFactories[labelOwnerId]);
+
+  frontend::Bit<true, featureOwnerSchedulerId, true> testLabelsShare0;
+  frontend::Bit<true, labelOwnerSchedulerId, true> testLabelsShare1;
+  std::tie(testLabelsShare0, testLabelsShare1) =
+      generateSecretLabelShares<featureOwnerSchedulerId, labelOwnerSchedulerId>(
+          testLabelValues, labelOwnerId);
+
+  auto task0 = [&testFeatures, &testLabelsShare0](
+                   std::unique_ptr<IWalrMatrixMultiplicationFactory<
+                       featureOwnerSchedulerId>> partyFactory) {
+    return partyFactory->create()->matrixVectorMultiplication(
+        testFeatures, testLabelsShare0);
+  };
+  auto task1 = [&testLabelsShare1](
+                   std::unique_ptr<IWalrMatrixMultiplicationFactory<
+                       labelOwnerSchedulerId>> partyFactory,
+                   const std::vector<double>& dpNoise) {
+    partyFactory->create()->matrixVectorMultiplication(
+        testLabelsShare1, dpNoise);
+  };
+
+  auto future0 = std::async(task0, std::move(featureOwnerFactory));
+  auto future1 = std::async(task1, std::move(labelOwnerFactory), testDpNoise);
+  auto rst = future0.get();
+  future1.get();
+
+  testVectorAlmostEq(rst, expectedOutput, tolerance);
+}
+
+template <
+    int featureOwnerSchedulerId,
+    int labelOwnerSchedulerId,
+    int featureOwnerId,
+    int labelOwnerId>
+void matrixVectorMultiplicationNoNoiseTest(
+    std::unique_ptr<IWalrMatrixMultiplicationFactory<featureOwnerSchedulerId>>
+        featureOwnerFactory,
+    std::unique_ptr<IWalrMatrixMultiplicationFactory<labelOwnerSchedulerId>>
+        labelOwnerFactory,
+    double tolerance = 1e-7) {
+  // generate test data
+  size_t nFeatures = 150;
+  size_t nLabels = 200;
+  // Random features and labels
+  auto testFeatures = generateRandomFeatures(nFeatures, nLabels);
+  auto testLabelValues = generateRandomLabels(nLabels);
+
+  auto expectedOutput =
+      plaintextMatrixVectorMultiplication(testFeatures, testLabelValues);
+
+  matrixVectorMultiplicationTestHelper<
+      featureOwnerSchedulerId,
+      labelOwnerSchedulerId,
+      featureOwnerId,
+      labelOwnerId>(
+      std::move(featureOwnerFactory),
+      std::move(labelOwnerFactory),
+      testFeatures,
+      testLabelValues,
+      std::vector<double>(nFeatures, 0.0), // no DP noise
+      expectedOutput,
+      tolerance);
+}
+
+// (2) Test with uniform random noise
+template <
+    int featureOwnerSchedulerId,
+    int labelOwnerSchedulerId,
+    int featureOwnerId,
+    int labelOwnerId>
+void matrixVectorMultiplicationUniformNoiseTest(
+    std::unique_ptr<IWalrMatrixMultiplicationFactory<featureOwnerSchedulerId>>
+        featureOwnerFactory,
+    std::unique_ptr<IWalrMatrixMultiplicationFactory<labelOwnerSchedulerId>>
+        labelOwnerFactory,
+    double tolerance = 1e-7) {
+  // generate test data
+  size_t nFeatures = 200;
+  size_t nLabels = 150;
+  // Random features and labels
+  auto testFeatures = generateRandomFeatures(nFeatures, nLabels);
+  auto testLabelValues = generateRandomLabels(nLabels);
+
+  auto expectedOutput =
+      plaintextMatrixVectorMultiplication(testFeatures, testLabelValues);
+  auto uniformNoise = generateRandomNoise(nFeatures, -5, 5);
+
+  // Cap the noise so that it does not make the expectedOutput negative.
+  // Because we are not supposed to handle negative numbers.
+  std::transform(
+      uniformNoise.cbegin(),
+      uniformNoise.cend(),
+      expectedOutput.cbegin(),
+      uniformNoise.begin(),
+      [tolerance](double noise, double output) {
+        if (noise + output < 0) {
+          return -output + std::min(tolerance, 1e-12);
+        } else {
+          return noise;
+        }
+      });
+
+  // Add the noise to the expectedOutput
+  std::transform(
+      expectedOutput.cbegin(),
+      expectedOutput.cend(),
+      uniformNoise.cbegin(),
+      expectedOutput.begin(),
+      std::plus<double>());
+
+  matrixVectorMultiplicationTestHelper<
+      featureOwnerSchedulerId,
+      labelOwnerSchedulerId,
+      featureOwnerId,
+      labelOwnerId>(
+      std::move(featureOwnerFactory),
+      std::move(labelOwnerFactory),
+      testFeatures,
+      testLabelValues,
+      uniformNoise,
+      expectedOutput,
+      tolerance);
+}
+
+TEST(matrixVectorMultiplicationNoNoiseTest, testDummyMatrixMultiplication) {
+  auto agentFactories = engine::communication::getInMemoryAgentFactory(2);
+  // feature owner is party 0 and uses scheduler 0
+  // label owner is party 1 and uses scheduler 1
+  auto featureOwnerFactory =
+      std::make_unique<insecure::DummyMatrixMultiplicationFactory<0>>(
+          0, 1, *agentFactories[0]);
+  auto labelOwnerFactory =
+      std::make_unique<insecure::DummyMatrixMultiplicationFactory<1>>(
+          1, 0, *agentFactories[1]);
+
+  matrixVectorMultiplicationNoNoiseTest<0, 1, 0, 1>(
+      std::move(featureOwnerFactory), std::move(labelOwnerFactory), 1e-7);
+}
+
+TEST(
+    matrixVectorMultiplicationUniformNoiseTest,
+    testDummyMatrixMultiplication) {
+  auto agentFactories = engine::communication::getInMemoryAgentFactory(2);
+  // feature owner is party 0 and uses scheduler 0
+  // label owner is party 1 and uses scheduler 1
+  auto featureOwnerFactory =
+      std::make_unique<insecure::DummyMatrixMultiplicationFactory<0>>(
+          0, 1, *agentFactories[0]);
+  auto labelOwnerFactory =
+      std::make_unique<insecure::DummyMatrixMultiplicationFactory<1>>(
+          1, 0, *agentFactories[1]);
+
+  matrixVectorMultiplicationUniformNoiseTest<0, 1, 0, 1>(
+      std::move(featureOwnerFactory), std::move(labelOwnerFactory), 1e-7);
+}
+} // namespace fbpcf::mpc_std_lib::walr

--- a/fbpcf/mpc_std_lib/walr_multiplication/util/COTWithRandomMessage.cpp
+++ b/fbpcf/mpc_std_lib/walr_multiplication/util/COTWithRandomMessage.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <emmintrin.h>
+#include <vector>
+#include "fbpcf/engine/util/util.h"
+
+#include <fbpcf/mpc_std_lib/walr_multiplication/util/COTWithRandomMessage.h>
+
+namespace fbpcf::mpc_std_lib::walr::util {
+
+std::pair<std::vector<__m128i>, std::vector<__m128i>>
+COTWithRandomMessage::send(size_t size) {
+  if (role_ != engine::util::Role::sender) {
+    throw std::runtime_error("Only sender of the OT can invoke this method.");
+  }
+  auto rcotSender0Messages = rcot_->rcot(size); // k0
+  assert(rcotSender0Messages.size() == size);
+  std::vector<__m128i> rcotSender1Messages(rcotSender0Messages);
+  auto flipIndicator = agent_->receiveBool(size);
+  assert(flipIndicator.size() == size);
+  for (size_t i = 0; i < size; i++) {
+    // k1
+    if (flipIndicator[i]) {
+      rcotSender0Messages[i] = _mm_xor_si128(rcotSender0Messages[i], delta_);
+    } else {
+      rcotSender1Messages[i] = _mm_xor_si128(rcotSender0Messages[i], delta_);
+    }
+  }
+
+  return {rcotSender0Messages, rcotSender1Messages};
+}
+
+std::vector<__m128i> COTWithRandomMessage::receive(
+    const std::vector<bool>& choice) {
+  auto size = choice.size();
+  auto rcotReceiverMessages = rcot_->rcot(size);
+  assert(rcotReceiverMessages.size() == size);
+  std::vector<bool> flipIndicator(size);
+  for (size_t i = 0; i < size; ++i) {
+    flipIndicator[i] =
+        engine::util::getLsb(rcotReceiverMessages[i]) ^ choice[i];
+  }
+  agent_->sendBool(flipIndicator);
+  return rcotReceiverMessages;
+}
+
+} // namespace fbpcf::mpc_std_lib::walr::util

--- a/fbpcf/mpc_std_lib/walr_multiplication/util/COTWithRandomMessage.h
+++ b/fbpcf/mpc_std_lib/walr_multiplication/util/COTWithRandomMessage.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <emmintrin.h>
+#include <fbpcf/engine/tuple_generator/oblivious_transfer/IRandomCorrelatedObliviousTransfer.h>
+#include "fbpcf/engine/communication/IPartyCommunicationAgent.h"
+#include "fbpcf/engine/util/util.h"
+
+namespace fbpcf::mpc_std_lib::walr::util {
+
+class COTWithRandomMessage {
+ public:
+  // Sender constructor
+  COTWithRandomMessage(
+      __m128i delta,
+      std::unique_ptr<engine::communication::IPartyCommunicationAgent> agent,
+      std::unique_ptr<engine::tuple_generator::oblivious_transfer::
+                          IRandomCorrelatedObliviousTransfer> rcot)
+      : delta_(delta),
+        role_(engine::util::Role::sender),
+        agent_(std::move(agent)),
+        rcot_(std::move(rcot)) {}
+
+  // Receiver constructor
+  COTWithRandomMessage(
+      std::unique_ptr<engine::communication::IPartyCommunicationAgent> agent,
+      std::unique_ptr<engine::tuple_generator::oblivious_transfer::
+                          IRandomCorrelatedObliviousTransfer> rcot)
+      : role_(engine::util::Role::receiver),
+        agent_(std::move(agent)),
+        rcot_(std::move(rcot)) {}
+
+  /**
+   * run a number of COTwRM as the sender.
+   * @param size number of COTwR to run;
+   * @return a pair of 0-message vector and 1-message vector
+   */
+  std::pair<std::vector<__m128i>, std::vector<__m128i>> send(size_t size);
+
+  /**
+   * run a number of COTwRM as the receiver.
+   * @param choice the choice bit vector, its length indicates number of
+   * COTwRMs to run.
+   * @return chosen-message vector
+   */
+  std::vector<__m128i> receive(const std::vector<bool>& choice);
+
+  std::unique_ptr<engine::communication::IPartyCommunicationAgent>
+  extractCommunicationAgent() {
+    return std::move(agent_);
+  }
+
+  /**
+   * Get the total amount of traffic transmitted.
+   * @return a pair of (sent, received) data in bytes.
+   */
+  std::pair<uint64_t, uint64_t> getTrafficStatistics() const {
+    return agent_->getTrafficStatistics();
+  }
+
+ private:
+  __m128i delta_;
+  engine::util::Role role_;
+  std::unique_ptr<engine::communication::IPartyCommunicationAgent> agent_;
+  std::unique_ptr<engine::tuple_generator::oblivious_transfer::
+                      IRandomCorrelatedObliviousTransfer>
+      rcot_;
+};
+
+} // namespace fbpcf::mpc_std_lib::walr::util

--- a/fbpcf/mpc_std_lib/walr_multiplication/util/COTWithRandomMessageFactory.h
+++ b/fbpcf/mpc_std_lib/walr_multiplication/util/COTWithRandomMessageFactory.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <emmintrin.h>
+#include <memory>
+#include "fbpcf/engine/tuple_generator/oblivious_transfer/IRandomCorrelatedObliviousTransferFactory.h"
+#include "fbpcf/mpc_std_lib/walr_multiplication/util/COTWithRandomMessage.h"
+
+namespace fbpcf::mpc_std_lib::walr::util {
+
+class COTWithRandomMessageFactory {
+ public:
+  explicit COTWithRandomMessageFactory(
+      std::unique_ptr<engine::tuple_generator::oblivious_transfer::
+                          IRandomCorrelatedObliviousTransferFactory>
+          rcotFactory)
+      : rcotFactory_(std::move(rcotFactory)) {}
+
+  std::unique_ptr<COTWithRandomMessage> create(
+      __m128i delta,
+      std::unique_ptr<engine::communication::IPartyCommunicationAgent> agent,
+      std::unique_ptr<engine::communication::IPartyCommunicationAgent>
+          rcotAgent);
+
+  std::unique_ptr<COTWithRandomMessage> create(
+      std::unique_ptr<engine::communication::IPartyCommunicationAgent> agent,
+      std::unique_ptr<engine::communication::IPartyCommunicationAgent>
+          rcotAgent);
+
+ private:
+  std::unique_ptr<engine::tuple_generator::oblivious_transfer::
+                      IRandomCorrelatedObliviousTransferFactory>
+      rcotFactory_;
+};
+} // namespace fbpcf::mpc_std_lib::walr::util

--- a/fbpcf/mpc_std_lib/walr_multiplication/util/COTWithRandomMessageFactory.h
+++ b/fbpcf/mpc_std_lib/walr_multiplication/util/COTWithRandomMessageFactory.h
@@ -22,16 +22,26 @@ class COTWithRandomMessageFactory {
           rcotFactory)
       : rcotFactory_(std::move(rcotFactory)) {}
 
+  // create sender
   std::unique_ptr<COTWithRandomMessage> create(
       __m128i delta,
       std::unique_ptr<engine::communication::IPartyCommunicationAgent> agent,
       std::unique_ptr<engine::communication::IPartyCommunicationAgent>
-          rcotAgent);
+          rcotAgent) {
+    auto rcot = rcotFactory_->create(delta, std::move(rcotAgent));
+    return std::make_unique<COTWithRandomMessage>(
+        delta, std::move(agent), std::move(rcot));
+  }
 
+  // create receiver
   std::unique_ptr<COTWithRandomMessage> create(
       std::unique_ptr<engine::communication::IPartyCommunicationAgent> agent,
       std::unique_ptr<engine::communication::IPartyCommunicationAgent>
-          rcotAgent);
+          rcotAgent) {
+    auto rcot = rcotFactory_->create(std::move(rcotAgent));
+    return std::make_unique<COTWithRandomMessage>(
+        std::move(agent), std::move(rcot));
+  }
 
  private:
   std::unique_ptr<engine::tuple_generator::oblivious_transfer::

--- a/fbpcf/mpc_std_lib/walr_multiplication/util/NumberMapper.h
+++ b/fbpcf/mpc_std_lib/walr_multiplication/util/NumberMapper.h
@@ -7,10 +7,11 @@
 
 #pragma once
 
-#include <limits.h>
-#include <sys/types.h>
 #include <cstdint>
+#include <limits>
 #include <stdexcept>
+#include <vector>
+#include "folly/logging/xlog.h"
 
 namespace fbpcf::mpc_std_lib::walr::util {
 
@@ -28,23 +29,61 @@ class NumberMapper {
           "The divisor's value should not exceed the max value a FixedPointType can represent.");
     }
   }
+  static constexpr double groupSize =
+      double(std::numeric_limits<FixedPointType>::max()) + 1;
 
-  // Methods supporting converting from/to FixedPointType
-  inline FixedPointType mapToFixedPointType(double input) const;
+  /*
+   * Methods supporting converting from/to FixedPointType.
+   * Given an nonnegative double input, mapToDouble(mapToFixedPointType(input))
+   * preserves the input (up to precision loss).
+   * (1) When abs(input) >= 1.0, the RELATIVE precision loss will be
+   * less than abs(input) / divisor.
+   * (2) When abs(input) < 1.0, the ABSOLUTE precision loss will be
+   * less than 1 / divisor.
+   */
+  inline FixedPointType mapToFixedPointType(double input) const {
+    double product = input * divisor_;
+    if (std::abs(product) > groupSize) {
+      XLOG_EVERY_MS(WARN, 500) << "Magnitude of input number " << input
+                               << " too large. Conversion exceeds group size."
+                               << " May incur unwanted precision loss.";
+    }
+    uintmax_t rst = static_cast<uintmax_t>(static_cast<intmax_t>(product));
+    return static_cast<FixedPointType>(rst);
+  }
 
   std::vector<FixedPointType> mapToFixedPointType(
-      const std::vector<double>& input) const;
+      const std::vector<double>& input) const {
+    std::vector<FixedPointType> rst(input.size());
+    std::transform(input.cbegin(), input.cend(), rst.begin(), [this](double a) {
+      return mapToFixedPointType(a);
+    });
+    return rst;
+  }
 
-  inline double mapToDouble(FixedPointType input) const;
+  inline double mapToDouble(FixedPointType input) const {
+    return input / static_cast<double>(divisor_);
+  }
 
   std::vector<double> mapToDouble(
-      const std::vector<FixedPointType>& input) const;
+      const std::vector<FixedPointType>& input) const {
+    std::vector<double> rst(input.size());
+    std::transform(
+        input.cbegin(), input.cend(), rst.begin(), [this](FixedPointType a) {
+          return mapToDouble(a);
+        });
+    return rst;
+  }
 
   uint64_t getDivisor() const {
     return divisor_;
   }
 
   void setDivisor(uint64_t divisor) {
+    if (divisor > std::numeric_limits<FixedPointType>::max()) {
+      throw std::invalid_argument(
+          "The divisor's value should not exceed the max value a FixedPointType can represent.");
+    }
     divisor_ = divisor;
   }
 

--- a/fbpcf/mpc_std_lib/walr_multiplication/util/NumberMapper.h
+++ b/fbpcf/mpc_std_lib/walr_multiplication/util/NumberMapper.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <limits.h>
+#include <sys/types.h>
+#include <cstdint>
+#include <stdexcept>
+
+namespace fbpcf::mpc_std_lib::walr::util {
+
+template <typename FixedPointType>
+class NumberMapper {
+  static_assert(
+      std::is_integral<FixedPointType>::value &&
+          std::is_unsigned_v<FixedPointType>,
+      "Currently only support FixedPointType being some uint type with width no more than 64.");
+
+ public:
+  explicit NumberMapper(uint64_t divisor) : divisor_(divisor) {
+    if (divisor > std::numeric_limits<FixedPointType>::max()) {
+      throw std::invalid_argument(
+          "The divisor's value should not exceed the max value a FixedPointType can represent.");
+    }
+  }
+
+  // Methods supporting converting from/to FixedPointType
+  inline FixedPointType mapToFixedPointType(double input) const;
+
+  std::vector<FixedPointType> mapToFixedPointType(
+      const std::vector<double>& input) const;
+
+  inline double mapToDouble(FixedPointType input) const;
+
+  std::vector<double> mapToDouble(
+      const std::vector<FixedPointType>& input) const;
+
+  uint64_t getDivisor() const {
+    return divisor_;
+  }
+
+  void setDivisor(uint64_t divisor) {
+    divisor_ = divisor;
+  }
+
+ private:
+  uint64_t divisor_;
+};
+
+} // namespace fbpcf::mpc_std_lib::walr::util

--- a/fbpcf/mpc_std_lib/walr_multiplication/util/test/COTWithRandomMessageTest.cpp
+++ b/fbpcf/mpc_std_lib/walr_multiplication/util/test/COTWithRandomMessageTest.cpp
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <emmintrin.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <future>
+#include <memory>
+#include <random>
+#include <thread>
+#include "fbpcf/engine/communication/InMemoryPartyCommunicationAgentHost.h"
+#include "fbpcf/engine/communication/test/AgentFactoryCreationHelper.h"
+#include "fbpcf/test/TestHelper.h"
+
+#include "fbpcf/engine/tuple_generator/oblivious_transfer/DummyRandomCorrelatedObliviousTransferFactory.h"
+#include "fbpcf/engine/tuple_generator/oblivious_transfer/EmpShRandomCorrelatedObliviousTransferFactory.h"
+#include "fbpcf/engine/tuple_generator/oblivious_transfer/ExtenderBasedRandomCorrelatedObliviousTransferFactory.h"
+#include "fbpcf/engine/tuple_generator/oblivious_transfer/ferret/RcotExtenderFactory.h"
+#include "fbpcf/engine/tuple_generator/oblivious_transfer/ferret/RegularErrorMultiPointCotFactory.h"
+#include "fbpcf/engine/tuple_generator/oblivious_transfer/ferret/SinglePointCotFactory.h"
+#include "fbpcf/engine/tuple_generator/oblivious_transfer/ferret/TenLocalLinearMatrixMultiplierFactory.h"
+
+#include <fbpcf/mpc_std_lib/walr_multiplication/util/COTWithRandomMessage.h>
+#include <fbpcf/mpc_std_lib/walr_multiplication/util/COTWithRandomMessageFactory.h>
+
+namespace fbpcf::mpc_std_lib::walr::util {
+
+void testCOTWithRandomMessage(
+    std::unique_ptr<engine::tuple_generator::oblivious_transfer::
+                        IRandomCorrelatedObliviousTransferFactory> rcotFactory0,
+    std::unique_ptr<engine::tuple_generator::oblivious_transfer::
+                        IRandomCorrelatedObliviousTransferFactory>
+        rcotFactory1) {
+  auto agentFactories = engine::communication::getInMemoryAgentFactory(2);
+
+  auto senderTask =
+      [&agentFactories](
+          std::unique_ptr<engine::tuple_generator::oblivious_transfer::
+                              IRandomCorrelatedObliviousTransferFactory>
+              rcotFactory,
+          __m128i delta,
+          size_t size,
+          int myId,
+          int partnerId) {
+        auto otFactory = std::make_unique<COTWithRandomMessageFactory>(
+            std::move(rcotFactory));
+
+        auto otAgent =
+            agentFactories[myId]->create(partnerId, "COTwRM_sender_traffic");
+        auto rcotAgent = agentFactories[myId]->create(
+            partnerId, "RCOT_of_COTwRM_sender_traffic");
+        auto ot =
+            otFactory->create(delta, std::move(otAgent), std::move(rcotAgent));
+        return ot->send(size);
+      };
+
+  auto receiverTask =
+      [&agentFactories](
+          std::unique_ptr<engine::tuple_generator::oblivious_transfer::
+                              IRandomCorrelatedObliviousTransferFactory>
+              rcotFactory,
+          const std::vector<bool>& choice,
+          int myId,
+          int partnerId) {
+        auto otFactory = std::make_unique<COTWithRandomMessageFactory>(
+            std::move(rcotFactory));
+
+        auto otAgent =
+            agentFactories[myId]->create(partnerId, "COTwRM_receiver_traffic");
+        auto rcotAgent = agentFactories[myId]->create(
+            partnerId, "RCOT_of_COTwRM_receiver_traffic");
+        auto ot = otFactory->create(std::move(otAgent), std::move(rcotAgent));
+        return ot->receive(choice);
+      };
+
+  __m128i delta = engine::util::getRandomM128iFromSystemNoise();
+  engine::util::setLsbTo1(delta);
+  int size = 200;
+  std::vector<bool> choice(size);
+
+  std::random_device rd;
+  std::mt19937_64 e(rd());
+  std::bernoulli_distribution dist(0.5);
+  std::generate(
+      choice.begin(), choice.end(), [&dist, &e]() { return dist(e); });
+
+  auto sender =
+      std::async(senderTask, std::move(rcotFactory0), delta, size, 0, 1);
+  auto receiver =
+      std::async(receiverTask, std::move(rcotFactory1), choice, 1, 0);
+
+  auto [m0, m1] = sender.get();
+  auto m = receiver.get();
+
+  for (int i = 0; i < size; i++) {
+    EXPECT_TRUE(compareM128i(m0[i], _mm_xor_si128(m1[i], delta)));
+    if (choice[i]) {
+      EXPECT_TRUE(compareM128i(m1[i], m[i]));
+    } else {
+      EXPECT_TRUE(compareM128i(m0[i], m[i]));
+    }
+  }
+}
+
+TEST(COTWithRandomMessageTest, testDummyRCOTBasedCOTwR) {
+  testCOTWithRandomMessage(
+      std::make_unique<engine::tuple_generator::oblivious_transfer::insecure::
+                           DummyRandomCorrelatedObliviousTransferFactory>(),
+      std::make_unique<engine::tuple_generator::oblivious_transfer::insecure::
+                           DummyRandomCorrelatedObliviousTransferFactory>());
+}
+
+TEST(COTWithRandomMessageTest, testFERRETBasedCOTwR) {
+  testCOTWithRandomMessage(
+      std::make_unique<
+          engine::tuple_generator::oblivious_transfer::
+              ExtenderBasedRandomCorrelatedObliviousTransferFactory>(
+          std::make_unique<engine::tuple_generator::oblivious_transfer::
+                               EmpShRandomCorrelatedObliviousTransferFactory>(
+              std::make_unique<engine::util::AesPrgFactory>(1024)),
+          std::make_unique<engine::tuple_generator::oblivious_transfer::ferret::
+                               RcotExtenderFactory>(
+              std::make_unique<
+                  engine::tuple_generator::oblivious_transfer::ferret::
+                      TenLocalLinearMatrixMultiplierFactory>(),
+              std::make_unique<engine::tuple_generator::oblivious_transfer::
+                                   ferret::RegularErrorMultiPointCotFactory>(
+                  std::make_unique<engine::tuple_generator::oblivious_transfer::
+                                       ferret::SinglePointCotFactory>())),
+          engine::tuple_generator::oblivious_transfer::ferret::kExtendedSize,
+          engine::tuple_generator::oblivious_transfer::ferret::kBaseSize,
+          engine::tuple_generator::oblivious_transfer::ferret::kWeight),
+      std::make_unique<
+          engine::tuple_generator::oblivious_transfer::
+              ExtenderBasedRandomCorrelatedObliviousTransferFactory>(
+          std::make_unique<engine::tuple_generator::oblivious_transfer::
+                               EmpShRandomCorrelatedObliviousTransferFactory>(
+              std::make_unique<engine::util::AesPrgFactory>(1024)),
+          std::make_unique<engine::tuple_generator::oblivious_transfer::ferret::
+                               RcotExtenderFactory>(
+              std::make_unique<
+                  engine::tuple_generator::oblivious_transfer::ferret::
+                      TenLocalLinearMatrixMultiplierFactory>(),
+              std::make_unique<engine::tuple_generator::oblivious_transfer::
+                                   ferret::RegularErrorMultiPointCotFactory>(
+                  std::make_unique<engine::tuple_generator::oblivious_transfer::
+                                       ferret::SinglePointCotFactory>())),
+          engine::tuple_generator::oblivious_transfer::ferret::kExtendedSize,
+          engine::tuple_generator::oblivious_transfer::ferret::kBaseSize,
+          engine::tuple_generator::oblivious_transfer::ferret::kWeight));
+}
+
+} // namespace fbpcf::mpc_std_lib::walr::util

--- a/fbpcf/mpc_std_lib/walr_multiplication/util/test/NumberMapperTest.cpp
+++ b/fbpcf/mpc_std_lib/walr_multiplication/util/test/NumberMapperTest.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <fbpcf/mpc_std_lib/walr_multiplication/util/NumberMapper.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <iterator>
+#include <limits>
+#include <random>
+#include <vector>
+
+namespace fbpcf::mpc_std_lib::walr::util {
+
+TEST(numberMapperTest, testBasicConversion) {
+  constexpr uint64_t divisor = static_cast<uint64_t>(1e7);
+  auto mapper32 = NumberMapper<uint32_t>(divisor);
+  constexpr uint64_t groupSize =
+      (uint64_t)std::numeric_limits<uint32_t>::max() + 1;
+
+  // Basic conversion
+  // 1.0 / 7 = 0.1428571428571
+  EXPECT_EQ(mapper32.mapToFixedPointType(1.0 / 7), 1428571);
+  EXPECT_EQ(mapper32.mapToFixedPointType(7.0), 70000000);
+  EXPECT_EQ(mapper32.mapToFixedPointType(0.0), 0);
+
+  // Converting negative number
+  // On the integer group of size 2^32, -k is equivalent to 2^32 - k
+  EXPECT_EQ(mapper32.mapToFixedPointType(-1.0 / 7), groupSize - 1428571);
+
+  // Overflow
+  double input = ((uint32_t)1 << 31) + (1.0 / 7);
+  EXPECT_EQ(
+      mapper32.mapToFixedPointType(input),
+      (uint64_t)(input * divisor) % groupSize);
+}
+
+TEST(numberMapperTest, testConversionPrecision) {
+  constexpr uint64_t divisor = static_cast<uint64_t>(1e9);
+  double tolerance = 1.0 / divisor; // tolerance on relative error
+  auto mapper64 = NumberMapper<uint64_t>(divisor);
+
+  std::random_device rd;
+  std::mt19937_64 e(rd());
+  std::uniform_real_distribution<double> dist(0, 10.1);
+  std::vector<double> input(99);
+  std::generate(input.begin(), input.end(), [&dist, &e]() { return dist(e); });
+  input.push_back(0.0);
+
+  auto output = mapper64.mapToDouble(mapper64.mapToFixedPointType(input));
+  ASSERT_EQ(input.size(), output.size());
+
+  // The conversion preserve the input (up to precision loss) only if input is
+  // non-negative.
+  // (1) When abs(input) >= 1.0, the RELATIVE precision loss should be
+  // less than abs(input) / divisor.
+  // (2) When abs(input) < 1.0, the ABSOLUTE precision loss should be
+  // less than 1 / divisor
+  for (size_t i = 0; i < output.size(); ++i) {
+    EXPECT_NEAR(
+        input[i],
+        output[i],
+        std::max({std::abs(input[i]), std::abs(output[i]), 1.0}) * tolerance);
+  }
+}
+} // namespace fbpcf::mpc_std_lib::walr::util


### PR DESCRIPTION
Summary:
This diff implements a Correlated Oblivious Transfer with Random Message (COTwRM) using existing RCOT solutions.

## What

The COTwRM should be ran at the same time by two parties.
* The sender receives two vectors of randomly generated 128-bit messages `m0` and `m1`, where `m1[i] = m0[i] ^ delta` for some secret `delta` that's known only to the sender.
* The receiver inputs a vector of choice bits, and receive a vector of 128-bit messages `m`, where `m[i] == m0[i]` if `choice[i] == false`, otherwise `m[i] == m1[i]`.

## Why

This COTwRM is mainly used for implementing the matrix multiplication method (D39078067). We use COTwRM to obliviously distribute keys between the two parties. Then these keys will be used to pad the feature vector. Depending on which key the receiver got, it can only "decrypt" either the noise vector, or the (masked) feature vector.

Reviewed By: RuiyuZhu

Differential Revision: D39072459

