### PR TITLE
Deprecate more legacy constructors in the agent factory

### DIFF
--- a/example/billionaire_problem/main.cpp
+++ b/example/billionaire_problem/main.cpp
@@ -31,6 +31,12 @@ int main(int argc, char* argv[]) {
   auto metricCollector =
       std::make_shared<fbpcf::util::MetricCollector>("billionaire_problem");
 
+  fbpcf::engine::communication::SocketPartyCommunicationAgent::TlsInfo tlsInfo;
+  tlsInfo.certPath = "";
+  tlsInfo.keyPath = "";
+  tlsInfo.passphrasePath = "";
+  tlsInfo.useTls = false;
+
   std::map<
       int,
       fbpcf::engine::communication::SocketPartyCommunicationAgentFactory::
@@ -40,7 +46,7 @@ int main(int argc, char* argv[]) {
            {1, {FLAGS_server_ip, FLAGS_port}}});
   auto factory = std::make_unique<
       fbpcf::engine::communication::SocketPartyCommunicationAgentFactory>(
-      FLAGS_party, partyInfos, metricCollector);
+      FLAGS_party, partyInfos, tlsInfo, metricCollector);
 
   auto game = std::make_unique<
       fbpcf::billionaire_problem::BillionaireProblemGame<0, true>>(

--- a/example/edit_distance/MainUtil.h
+++ b/example/edit_distance/MainUtil.h
@@ -25,9 +25,15 @@ void startEditDistanceGame(
           PartyInfo>
       partyInfos({{0, {serverIp, port}}, {1, {serverIp, port}}});
 
+  fbpcf::engine::communication::SocketPartyCommunicationAgent::TlsInfo tlsInfo;
+  tlsInfo.certPath = "";
+  tlsInfo.keyPath = "";
+  tlsInfo.passphrasePath = "";
+  tlsInfo.useTls = false;
+
   auto communicationAgentFactory = std::make_unique<
       fbpcf::engine::communication::SocketPartyCommunicationAgentFactory>(
-      MyRole, partyInfos, "Edit Distance Traffic for main thread");
+      MyRole, partyInfos, tlsInfo, "Edit Distance Traffic for main thread");
 
   XLOG(INFO, "Creating Edit Distance App");
 

--- a/fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h
+++ b/fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h
@@ -45,7 +45,7 @@ will contain a port (and an address that will be ignored) and will behave as a
 TCP server. We expect the gap between port numbers are large enough to allow
 establishing multiple connections (>3) between each party pair.
   */
-  SocketPartyCommunicationAgentFactory(
+  [[deprecated("Use the constructor with TlsInfo instead.")]] SocketPartyCommunicationAgentFactory(
       int myId,
       std::map<int, PartyInfo> partyInfos,
       std::string myname)
@@ -64,7 +64,7 @@ establishing multiple connections (>3) between each party pair.
     setupInitialConnection(partyInfos);
   }
 
-  SocketPartyCommunicationAgentFactory(
+  [[deprecated("Use the constructor with TlsInfo instead.")]] SocketPartyCommunicationAgentFactory(
       int myId,
       std::map<int, PartyInfo> partyInfos,
       std::shared_ptr<fbpcf::util::MetricCollector> metricCollector)

--- a/fbpcf/engine/communication/test/PartyCommunicationAgentTest.cpp
+++ b/fbpcf/engine/communication/test/PartyCommunicationAgentTest.cpp
@@ -153,6 +153,12 @@ TEST(SocketPartyCommunicationAgentTest, testSendAndReceiveWithoutTls) {
   auto port02 = port01 + 4;
   auto port12 = port01 + 8;
 
+  fbpcf::engine::communication::SocketPartyCommunicationAgent::TlsInfo tlsInfo;
+  tlsInfo.certPath = "";
+  tlsInfo.keyPath = "";
+  tlsInfo.passphrasePath = "";
+  tlsInfo.useTls = false;
+
   std::map<int, SocketPartyCommunicationAgentFactory::PartyInfo> partyInfo0 = {
       {1, {"127.0.0.1", port01}}, {2, {"127.0.0.1", port02}}};
   std::map<int, SocketPartyCommunicationAgentFactory::PartyInfo> partyInfo1 = {
@@ -160,18 +166,18 @@ TEST(SocketPartyCommunicationAgentTest, testSendAndReceiveWithoutTls) {
   std::map<int, SocketPartyCommunicationAgentFactory::PartyInfo> partyInfo2 = {
       {0, {"127.0.0.1", port02}}, {1, {"127.0.0.1", port12}}};
 
-  auto factory1 = std::async([&partyInfo1]() {
+  auto factory1 = std::async([&partyInfo1, &tlsInfo]() {
     return std::make_unique<SocketPartyCommunicationAgentFactory>(
-        1, partyInfo1, "Party_1");
+        1, partyInfo1, tlsInfo, "Party_1");
   });
 
-  auto factory2 = std::async([&partyInfo2]() {
+  auto factory2 = std::async([&partyInfo2, &tlsInfo]() {
     return std::make_unique<SocketPartyCommunicationAgentFactory>(
-        2, partyInfo2, "Party_2");
+        2, partyInfo2, tlsInfo, "Party_2");
   });
 
   auto factory0 = std::make_unique<SocketPartyCommunicationAgentFactory>(
-      0, partyInfo0, "Party_0");
+      0, partyInfo0, tlsInfo, "Party_0");
 
   int size = 1048576; // 1024 ^ 2
 
@@ -208,6 +214,12 @@ TEST(SocketPartyCommunicationAgentTest, testSendAndReceiveWithJammedPort) {
   auto port02 = port01 + 4;
   auto port12 = port01 + 8;
 
+  fbpcf::engine::communication::SocketPartyCommunicationAgent::TlsInfo tlsInfo;
+  tlsInfo.certPath = "";
+  tlsInfo.keyPath = "";
+  tlsInfo.passphrasePath = "";
+  tlsInfo.useTls = false;
+
   std::map<int, SocketPartyCommunicationAgentFactory::PartyInfo> partyInfo0 = {
       {1, {"127.0.0.1", port01}}, {2, {"127.0.0.1", port02}}};
   std::map<int, SocketPartyCommunicationAgentFactory::PartyInfo> partyInfo1 = {
@@ -236,18 +248,18 @@ TEST(SocketPartyCommunicationAgentTest, testSendAndReceiveWithJammedPort) {
     ::bind(sockfd3, (struct sockaddr*)&servAddr, sizeof(struct sockaddr_in));
   }
 
-  auto factory1 = std::async([&partyInfo1]() {
+  auto factory1 = std::async([&partyInfo1, &tlsInfo]() {
     return std::make_unique<SocketPartyCommunicationAgentFactory>(
-        1, partyInfo1, "Party_1");
+        1, partyInfo1, tlsInfo, "Party_1");
   });
 
-  auto factory2 = std::async([&partyInfo2]() {
+  auto factory2 = std::async([&partyInfo2, &tlsInfo]() {
     return std::make_unique<SocketPartyCommunicationAgentFactory>(
-        2, partyInfo2, "Party_2");
+        2, partyInfo2, tlsInfo, "Party_2");
   });
 
   auto factory0 = std::make_unique<SocketPartyCommunicationAgentFactory>(
-      0, partyInfo0, "Party_0");
+      0, partyInfo0, tlsInfo, "Party_0");
 
   int size = 1048576; // 1024 ^ 2
   auto thread0 =

--- a/fbpcf/engine/util/test/benchmarks/BenchmarkHelper.h
+++ b/fbpcf/engine/util/test/benchmarks/BenchmarkHelper.h
@@ -48,14 +48,20 @@ getSocketAgents() {
   std::map<int, communication::SocketPartyCommunicationAgentFactory::PartyInfo>
       partyInfo1 = {{0, {"127.0.0.1", port}}};
 
-  auto factory1Future = std::async([&partyInfo1]() {
+  fbpcf::engine::communication::SocketPartyCommunicationAgent::TlsInfo tlsInfo;
+  tlsInfo.certPath = "";
+  tlsInfo.keyPath = "";
+  tlsInfo.passphrasePath = "";
+  tlsInfo.useTls = false;
+
+  auto factory1Future = std::async([&partyInfo1, &tlsInfo]() {
     return std::make_unique<
         communication::SocketPartyCommunicationAgentFactory>(
-        1, partyInfo1, "party_1_unit_test_traffic");
+        1, partyInfo1, tlsInfo, "party_1_unit_test_traffic");
   });
   auto factory0 =
       std::make_unique<communication::SocketPartyCommunicationAgentFactory>(
-          0, partyInfo0, "party_0_unit_test_traffic");
+          0, partyInfo0, tlsInfo, "party_0_unit_test_traffic");
   auto factory1 = factory1Future.get();
 
   auto task = [](std::unique_ptr<communication::IPartyCommunicationAgentFactory>


### PR DESCRIPTION
Summary:
As we modify the APIs, we should stick with the following process
- Add overloaded constructor(s) for any new arguments
- Make necessary migrations
- Mark the old ones as deprecated
- In the next major version release, deprecate the old ones

Differential Revision: D39585072

