### PR TITLE
Pass Metric Collectors into scheduler factories

### DIFF
--- a/example/billionaire_problem/main.cpp
+++ b/example/billionaire_problem/main.cpp
@@ -14,6 +14,7 @@
 
 #include "./BillionaireProblemGame.h"
 #include "fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h"
+#include "fbpcf/util/MetricCollector.h"
 
 DEFINE_int32(party, 0, "my party ID");
 DEFINE_string(server_ip, "127.0.0.1", "server's ip address");
@@ -27,6 +28,9 @@ int main(int argc, char* argv[]) {
   XLOGF(INFO, "server IP: {}", FLAGS_server_ip);
   XLOGF(INFO, "port: {}", FLAGS_port);
 
+  auto metricCollector =
+      std::make_shared<fbpcf::util::MetricCollector>("billionaire_problem");
+
   std::map<
       int,
       fbpcf::engine::communication::SocketPartyCommunicationAgentFactory::
@@ -36,7 +40,7 @@ int main(int argc, char* argv[]) {
            {1, {FLAGS_server_ip, FLAGS_port}}});
   auto factory = std::make_unique<
       fbpcf::engine::communication::SocketPartyCommunicationAgentFactory>(
-      FLAGS_party, partyInfos, "billionaire_problem_traffic");
+      FLAGS_party, partyInfos, metricCollector);
 
   auto game = std::make_unique<
       fbpcf::billionaire_problem::BillionaireProblemGame<0, true>>(

--- a/fbpcf/engine/communication/IPartyCommunicationAgentFactory.h
+++ b/fbpcf/engine/communication/IPartyCommunicationAgentFactory.h
@@ -23,6 +23,10 @@ class IPartyCommunicationAgentFactory {
       : metricCollector_(std::make_shared<fbpcf::util::MetricCollector>(name)) {
   }
 
+  explicit IPartyCommunicationAgentFactory(
+      std::shared_ptr<fbpcf::util::MetricCollector> metricCollector)
+      : metricCollector_(metricCollector) {}
+
   virtual ~IPartyCommunicationAgentFactory() = default;
 
   /**

--- a/fbpcf/engine/communication/InMemoryPartyCommunicationAgentFactory.h
+++ b/fbpcf/engine/communication/InMemoryPartyCommunicationAgentFactory.h
@@ -41,6 +41,18 @@ class InMemoryPartyCommunicationAgentFactory final
     }
   }
 
+  InMemoryPartyCommunicationAgentFactory(
+      int myId,
+      std::map<int, std::shared_ptr<HostInfo>>&& sharedHosts,
+      std::shared_ptr<fbpcf::util::MetricCollector> metricCollector)
+      : IPartyCommunicationAgentFactory(metricCollector),
+        myId_(myId),
+        sharedHosts_(sharedHosts) {
+    for (auto& item : sharedHosts_) {
+      createdAgentCount_.emplace(item.first, 0);
+    }
+  }
+
   /**
    * @inherit doc
    */

--- a/fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h
+++ b/fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h
@@ -62,6 +62,23 @@ establishing multiple connections (>3) between each party pair.
     setupInitialConnection(partyInfos);
   }
 
+  SocketPartyCommunicationAgentFactory(
+      int myId,
+      std::map<int, PartyInfo> partyInfos,
+      std::shared_ptr<fbpcf::util::MetricCollector> metricCollector)
+      : IPartyCommunicationAgentFactory(metricCollector),
+        myId_(myId),
+        useTls_(false),
+        tlsDir_("") {
+    SocketPartyCommunicationAgent::TlsInfo tlsInfo;
+    tlsInfo.useTls = false;
+    tlsInfo.certPath = "";
+    tlsInfo.keyPath = "";
+    tlsInfo.passphrasePath = "";
+    tlsInfo_ = tlsInfo;
+    setupInitialConnection(partyInfos);
+  }
+
   [[deprecated("Use the constructor with TlsInfo instead.")]] SocketPartyCommunicationAgentFactory(
       int myId,
       std::map<int, PartyInfo> partyInfos,
@@ -87,6 +104,17 @@ establishing multiple connections (>3) between each party pair.
       SocketPartyCommunicationAgent::TlsInfo tlsInfo,
       std::string myname)
       : IPartyCommunicationAgentFactory(myname),
+        myId_(myId),
+        tlsInfo_(tlsInfo) {
+    setupInitialConnection(partyInfos);
+  }
+
+  SocketPartyCommunicationAgentFactory(
+      int myId,
+      std::map<int, PartyInfo> partyInfos,
+      SocketPartyCommunicationAgent::TlsInfo tlsInfo,
+      std::shared_ptr<fbpcf::util::MetricCollector> metricCollector)
+      : IPartyCommunicationAgentFactory(metricCollector),
         myId_(myId),
         tlsInfo_(tlsInfo) {
     setupInitialConnection(partyInfos);

--- a/fbpcf/scheduler/EagerSchedulerFactory.h
+++ b/fbpcf/scheduler/EagerSchedulerFactory.h
@@ -21,7 +21,15 @@ class EagerSchedulerFactory final : public ISchedulerFactory<unsafe> {
  public:
   EagerSchedulerFactory(
       std::unique_ptr<engine::ISecretShareEngineFactory> engineFactory)
-      : engineFactory_(std::move(engineFactory)) {}
+      : ISchedulerFactory<unsafe>(
+            std::make_shared<fbpcf::util::MetricCollector>("eager_scheduler")),
+        engineFactory_(std::move(engineFactory)) {}
+
+  EagerSchedulerFactory(
+      std::unique_ptr<engine::ISecretShareEngineFactory> engineFactory,
+      std::shared_ptr<fbpcf::util::MetricCollector> metricCollector)
+      : ISchedulerFactory<unsafe>(metricCollector),
+        engineFactory_(std::move(engineFactory)) {}
 
   std::unique_ptr<IScheduler> create() override {
     return std::make_unique<EagerScheduler>(
@@ -37,39 +45,48 @@ inline std::unique_ptr<EagerSchedulerFactory<unsafe>>
 getEagerSchedulerFactoryWithInsecureEngine(
     int myId,
     engine::communication::IPartyCommunicationAgentFactory&
-        communicationAgentFactory) {
+        communicationAgentFactory,
+    std::shared_ptr<fbpcf::util::MetricCollector> metricCollector =
+        std::make_shared<fbpcf::util::MetricCollector>(
+            "default_metric_collector")) {
   std::unique_ptr<engine::ISecretShareEngineFactory> engineFactory =
       engine::getInsecureEngineFactoryWithDummyTupleGenerator(
           myId, 2, communicationAgentFactory);
 
   return std::make_unique<EagerSchedulerFactory<unsafe>>(
-      std::move(engineFactory));
+      std::move(engineFactory), metricCollector);
 }
 
 inline std::unique_ptr<EagerSchedulerFactory</* unsafe */ true>>
 getEagerSchedulerFactoryWithClassicOT(
     int myId,
     engine::communication::IPartyCommunicationAgentFactory&
-        communicationAgentFactory) {
+        communicationAgentFactory,
+    std::shared_ptr<fbpcf::util::MetricCollector> metricCollector =
+        std::make_shared<fbpcf::util::MetricCollector>(
+            "default_metric_collector")) {
   std::unique_ptr<engine::ISecretShareEngineFactory> engineFactory =
       engine::getSecureEngineFactoryWithClassicOt(
           myId, 2, communicationAgentFactory);
 
   return std::make_unique<EagerSchedulerFactory</* unsafe */ true>>(
-      std::move(engineFactory));
+      std::move(engineFactory), metricCollector);
 }
 
 inline std::unique_ptr<EagerSchedulerFactory</* unsafe */ true>>
 getEagerSchedulerFactoryWithRealEngine(
     int myId,
     engine::communication::IPartyCommunicationAgentFactory&
-        communicationAgentFactory) {
+        communicationAgentFactory,
+    std::shared_ptr<fbpcf::util::MetricCollector> metricCollector =
+        std::make_shared<fbpcf::util::MetricCollector>(
+            "default_metric_collector")) {
   std::unique_ptr<engine::ISecretShareEngineFactory> engineFactory =
       engine::getSecureEngineFactoryWithFERRET(
           myId, 2, communicationAgentFactory);
 
   return std::make_unique<EagerSchedulerFactory</* unsafe */ true>>(
-      std::move(engineFactory));
+      std::move(engineFactory), metricCollector);
 }
 
 } // namespace fbpcf::scheduler

--- a/fbpcf/scheduler/ISchedulerFactory.h
+++ b/fbpcf/scheduler/ISchedulerFactory.h
@@ -8,15 +8,22 @@
 #pragma once
 
 #include "fbpcf/scheduler/IScheduler.h"
+#include "fbpcf/util/MetricCollector.h"
 
 namespace fbpcf::scheduler {
 
 template <bool unsafe>
 class ISchedulerFactory {
  public:
+  explicit ISchedulerFactory(
+      std::shared_ptr<fbpcf::util::MetricCollector> metricCollector)
+      : metricCollector_(metricCollector) {}
   virtual ~ISchedulerFactory() = default;
 
   virtual std::unique_ptr<IScheduler> create() = 0;
+
+ protected:
+  std::shared_ptr<fbpcf::util::MetricCollector> metricCollector_;
 };
 
 } // namespace fbpcf::scheduler

--- a/fbpcf/scheduler/NetworkPlaintextSchedulerFactory.h
+++ b/fbpcf/scheduler/NetworkPlaintextSchedulerFactory.h
@@ -23,7 +23,20 @@ class NetworkPlaintextSchedulerFactory final
       int myId,
       engine::communication::IPartyCommunicationAgentFactory&
           communicationAgentFactory)
