### PR TITLE
Implement AES in CTR mode

### DIFF
--- a/fbpcf/mpc_std_lib/aes_circuit/AesCircuit.h
+++ b/fbpcf/mpc_std_lib/aes_circuit/AesCircuit.h
@@ -20,7 +20,7 @@ class AesCircuit : public IAesCircuit<BitType> {
  private:
   std::vector<BitType> encrypt_impl(
       const std::vector<BitType>& plaintext,
-      const std::vector<BitType>& expandedEncKey) const;
+      const std::vector<BitType>& expandedEncKey) const override;
   void sharedSBoxInPlace(
       const std::array<BitType, 28>& T,
       const BitType& D,
@@ -33,7 +33,7 @@ class AesCircuit : public IAesCircuit<BitType> {
    */
   std::vector<BitType> decrypt_impl(
       const std::vector<BitType>& ciphertext,
-      const std::vector<BitType>& expandedDecKey) const;
+      const std::vector<BitType>& expandedDecKey) const override;
 
  protected:
   std::vector<std::array<WordType, 4>> convertToWords(

--- a/fbpcf/mpc_std_lib/aes_circuit/AesCircuitCtr.h
+++ b/fbpcf/mpc_std_lib/aes_circuit/AesCircuitCtr.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <array>
+#include <memory>
+#include "fbpcf/mpc_std_lib/aes_circuit/IAesCircuit.h"
+#include "fbpcf/mpc_std_lib/aes_circuit/IAesCircuitCtr.h"
+
+namespace fbpcf::mpc_std_lib::aes_circuit {
+
+/*
+ * This is the implementation of AES circuit in Counter mode
+ */
+template <typename BitType>
+class AesCircuitCtr final : public IAesCircuitCtr<BitType> {
+ public:
+  explicit AesCircuitCtr(std::unique_ptr<IAesCircuit<BitType>> AesCircuit)
+      : AesCircuit_{std::move(AesCircuit)} {}
+
+ private:
+  virtual std::vector<BitType> encrypt_impl(
+      const std::vector<BitType>& plaintext,
+      const std::vector<BitType>& expandedEncKey,
+      const std::vector<BitType>& mask) const override;
+
+  std::unique_ptr<IAesCircuit<BitType>> AesCircuit_;
+};
+
+} // namespace fbpcf::mpc_std_lib::aes_circuit

--- a/fbpcf/mpc_std_lib/aes_circuit/AesCircuitCtrFactory.h
+++ b/fbpcf/mpc_std_lib/aes_circuit/AesCircuitCtrFactory.h
@@ -8,15 +8,18 @@
 #pragma once
 
 #include "fbpcf/mpc_std_lib/aes_circuit/AesCircuit.h"
+#include "fbpcf/mpc_std_lib/aes_circuit/AesCircuitCtr.h"
+#include "fbpcf/mpc_std_lib/aes_circuit/IAesCircuitCtrFactory.h"
 #include "fbpcf/mpc_std_lib/aes_circuit/IAesCircuitFactory.h"
 
 namespace fbpcf::mpc_std_lib::aes_circuit {
 
 template <typename BitType>
-class AesCircuitFactory : IAesCircuitFactory<BitType> {
+class AesCircuitCtrFactory : IAesCircuitCtrFactory<BitType> {
  public:
-  std::unique_ptr<IAesCircuit<BitType>> create() override {
-    return std::make_unique<AesCircuit<BitType>>();
+  std::unique_ptr<IAesCircuitCtr<BitType>> create() override {
+    return std::make_unique<AesCircuitCtr<BitType>>(
+        std::make_unique<AesCircuit<BitType>>());
   }
 
   typename IAesCircuitFactory<BitType>::CircuitType getCircuitType()

--- a/fbpcf/mpc_std_lib/aes_circuit/AesCircuitCtr_impl.h
+++ b/fbpcf/mpc_std_lib/aes_circuit/AesCircuitCtr_impl.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <vector>
+#include "fbpcf/mpc_std_lib/aes_circuit/AesCircuitCtr.h"
+
+namespace fbpcf::mpc_std_lib::aes_circuit {
+
+template <typename BitType>
+std::vector<BitType> AesCircuitCtr<BitType>::encrypt_impl(
+    const std::vector<BitType>& plaintext,
+    const std::vector<BitType>& expandedEncKey,
+    const std::vector<BitType>& mask) const {
+  size_t blockNo = plaintext.size() / 128;
+  std::vector<BitType> encryptedMask =
+      AesCircuit_->encrypt(mask, expandedEncKey);
+  std::vector<BitType> rst;
+  rst.reserve(blockNo * 128);
+  for (int i = 0; i < blockNo; ++i) {
+    for (int j = 0; j < 128; ++j) {
+      rst.push_back(plaintext[i * 128 + j] ^ encryptedMask[i * 128 + j]);
+    }
+  }
+  return rst;
+}
+} // namespace fbpcf::mpc_std_lib::aes_circuit

--- a/fbpcf/mpc_std_lib/aes_circuit/AesCircuit_impl.h
+++ b/fbpcf/mpc_std_lib/aes_circuit/AesCircuit_impl.h
@@ -80,8 +80,8 @@ std::vector<BitType> AesCircuit<BitType>::encrypt_impl(
 
 template <typename BitType>
 std::vector<BitType> AesCircuit<BitType>::decrypt_impl(
-    const std::vector<BitType>& ciphertext,
-    const std::vector<BitType>& expandedDecKey) const {
+    const std::vector<BitType>& /* ciphertext */,
+    const std::vector<BitType>& /* expandedDecKey */) const {
   throw std::runtime_error("Not implemented!");
 }
 

--- a/fbpcf/mpc_std_lib/aes_circuit/DummyAesCircuit.h
+++ b/fbpcf/mpc_std_lib/aes_circuit/DummyAesCircuit.h
@@ -22,7 +22,7 @@ class DummyAesCircuit final : public IAesCircuit<BitType> {
  private:
   std::vector<BitType> encrypt_impl(
       const std::vector<BitType>& plaintext,
-      const std::vector<BitType>& /* expandedEncKey */) const {
+      const std::vector<BitType>& /* expandedEncKey */) const override {
     return plaintext;
   }
 
@@ -31,7 +31,7 @@ class DummyAesCircuit final : public IAesCircuit<BitType> {
    */
   std::vector<BitType> decrypt_impl(
       const std::vector<BitType>& ciphertext,
-      const std::vector<BitType>& /* expandedDecKey */) const {
+      const std::vector<BitType>& /* expandedDecKey */) const override {
     return ciphertext;
   }
 };

--- a/fbpcf/mpc_std_lib/aes_circuit/DummyAesCircuitFactory.h
+++ b/fbpcf/mpc_std_lib/aes_circuit/DummyAesCircuitFactory.h
@@ -13,13 +13,14 @@
 namespace fbpcf::mpc_std_lib::aes_circuit::insecure {
 
 template <typename BitType>
-class DummyAesCircuitFactory {
+class DummyAesCircuitFactory : public IAesCircuitFactory<BitType> {
  public:
-  std::unique_ptr<IAesCircuit<BitType>> create() {
+  std::unique_ptr<IAesCircuit<BitType>> create() override {
     return std::make_unique<insecure::DummyAesCircuit<BitType>>();
   }
 
-  typename IAesCircuitFactory<BitType>::CircuitType getCircuitType() const {
+  typename IAesCircuitFactory<BitType>::CircuitType getCircuitType()
+      const override {
     return IAesCircuitFactory<BitType>::CircuitType::Dummy;
   }
 };

--- a/fbpcf/mpc_std_lib/aes_circuit/IAesCircuitCtr.h
+++ b/fbpcf/mpc_std_lib/aes_circuit/IAesCircuitCtr.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <stdexcept>
+#include <vector>
+
+namespace fbpcf::mpc_std_lib::aes_circuit {
+
+/*
+ * An AES circuit object implements the AES Counter mode at a conceptual-bit
+ * level. This "conceptual bit" can be anything that has an isomorphic behavior
+ * regarding AND and XOR as normal bits. Currently we support both encryption
+ * and decryption.
+ */
+/**
+ * Bit type can be either bool or any MPC Bit types.
+ */
+template <typename BitType>
+class IAesCircuitCtr {
+ public:
+  static const size_t kExpandedKeyWidth =
+      1408; /** The expanded AES key contains 11 16-byte keys. 1408 = 11 * 16 *
+               8 **/
+
+  virtual ~IAesCircuitCtr() = default;
+
+  /**
+   * Encrypt the plaintext with the expanded key.
+   * @param plaintext the plaintext for AES inside MPC. It must be a
+   * multiplication of 128.
+   * @param expandedEncKey the expanded enc AES key inside MPC. It must be the
+   * expected expanded key size.
+   * @param mask the mask (counter) will be encrypted by AES circuit. It must
+   * has the same size with plaintxet.
+   * @return the ciphertext inside MPC;
+   */
+  std::vector<BitType> encrypt(
+      const std::vector<BitType>& plaintext,
+      const std::vector<BitType>& expandedEncKey,
+      const std::vector<BitType>& mask) const {
+    if (plaintext.size() % 128 != 0) {
+      throw std::runtime_error("Input plaintext must be a multiple of 128");
+    }
+    if (expandedEncKey.size() != kExpandedKeyWidth) {
+      throw std::runtime_error("Expanded Enc AES key must be 1408 bits.");
+    }
+    if (plaintext.size() != mask.size()) {
+      throw std::runtime_error(
+          "Input plaintext should has the same size as mask");
+    }
+    return encrypt_impl(plaintext, expandedEncKey, mask);
+  }
+
+  /**
+   * decrypt the ciphertext with the expanded key.
+   * @param ciphertext the ciphertext for AES inside MPC. It must be a
+   * multiplication of 128.
+   * @param expandedKey the expanded AES key inside MPC. It must be the
+   * expected expanded key size.
+   * @param mask the mask (counter) will be encrypted by AES circuit. It must
+   * has the same size with plaintxet.
+   * @return the plaintext inside MPC;
+   */
+  std::vector<BitType> decrypt(
+      const std::vector<BitType>& ciphertext,
+      const std::vector<BitType>& expandedDecKey,
+      const std::vector<BitType>& mask) const {
+    if (ciphertext.size() % 128 != 0) {
+      throw std::runtime_error("Input ciphertext must be a multiple of 128");
+    }
+    if (expandedDecKey.size() != kExpandedKeyWidth) {
+      throw std::runtime_error("Expanded Dec AES key must be 1408 bits.");
+    }
+    if (ciphertext.size() != mask.size()) {
+      throw std::runtime_error(
+          "Input ciphertext should has the same size as mask");
+    }
+    return encrypt_impl(ciphertext, expandedDecKey, mask);
+  }
+
+ private:
+  virtual std::vector<BitType> encrypt_impl(
+      const std::vector<BitType>& plaintext,
+      const std::vector<BitType>& expandedEncKey,
+      const std::vector<BitType>& mask) const = 0;
+};
+
+} // namespace fbpcf::mpc_std_lib::aes_circuit

--- a/fbpcf/mpc_std_lib/aes_circuit/IAesCircuitCtrFactory.h
+++ b/fbpcf/mpc_std_lib/aes_circuit/IAesCircuitCtrFactory.h
@@ -7,22 +7,21 @@
 
 #pragma once
 
-#include "fbpcf/mpc_std_lib/aes_circuit/AesCircuit.h"
+#include <memory>
+#include "fbpcf/mpc_std_lib/aes_circuit/IAesCircuitCtr.h"
 #include "fbpcf/mpc_std_lib/aes_circuit/IAesCircuitFactory.h"
 
 namespace fbpcf::mpc_std_lib::aes_circuit {
 
 template <typename BitType>
-class AesCircuitFactory : IAesCircuitFactory<BitType> {
+class IAesCircuitCtrFactory {
  public:
-  std::unique_ptr<IAesCircuit<BitType>> create() override {
-    return std::make_unique<AesCircuit<BitType>>();
-  }
+  virtual ~IAesCircuitCtrFactory() = default;
 
-  typename IAesCircuitFactory<BitType>::CircuitType getCircuitType()
-      const override {
-    return IAesCircuitFactory<BitType>::CircuitType::Secure;
-  }
+  virtual std::unique_ptr<IAesCircuitCtr<BitType>> create() = 0;
+
+  virtual typename IAesCircuitFactory<BitType>::CircuitType getCircuitType()
+      const = 0;
 };
 
 } // namespace fbpcf::mpc_std_lib::aes_circuit


### PR DESCRIPTION
Summary:
This diff added a new interface for AES in CTR mode.
1. Added new interface ``IAesCircuitCtr`` and new class ``AesCircuitCtr`` that wraps basic AES circuit. The encryption and decryption in the new ``AesCircuitCtr`` are same and use logic from ``AesCircuit``.
2. Modified all factory classes to let them derive their correspodning interface class. Also added ``override`` keyword where appropriate.
3. Added ``IAesCircuitCtrFactory`` and ``AesCircuitCtrFactory`` for generating AES CTR circuit instance.
4. Added test case for CTR mode

Reviewed By: robotal

Differential Revision: D39158735

