### PR TITLE
Pass Metric Collectors into party communication agent factories

### DIFF
--- a/example/billionaire_problem/main.cpp
+++ b/example/billionaire_problem/main.cpp
@@ -14,6 +14,7 @@
 
 #include "./BillionaireProblemGame.h"
 #include "fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h"
+#include "fbpcf/util/MetricCollector.h"
 
 DEFINE_int32(party, 0, "my party ID");
 DEFINE_string(server_ip, "127.0.0.1", "server's ip address");
@@ -27,6 +28,9 @@ int main(int argc, char* argv[]) {
   XLOGF(INFO, "server IP: {}", FLAGS_server_ip);
   XLOGF(INFO, "port: {}", FLAGS_port);
 
+  auto metricCollector =
+      std::make_shared<fbpcf::util::MetricCollector>("billionaire_problem");
+
   std::map<
       int,
       fbpcf::engine::communication::SocketPartyCommunicationAgentFactory::
@@ -36,7 +40,7 @@ int main(int argc, char* argv[]) {
            {1, {FLAGS_server_ip, FLAGS_port}}});
   auto factory = std::make_unique<
       fbpcf::engine::communication::SocketPartyCommunicationAgentFactory>(
-      FLAGS_party, partyInfos, "billionaire_problem_traffic");
+      FLAGS_party, partyInfos, metricCollector);
 
   auto game = std::make_unique<
       fbpcf::billionaire_problem::BillionaireProblemGame<0, true>>(

--- a/fbpcf/engine/communication/IPartyCommunicationAgentFactory.h
+++ b/fbpcf/engine/communication/IPartyCommunicationAgentFactory.h
@@ -23,6 +23,10 @@ class IPartyCommunicationAgentFactory {
       : metricCollector_(std::make_shared<fbpcf::util::MetricCollector>(name)) {
   }
 
+  explicit IPartyCommunicationAgentFactory(
+      std::shared_ptr<fbpcf::util::MetricCollector> metricCollector)
+      : metricCollector_(metricCollector) {}
+
   virtual ~IPartyCommunicationAgentFactory() = default;
 
   /**

--- a/fbpcf/engine/communication/InMemoryPartyCommunicationAgentFactory.h
+++ b/fbpcf/engine/communication/InMemoryPartyCommunicationAgentFactory.h
@@ -41,6 +41,18 @@ class InMemoryPartyCommunicationAgentFactory final
     }
   }
 
+  InMemoryPartyCommunicationAgentFactory(
+      int myId,
+      std::map<int, std::shared_ptr<HostInfo>>&& sharedHosts,
+      std::shared_ptr<fbpcf::util::MetricCollector> metricCollector)
+      : IPartyCommunicationAgentFactory(metricCollector),
+        myId_(myId),
+        sharedHosts_(sharedHosts) {
+    for (auto& item : sharedHosts_) {
+      createdAgentCount_.emplace(item.first, 0);
+    }
+  }
+
   /**
    * @inherit doc
    */

--- a/fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h
+++ b/fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h
@@ -62,6 +62,23 @@ establishing multiple connections (>3) between each party pair.
     setupInitialConnection(partyInfos);
   }
 
+  SocketPartyCommunicationAgentFactory(
+      int myId,
+      std::map<int, PartyInfo> partyInfos,
+      std::shared_ptr<fbpcf::util::MetricCollector> metricCollector)
+      : IPartyCommunicationAgentFactory(metricCollector),
+        myId_(myId),
+        useTls_(false),
+        tlsDir_("") {
+    SocketPartyCommunicationAgent::TlsInfo tlsInfo;
+    tlsInfo.useTls = false;
+    tlsInfo.certPath = "";
+    tlsInfo.keyPath = "";
+    tlsInfo.passphrasePath = "";
+    tlsInfo_ = tlsInfo;
+    setupInitialConnection(partyInfos);
+  }
+
   [[deprecated("Use the constructor with TlsInfo instead.")]] SocketPartyCommunicationAgentFactory(
       int myId,
       std::map<int, PartyInfo> partyInfos,
@@ -87,6 +104,17 @@ establishing multiple connections (>3) between each party pair.
       SocketPartyCommunicationAgent::TlsInfo tlsInfo,
       std::string myname)
       : IPartyCommunicationAgentFactory(myname),
+        myId_(myId),
+        tlsInfo_(tlsInfo) {
+    setupInitialConnection(partyInfos);
+  }
+
+  SocketPartyCommunicationAgentFactory(
+      int myId,
+      std::map<int, PartyInfo> partyInfos,
+      SocketPartyCommunicationAgent::TlsInfo tlsInfo,
+      std::shared_ptr<fbpcf::util::MetricCollector> metricCollector)
+      : IPartyCommunicationAgentFactory(metricCollector),
         myId_(myId),
         tlsInfo_(tlsInfo) {
     setupInitialConnection(partyInfos);


### PR DESCRIPTION
Summary:
This diff
- allows passing a metric collector into IPartyCommunicationAgentFactory instead of passing in a string "myname"

Reviewed By: adshastri

Differential Revision: D39029645