-      : myId_(myId), communicationAgentFactory_(communicationAgentFactory) {}
+      : ISchedulerFactory<unsafe>(
+            std::make_shared<fbpcf::util::MetricCollector>(
+                "network_plaintext_scheduler")),
+        myId_(myId),
+        communicationAgentFactory_(communicationAgentFactory) {}
+
+  NetworkPlaintextSchedulerFactory(
+      int myId,
+      engine::communication::IPartyCommunicationAgentFactory&
+          communicationAgentFactory,
+      std::shared_ptr<fbpcf::util::MetricCollector> metricCollector)
+      : ISchedulerFactory<unsafe>(metricCollector),
+        myId_(myId),
+        communicationAgentFactory_(communicationAgentFactory) {}
 
   std::unique_ptr<IScheduler> create() override {
     auto numberOfParties = 2;

--- a/fbpcf/scheduler/PlaintextSchedulerFactory.h
+++ b/fbpcf/scheduler/PlaintextSchedulerFactory.h
@@ -17,6 +17,14 @@ namespace fbpcf::scheduler {
 template <bool unsafe>
 class PlaintextSchedulerFactory final : public ISchedulerFactory<unsafe> {
  public:
+  PlaintextSchedulerFactory()
+      : ISchedulerFactory<unsafe>(
+            std::make_shared<fbpcf::util::MetricCollector>(
+                "plaintext_scheduler")) {}
+
+  PlaintextSchedulerFactory(
+      std::shared_ptr<fbpcf::util::MetricCollector> metricCollector)
+      : ISchedulerFactory<unsafe>(metricCollector) {}
   std::unique_ptr<IScheduler> create() override {
     return std::make_unique<PlaintextScheduler>(
         WireKeeper::createWithVectorArena<unsafe>());


### PR DESCRIPTION
Summary:
This diff
- requires a metric collector for all implementations of ISchedulerFactory
- adds a constructor that takes in a metric collector for each of the implementation of ISchedulerFactory
- For all the helper methods get.*SchedulerFactory, add a metric collector parameter with a default value.

Reviewed By: adshastri

Differential Revision: D39370779

