### PR TITLE
Change the overflow behavior of `NumberMapper`.

### DIFF
--- a/fbpcf/mpc_std_lib/walr_multiplication/util/test/NumberMapperTest.cpp
+++ b/fbpcf/mpc_std_lib/walr_multiplication/util/test/NumberMapperTest.cpp
@@ -8,6 +8,7 @@
 #include <fbpcf/mpc_std_lib/walr_multiplication/util/NumberMapper.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <sys/types.h>
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
@@ -42,7 +43,6 @@ TEST(numberMapperTest, testBasicConversion) {
   auto mapper32 = NumberMapper<uint32_t>(divisor);
   constexpr uint64_t groupSize =
       (uint64_t)std::numeric_limits<uint32_t>::max() + 1;
-
   // Basic conversion
   // 1.0 / 7 = 0.1428571428571
   EXPECT_EQ(mapper32.mapToFixedPointType(1.0 / 7), 1428571);
@@ -52,18 +52,11 @@ TEST(numberMapperTest, testBasicConversion) {
   // Converting negative number
   // On the integer group of size 2^32, -k is equivalent to 2^32 - k
   EXPECT_EQ(mapper32.mapToFixedPointType(-1.0 / 7), groupSize - 1428571);
-
-  // Overflow
-  double input = ((uint32_t)1 << 31) + (1.0 / 7);
-  EXPECT_EQ(
-      mapper32.mapToFixedPointType(input),
-      (uint64_t)(input * divisor) % groupSize);
 }
 
 TEST(numberMapperTest, testUnsignedConversionPrecision) {
   constexpr uint64_t divisor = static_cast<uint64_t>(1e9);
   auto mapper64 = NumberMapper<uint64_t>(divisor);
-
   std::random_device rd;
   std::mt19937_64 e(rd());
   std::uniform_real_distribution<double> dist(0, 10.1);


### PR DESCRIPTION
Summary:
## Why
Previously when the `NumberMapper` receives an input that causes overflow (i.e., the input is mapped to a number that exceeds the integer group size), it will log a warning, but proceeds to convert it anyway; It also tries to first convert the `double` input using a widest-possible `intXX_t` to "preserve information".

We note that this is not really useful, since the result will be converted to a `uintXX_t` with possibly smaller width, and the information is lost anyway.
Besides, if overflow happens during the step of converting `double` to `intXX_t`, the behavior is undefined and the result depending on compiler implementation.

Therefore, (in the current implementation) we'd better not specify the overflow behavior of `NumberMapper`, and let the user keep this in mind themselves.

## What

1. When overflow happens, let `NumberMapper` log an ERR rather than WARN, since the conversion result is almost surely meaningless.
2. Remove the overflow unittest, since the behavior is undefined.
3. Define a new estimated value range to detect potential overflow issue. Since we are supporting signed value conversion, the range is now half the group size.
4. Allow the `divisor` to be larger than the group size: previous version will throw an exception for very large `divisor` as an early prevention of overflow, but such `divisor` can be useful for input (abs) value much smaller than 1.

Reviewed By: RuiyuZhu

Differential Revision: D39402511

