### PR TITLE
Switch to using LazyScheduler in the unittest and some minor bug fix

### DIFF
--- a/fbpcf/mpc_std_lib/walr_multiplication/DummyMatrixMultiplication.h
+++ b/fbpcf/mpc_std_lib/walr_multiplication/DummyMatrixMultiplication.h
@@ -81,7 +81,7 @@ class DummyMatrixMultiplication final
   void matrixVectorMultiplication(
       const frontend::Bit<true, schedulerId, true>& labels,
       const std::vector<double>& dpNoise) const {
-    labels.openToParty(partnerId_);
+    labels.openToParty(partnerId_).getValue();
     agent_->sendT<double>(dpNoise);
   }
 

--- a/fbpcf/mpc_std_lib/walr_multiplication/OTBasedMatrixMultiplication_impl.h
+++ b/fbpcf/mpc_std_lib/walr_multiplication/OTBasedMatrixMultiplication_impl.h
@@ -44,8 +44,12 @@ std::vector<double> OTBasedMatrixMultiplication<schedulerId, FixedPointType>::
         std::to_string(std::numeric_limits<uint32_t>::max()) + " rows.");
   }
 
+  // Extracting label before running COTwRM to help the other party
+  // extract its label share, which will be used as choice bit
+  auto extractedLabels = labels.extractBit().getValue();
+
   // create COT with random message
-  // For each column, we run the COTwR once to generate two 128-bit random
+  // For each column, we run the COTwRM once to generate two 128-bit random
   // messages k0 and k1, which will be used to generate the random additive
   // noise vectors.
   auto [sender0Messages, sender1Messages] = cotWRM_->send(nLabels);
@@ -53,7 +57,6 @@ std::vector<double> OTBasedMatrixMultiplication<schedulerId, FixedPointType>::
   assert(sender1Messages.size() == nLabels);
 
   // Now we run the protocol
-  auto extractedLabels = labels.extractBit().getValue();
   std::vector<FixedPointType> totalNoise(nFeatures, 0);
   for (size_t i = 0; i < nLabels; i++) {
     std::vector<FixedPointType> feature =

--- a/fbpcf/mpc_std_lib/walr_multiplication/test/WalrMatrixMultiplicationTest.cpp
+++ b/fbpcf/mpc_std_lib/walr_multiplication/test/WalrMatrixMultiplicationTest.cpp
@@ -141,7 +141,9 @@ void matrixVectorMultiplicationTestHelper(
     double tolerance = 1e-7) {
   // setup mpc engine and schedulers
   auto agentFactories = engine::communication::getInMemoryAgentFactory(2);
-  setupRealBackend<featureOwnerSchedulerId, labelOwnerSchedulerId>(
+  setupRealBackendWithLazyScheduler<
+      featureOwnerSchedulerId,
+      labelOwnerSchedulerId>(
       *agentFactories[featureOwnerId], *agentFactories[labelOwnerId]);
 
   frontend::Bit<true, featureOwnerSchedulerId, true> testLabelsShare0;


### PR DESCRIPTION
Summary:
## Why

The previous unittest uses EagerScheduler as backend engine, which didn't catch some subtle bugs that appear only with the LazyScheduler.

## What
1. In the unittest, replace `setupRealBackend` with `setupRealBackendWithLazyScheduler` when setting up the engine for testing.

2. In `OTBasedMatrixMultiplication`, make the feature owner *extract label share* and *run the OT* in the same order as that of the label owner.

3. In `DummyMatrixMultiplication`, let the label owner also get the value of its label share. This is to make it operate symmetrically with the feature owner, otherwise it will block the LazyScheduler.

Reviewed By: chualynn

Differential Revision: D39369284

