### PR TITLE
Update BitString constructor

### DIFF
--- a/fbpcf/frontend/BitString.h
+++ b/fbpcf/frontend/BitString.h
@@ -61,8 +61,12 @@ class BitString : public scheduler::SchedulerKeeper<schedulerId> {
 
   explicit BitString(size_t size) : data_(size) {}
 
+  // For batch type constructor, inner vector size should be the batch size.
+  // Outer vector size is BitString length.
   explicit BitString(const std::vector<BoolType>& data);
 
+  // For batch type constructor, inner vector size should be the batch size.
+  // Outer vector size is BitString length.
   BitString(const std::vector<BoolType>& data, int partyId);
 
   explicit BitString(ExtractedString&& extractedString);
@@ -75,7 +79,9 @@ class BitString : public scheduler::SchedulerKeeper<schedulerId> {
   BitString<false, schedulerId, usingBatch> openToParty(int partyId) const;
 
   /**
-   * get the plaintext value associated with this BitString
+   * get the plaintext value associated with this BitString.
+   * For batch type constructor, inner vector size is the batch size.
+   * Outer vector size is BitString length.
    */
   std::vector<BoolType> getValue() const;
 
@@ -156,9 +162,6 @@ class BitString : public scheduler::SchedulerKeeper<schedulerId> {
   std::vector<Bit<isSecret, schedulerId, usingBatch>> data_;
 
   friend class BitString<!isSecret, schedulerId, usingBatch>;
-
-  static std::vector<std::vector<bool>> transposeVector(
-      const std::vector<std::vector<bool>>& src);
 };
 
 } // namespace fbpcf::frontend

--- a/fbpcf/frontend/BitString_impl.h
+++ b/fbpcf/frontend/BitString_impl.h
@@ -19,18 +19,9 @@ namespace fbpcf::frontend {
 template <bool isSecret, int schedulerId, bool usingBatch>
 BitString<isSecret, schedulerId, usingBatch>::BitString(
     const std::vector<BoolType>& data) {
-  if constexpr (usingBatch) {
-    data_ =
-        std::vector<Bit<isSecret, schedulerId, usingBatch>>(data.at(0).size());
-    auto transposed = transposeVector(data);
-    for (size_t i = 0; i < data_.size(); i++) {
-      data_[i] = Bit<isSecret, schedulerId, usingBatch>(transposed.at(i));
-    }
-  } else {
-    data_ = std::vector<Bit<isSecret, schedulerId, usingBatch>>(data.size());
-    for (size_t i = 0; i < data_.size(); i++) {
-      data_[i] = Bit<isSecret, schedulerId, usingBatch>(data.at(i));
-    }
+  data_ = std::vector<Bit<isSecret, schedulerId, usingBatch>>(data.size());
+  for (size_t i = 0; i < data_.size(); i++) {
+    data_[i] = Bit<isSecret, schedulerId, usingBatch>(data.at(i));
   }
 }
 
@@ -38,19 +29,9 @@ template <bool isSecret, int schedulerId, bool usingBatch>
 BitString<isSecret, schedulerId, usingBatch>::BitString(
     const std::vector<BoolType>& data,
     int partyId) {
-  if constexpr (usingBatch) {
-    data_ =
-        std::vector<Bit<isSecret, schedulerId, usingBatch>>(data.at(0).size());
-    auto transposed = transposeVector(data);
-    for (size_t i = 0; i < data_.size(); i++) {
-      data_[i] =
-          Bit<isSecret, schedulerId, usingBatch>(transposed.at(i), partyId);
-    }
-  } else {
-    data_ = std::vector<Bit<isSecret, schedulerId, usingBatch>>(data.size());
-    for (size_t i = 0; i < data_.size(); i++) {
-      data_[i] = Bit<isSecret, schedulerId, usingBatch>(data.at(i), partyId);
-    }
+  data_ = std::vector<Bit<isSecret, schedulerId, usingBatch>>(data.size());
+  for (size_t i = 0; i < data_.size(); i++) {
+    data_[i] = Bit<isSecret, schedulerId, usingBatch>(data.at(i), partyId);
   }
 }
 
@@ -83,11 +64,7 @@ BitString<isSecret, schedulerId, usingBatch>::getValue() const {
   for (size_t i = 0; i < size(); i++) {
     plaintext[i] = data_.at(i).getValue();
   }
-  if constexpr (usingBatch) {
-    return transposeVector(std::move(plaintext));
-  } else {
-    return plaintext;
-  }
+  return plaintext;
 }
 
 template <bool isSecret, int schedulerId, bool usingBatch>
@@ -236,24 +213,6 @@ size_t BitString<isSecret, schedulerId, usingBatch>::getBatchSize() const {
     throw std::runtime_error("Cannot query batch size on an empty BitString!");
   }
   return data_[0].getBatchSize();
-}
-
-template <bool isSecret, int schedulerId, bool usingBatch>
-std::vector<std::vector<bool>>
-BitString<isSecret, schedulerId, usingBatch>::transposeVector(
-    const std::vector<std::vector<bool>>& src) {
-  size_t outerSize = src.size();
-  size_t innerSize = src.at(0).size();
-  std::vector<std::vector<bool>> rst(innerSize, std::vector<bool>(outerSize));
-  for (size_t i = 0; i < outerSize; i++) {
-    if (src.at(i).size() != innerSize) {
-      throw std::runtime_error("All batches have to have the same size!");
-    }
-    for (size_t j = 0; j < innerSize; j++) {
-      rst[j][i] = src.at(i).at(j);
-    }
-  }
-  return rst;
 }
 
 } // namespace fbpcf::frontend

--- a/fbpcf/frontend/test/BitStringTest.cpp
+++ b/fbpcf/frontend/test/BitStringTest.cpp
@@ -295,7 +295,7 @@ TEST(StringTest, testMux) {
   }
   std::vector<std::vector<bool>> testBatchValue1(
       dSize(e), std::vector<bool>(dSize(e)));
-  std::vector<bool> testBatchChoice(testBatchValue1.size());
+  std::vector<bool> testBatchChoice(testBatchValue1[0].size());
   auto testBatchValue2 = testBatchValue1;
   for (size_t i = 0; i < testBatchValue1.size(); i++) {
     for (size_t j = 0; j < testBatchValue1.at(0).size(); j++) {
@@ -303,7 +303,7 @@ TEST(StringTest, testMux) {
       testBatchValue2[i][j] = dBool(e);
     }
   }
-  for (size_t j = 0; j < testBatchValue1.size(); j++) {
+  for (size_t j = 0; j < testBatchChoice.size(); j++) {
     testBatchChoice[j] = dBool(e);
   }
 
@@ -346,7 +346,7 @@ TEST(StringTest, testMux) {
   for (size_t i = 0; i < testBatchValue1.size(); i++) {
     for (size_t j = 0; j < testBatchValue1.at(0).size(); j++) {
       testBatchValue1[i][j] =
-          testBatchChoice[i] ? testBatchValue2[i][j] : testBatchValue1[i][j];
+          testBatchChoice[j] ? testBatchValue2[i][j] : testBatchValue1[i][j];
     }
   }
 
@@ -396,13 +396,13 @@ TEST(StringTest, testResizeWithAND) {
   }
   std::vector<std::vector<bool>> testBatchValue1(
       dSize(e), std::vector<bool>(dSize(e)));
-  auto testBatchValue2 = testBatchValue1;
+  std::vector<std::vector<bool>> testBatchValue2(
+      testBatchValue1.size() * 2, std::vector<bool>(testBatchValue1[0].size()));
   for (size_t i = 0; i < testBatchValue1.size(); i++) {
-    testBatchValue2[i].resize(testBatchValue1.at(0).size() * 2);
     for (size_t j = 0; j < testBatchValue1.at(0).size(); j++) {
       testBatchValue1[i][j] = dBool(e);
       testBatchValue2[i][j] = dBool(e);
-      testBatchValue2[i][j + testBatchValue1.at(0).size()] = dBool(e);
+      testBatchValue2[i + testBatchValue1.size()][j] = dBool(e);
     }
   }
 
@@ -474,21 +474,21 @@ TEST(StringTest, testRebatching) {
   uint32_t batchSize2 = dSize(e);
   uint32_t batchSize3 = dSize(e);
   std::vector<std::vector<bool>> testBatchValue1(
-      batchSize1, std::vector<bool>(length));
+      length, std::vector<bool>(batchSize1));
   std::vector<std::vector<bool>> testBatchValue2(
-      batchSize2, std::vector<bool>(length));
+      length, std::vector<bool>(batchSize2));
   std::vector<std::vector<bool>> testBatchValue3(
-      batchSize3, std::vector<bool>(length));
+      length, std::vector<bool>(batchSize3));
 
   for (size_t i = 0; i < length; i++) {
     for (size_t j = 0; j < batchSize1; j++) {
-      testBatchValue1[j][i] = dBool(e);
+      testBatchValue1[i][j] = dBool(e);
     }
     for (size_t j = 0; j < batchSize2; j++) {
-      testBatchValue2[j][i] = dBool(e);
+      testBatchValue2[i][j] = dBool(e);
     }
     for (size_t j = 0; j < batchSize3; j++) {
-      testBatchValue3[j][i] = dBool(e);
+      testBatchValue3[i][j] = dBool(e);
     }
   }
 
@@ -505,20 +505,25 @@ TEST(StringTest, testRebatching) {
   auto t6 = v123.at(1).openToParty(0).getValue();
   auto t7 = v123.at(2).openToParty(0).getValue();
 
-  for (size_t i = 0; i < batchSize1; i++) {
+  for (size_t i = 0; i < length; i++) {
     testVectorEq(t5.at(i), testBatchValue1.at(i));
-  }
-  for (size_t i = 0; i < batchSize2; i++) {
     testVectorEq(t6.at(i), testBatchValue2.at(i));
-  }
-  for (size_t i = 0; i < batchSize3; i++) {
     testVectorEq(t7.at(i), testBatchValue3.at(i));
   }
-  testBatchValue1.insert(
-      testBatchValue1.end(), testBatchValue2.begin(), testBatchValue2.end());
-  testBatchValue1.insert(
-      testBatchValue1.end(), testBatchValue3.begin(), testBatchValue3.end());
-  for (size_t i = 0; i < batchSize1 + batchSize2 + batchSize3; i++) {
+
+  for (size_t i = 0; i < length; i++) {
+    testBatchValue1[i].insert(
+        testBatchValue1[i].end(),
+        testBatchValue2[i].begin(),
+        testBatchValue2[i].end());
+
+    testBatchValue1[i].insert(
+        testBatchValue1[i].end(),
+        testBatchValue3[i].begin(),
+        testBatchValue3[i].end());
+  }
+
+  for (size_t i = 0; i < length; i++) {
     testVectorEq(t4.at(i), testBatchValue1.at(i));
   }
 }
@@ -559,9 +564,9 @@ TEST(StringTest, testBatchSize) {
 
   SecBatchString v5(v3.extractStringShare());
 
-  EXPECT_EQ(v3.getBatchSize(), testBatchValue.size());
-  EXPECT_EQ(v4.getBatchSize(), testBatchValue.size());
-  EXPECT_EQ(v5.getBatchSize(), testBatchValue.size());
+  EXPECT_EQ(v3.getBatchSize(), testBatchValue[0].size());
+  EXPECT_EQ(v4.getBatchSize(), testBatchValue[0].size());
+  EXPECT_EQ(v5.getBatchSize(), testBatchValue[0].size());
 }
 
 } // namespace fbpcf::frontend

--- a/fbpcf/frontend/test/benchmarks/FrontendBenchmark.cpp
+++ b/fbpcf/frontend/test/benchmarks/FrontendBenchmark.cpp
@@ -485,11 +485,11 @@ class BitStringGame : public MpcGame<schedulerId> {
     if constexpr (usingBatch) {
       b1 = BitString(
           std::vector<std::vector<bool>>(
-              batchSize, std::vector<bool>(size, true)),
+              size, std::vector<bool>(batchSize, true)),
           0);
       b2 = BitString(
           std::vector<std::vector<bool>>(
-              batchSize, std::vector<bool>(size, false)),
+              size, std::vector<bool>(batchSize, false)),
           1);
     } else {
       b1 = BitString(std::vector<bool>(size, true), 0);


### PR DESCRIPTION
Summary:
See D35122217 (https://github.com/facebookresearch/fbpcf/commit/4baba646ad483d995a43bf778eebdf63b34ff7ac)

Currently the BitString constructor is treating the input as each vector is a batch of bits with agreed upon length.

# Argument against this change:
This doesn't follow the convention of MPC engine batching where the type describes a compile time restriction, and the batch size can be input at a later point.

For example, a Bit types UnitType is represented by a single Bit. If we have a std::vector<UnitType> then the length of that vector is the `batchSize`. Currently that is also true, each element is a std::vector<> of the agreed length, and there are `batchSize` total vectors.

# Argument for this change
Let us imagine the following code snippet
```
BitStringBatched str;
std::vector<std::vector<bool>> openedValues1 = str.openToParty(0).getValues()

std::vector<std::vector<bool>> openedValues2;
for (BitBatched b : str) {
openedValues2.push_back(b.openToParty(0).getValues()
}

BitStringBatched str2(openedValues1)
BitStringBatched str3(openedValues2)
```

In this example, the second way of extracting the values would only work with the convention in this diff.

Differential Revision: D39579926

