### PR TITLE
Finally fix flaky tests using an actually guaranteed free port

### DIFF
--- a/fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h
+++ b/fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h
@@ -27,7 +27,7 @@ namespace fbpcf::engine::communication {
 /**
  * An communication factory API
  */
-class SocketPartyCommunicationAgentFactory final
+class SocketPartyCommunicationAgentFactory
     : public IPartyCommunicationAgentFactory {
  public:
   struct PartyInfo {

--- a/fbpcf/engine/communication/test/SocketPartyCommunicationAgentFactoryForTests.h
+++ b/fbpcf/engine/communication/test/SocketPartyCommunicationAgentFactoryForTests.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+#include <map>
+
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#include <cerrno>
+#include <stdexcept>
+#include <string>
+
+#include <fbpcf/util/MetricCollector.h>
+#include "fbpcf/engine/communication/IPartyCommunicationAgentFactory.h"
+#include "fbpcf/engine/communication/SocketPartyCommunicationAgent.h"
+#include "fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h"
+
+namespace fbpcf::engine::communication {
+
+/**
+ * An communication factory API for tests only
+ * It allows you to separate the socket binding
+ * from the actual listen+connect step.
+ */
+class SocketPartyCommunicationAgentFactoryForTests final
+    : public SocketPartyCommunicationAgentFactory {
+ public:
+  SocketPartyCommunicationAgentFactoryForTests(
+      int myId,
+      std::map<int, PartyInfo> partyInfos,
+      SocketPartyCommunicationAgent::TlsInfo tlsInfo,
+      std::shared_ptr<fbpcf::util::MetricCollector> metricCollector)
+      : SocketPartyCommunicationAgentFactory(
+            myId,
+            partyInfos,
+            tlsInfo,
+            metricCollector,
+            true) {}
+
+  /**
+   * Returns the ports that were bound to.
+   * This is important when the initial connection is
+   * different than the port that was provided. This
+   * happens when the provided port was not free.
+   */
+  std::map<int, int> getBoundPorts() {
+    std::map<int, int> ports;
+    for (const auto [partyId, socket] : sockets_) {
+      ports.insert({partyId, getPortFromSocket(socket)});
+    }
+
+    return ports;
+  }
+
+  void completeNetworkingSetup() {
+    setupInitialConnection(partyInfos_);
+  }
+};
+
+} // namespace fbpcf::engine::communication

--- a/fbpcf/engine/util/test/benchmarks/BenchmarkHelper.h
+++ b/fbpcf/engine/util/test/benchmarks/BenchmarkHelper.h
@@ -14,10 +14,12 @@
 #include <queue>
 #include <random>
 #include <stdexcept>
+#include <utility>
 
 #include "fbpcf/engine/communication/IPartyCommunicationAgent.h"
 #include "fbpcf/engine/communication/IPartyCommunicationAgentFactory.h"
 #include "fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h"
+#include "fbpcf/engine/communication/test/AgentFactoryCreationHelper.h"
 #include "fbpcf/engine/communication/test/SocketInTestHelper.h"
 #include "folly/Random.h"
 #include "folly/logging/xlog.h"
@@ -123,15 +125,13 @@ inline std::pair<
     std::unique_ptr<communication::IPartyCommunicationAgentFactory>,
     std::unique_ptr<communication::IPartyCommunicationAgentFactory>>
 getSocketAgentFactories() {
-  auto agentsByParty =
-      std::make_shared<BenchmarkSocketAgentFactory::AgentsByParty>();
-  agentsByParty->agents = std::vector<
-      std::queue<std::unique_ptr<communication::IPartyCommunicationAgent>>>(2);
-  agentsByParty->mutex = std::make_unique<std::mutex>();
+  fbpcf::engine::communication::SocketPartyCommunicationAgent::TlsInfo tlsInfo;
+  tlsInfo.certPath = "";
+  tlsInfo.keyPath = "";
+  tlsInfo.passphrasePath = "";
+  tlsInfo.useTls = false;
 
-  return {
-      std::make_unique<util::BenchmarkSocketAgentFactory>(0, agentsByParty),
-      std::make_unique<util::BenchmarkSocketAgentFactory>(1, agentsByParty)};
+  return communication::getSocketAgentFactoryPair(tlsInfo);
 };
 
 } // namespace fbpcf::engine::util


### PR DESCRIPTION
Summary:
# Why
We have a ton of flaky PCF 2 tests due to networking issues. We need to actually fix them, otherwise they will constantly be in a state of flakiness and won't be able to adequately catch issues.

Right now, we rely on one "guaranteed free port". But this still has a small bug. When running a stress run, these tests run concurrently, which means there is a race condition in our logic when determining a guaranteed free port. The ONLY way to guarantee a free port is to ask the OS to *atomically* bind to a free port and then retrieve it.

So, in this diff, we get a free port from the OS, and then pass it in to the other party to create the connection.

# What
In order to accomplish this, we need to slightly change the way the factory works. Today, the constructor sets up a server port/client port as an "initial connection". We need to tweak this such that the constructor will ONLY bind to a socket but NOT listen to it (i.e. we don't want the constructor to block).

So, the new flow looks as follows
1) Create a socket factory for the publisher
2) Retrieve the port(s) that it bound to
3) Put these ports into a new map of partyInfos
4) Create a socket factory for the partner with this new information

To accomplish this, we create a duplicate version of the socket factory that exposes the necessary API instead of changing the production API. This new version will only be needed for tests.

# Next
We will put up another diff to make this change for the PCF2 Calculator, Shard Combiner, and Attribution app tests.

Differential Revision: D39493637

