### PR TITLE
Remove 3P ANDandMULT secure-SSE test case

### DIFF
--- a/fbpcf/engine/test/SecretShareEngineTest.cpp
+++ b/fbpcf/engine/test/SecretShareEngineTest.cpp
@@ -969,16 +969,6 @@ INSTANTIATE_TEST_SUITE_P(
                 communication::IPartyCommunicationAgentFactory& agentFactory)>>(
             "SecureEngineWithFerret",
             2,
-            getSecureEngineFactoryWithBooleanAndIntegerTupleGenerator),
-        std::make_tuple<
-            std::string,
-            size_t,
-            std::function<std::unique_ptr<SecretShareEngineFactory>(
-                int myId,
-                int numberOfParty,
-                communication::IPartyCommunicationAgentFactory& agentFactory)>>(
-            "SecureEngineWithFerret",
-            3,
             getSecureEngineFactoryWithBooleanAndIntegerTupleGenerator)),
     [](const testing::TestParamInfo<NonFreeMultAndANDTestFixture::ParamType>&
            info) {


### PR DESCRIPTION
Summary: Fixing T131720217. Seems the test it is not running well in sandcastle. Leaving just the dummy SSE in.

Differential Revision: D39441012

