### PR TITLE
Record metrics for composite tuples

### DIFF
--- a/example/billionaire_problem/main.cpp
+++ b/example/billionaire_problem/main.cpp
@@ -51,7 +51,7 @@ int main(int argc, char* argv[]) {
   auto game = std::make_unique<
       fbpcf::billionaire_problem::BillionaireProblemGame<0, true>>(
       fbpcf::scheduler::getLazySchedulerFactoryWithRealEngine(
-          FLAGS_party, *factory)
+          FLAGS_party, *factory, metricCollector)
           ->create());
 
   const int size = 32;

--- a/fbpcf/engine/DummySecretShareEngineFactory.h
+++ b/fbpcf/engine/DummySecretShareEngineFactory.h
@@ -31,7 +31,9 @@ inline std::unique_ptr<DummySecretShareEngineFactory> getDummyEngineFactory(
     int myId,
     [[maybe_unused]] int numberOfParty,
     [[maybe_unused]] communication::IPartyCommunicationAgentFactory&
-        communicationAgentFactory) {
+        communicationAgentFactory,
+    [[maybe_unused]] std::shared_ptr<fbpcf::util::MetricCollector>
+        metricCollector) {
   return std::make_unique<DummySecretShareEngineFactory>(myId);
 }
 

--- a/fbpcf/engine/test/benchmarks/SecretShareEngineBenchmark.cpp
+++ b/fbpcf/engine/test/benchmarks/SecretShareEngineBenchmark.cpp
@@ -24,10 +24,18 @@ class BaseSecretShareEngineBenchmark : public util::NetworkedBenchmark {
 
     // We intentionally use a dummy tuple generator here to measure only the
     // network traffic incurred by the secret share engine.
-    senderFactory_ =
-        getInsecureEngineFactoryWithDummyTupleGenerator(0, 2, *agentFactory0_);
-    receiverFactory_ =
-        getInsecureEngineFactoryWithDummyTupleGenerator(1, 2, *agentFactory1_);
+    senderFactory_ = getInsecureEngineFactoryWithDummyTupleGenerator(
+        0,
+        2,
+        *agentFactory0_,
+        std::make_shared<fbpcf::util::MetricCollector>(
+            "default_metric_collector_sender"));
+    receiverFactory_ = getInsecureEngineFactoryWithDummyTupleGenerator(
+        1,
+        2,
+        *agentFactory1_,
+        std::make_shared<fbpcf::util::MetricCollector>(
+            "default_metric_collector_receiver"));
 
     // Set up randomized inputs
     batchInput0_ = util::getRandomBoolVector(batchSize_);

--- a/fbpcf/engine/tuple_generator/DummyTupleGenerator.h
+++ b/fbpcf/engine/tuple_generator/DummyTupleGenerator.h
@@ -15,11 +15,16 @@ namespace fbpcf::engine::tuple_generator::insecure {
  */
 class DummyTupleGenerator final : public ITupleGenerator {
  public:
+  explicit DummyTupleGenerator(std::shared_ptr<TuplesMetricRecorder> recorder)
+      : recorder_(recorder) {}
+
   std::vector<BooleanTuple> getBooleanTuple(uint32_t size) override {
     std::vector<BooleanTuple> result;
     for (size_t i = 0; i < size; i++) {
       result.push_back(BooleanTuple(0, 0, 0));
     }
+    recorder_->addTuplesConsumed(size);
+    recorder_->addTuplesGenerated(size);
     return result;
   }
 
@@ -70,6 +75,9 @@ class DummyTupleGenerator final : public ITupleGenerator {
   std::pair<uint64_t, uint64_t> getTrafficStatistics() const override {
     return {0, 0};
   }
+
+ private:
+  std::shared_ptr<TuplesMetricRecorder> recorder_;
 };
 
 } // namespace fbpcf::engine::tuple_generator::insecure

--- a/fbpcf/engine/tuple_generator/DummyTupleGenerator.h
+++ b/fbpcf/engine/tuple_generator/DummyTupleGenerator.h
@@ -45,6 +45,13 @@ class DummyTupleGenerator final : public ITupleGenerator {
             std::vector<bool>(tupleSize, 0),
             std::vector<bool>(tupleSize, 0));
       }
+      if (tupleSize > kCompositeTupleExpansionThreshold) {
+        recorder_->addCompositeTuplesRequiringExpansionRequested(
+            tupleCount, tupleSize);
+      } else {
+        recorder_->addCompositeTuplesWithoutExpansionRequested(
+            tupleCount, tupleSize);
+      }
     }
 
     return result;

--- a/fbpcf/engine/tuple_generator/DummyTupleGeneratorFactory.h
+++ b/fbpcf/engine/tuple_generator/DummyTupleGeneratorFactory.h
@@ -20,11 +20,16 @@ namespace fbpcf::engine::tuple_generator::insecure {
 
 class DummyTupleGeneratorFactory final : public ITupleGeneratorFactory {
  public:
+  explicit DummyTupleGeneratorFactory(
+      std::shared_ptr<fbpcf::util::MetricCollector> metricCollector)
+      : ITupleGeneratorFactory(metricCollector) {}
   /**
    * Create a dummy tuple generator;
    */
   std::unique_ptr<ITupleGenerator> create() override {
-    return std::make_unique<DummyTupleGenerator>();
+    auto recorder = std::make_shared<TuplesMetricRecorder>();
+    metricCollector_->addNewRecorder("tuple_generator", recorder);
+    return std::make_unique<DummyTupleGenerator>(recorder);
   }
 };
 

--- a/fbpcf/engine/tuple_generator/ITupleGeneratorFactory.h
+++ b/fbpcf/engine/tuple_generator/ITupleGeneratorFactory.h
@@ -9,6 +9,7 @@
 #include <memory>
 
 #include "fbpcf/engine/tuple_generator/ITupleGenerator.h"
+#include "fbpcf/util/MetricCollector.h"
 
 namespace fbpcf::engine::tuple_generator {
 
@@ -18,12 +19,18 @@ namespace fbpcf::engine::tuple_generator {
 
 class ITupleGeneratorFactory {
  public:
+  explicit ITupleGeneratorFactory(
+      std::shared_ptr<fbpcf::util::MetricCollector> metricCollector)
+      : metricCollector_(metricCollector) {}
   virtual ~ITupleGeneratorFactory() = default;
 
   /**
    * Create a tuple generator with all party.
    */
   virtual std::unique_ptr<ITupleGenerator> create() = 0;
+
+ protected:
+  std::shared_ptr<fbpcf::util::MetricCollector> metricCollector_;
 };
 
 } // namespace fbpcf::engine::tuple_generator

--- a/fbpcf/engine/tuple_generator/NullTupleGeneratorFactory.h
+++ b/fbpcf/engine/tuple_generator/NullTupleGeneratorFactory.h
@@ -17,6 +17,9 @@ namespace fbpcf::engine::tuple_generator {
 
 class NullTupleGeneratorFactory final : public ITupleGeneratorFactory {
  public:
+  explicit NullTupleGeneratorFactory(
+      std::shared_ptr<fbpcf::util::MetricCollector> metricCollector)
+      : ITupleGeneratorFactory(metricCollector) {}
   /**
    * Create a null tuple generator;
    */

--- a/fbpcf/engine/tuple_generator/TupleGeneratorFactory.h
+++ b/fbpcf/engine/tuple_generator/TupleGeneratorFactory.h
@@ -27,8 +27,10 @@ class TupleGeneratorFactory final : public ITupleGeneratorFactory {
       std::unique_ptr<util::IPrgFactory> prgFactory,
       int bufferSize,
       int myId,
-      int numberOfParty)
-      : productShareFactory_(std::move(productShareFactory)),
+      int numberOfParty,
+      std::shared_ptr<fbpcf::util::MetricCollector> metricCollector)
+      : ITupleGeneratorFactory(metricCollector),
+        productShareFactory_(std::move(productShareFactory)),
         prgFactory_(std::move(prgFactory)),
         bufferSize_(bufferSize),
         myId_(myId),
@@ -46,6 +48,8 @@ class TupleGeneratorFactory final : public ITupleGeneratorFactory {
       }
     }
     auto recorder = std::make_shared<TuplesMetricRecorder>();
+    metricCollector_->addNewRecorder("tuple_generator", recorder);
+
     return std::make_unique<TupleGenerator>(
         std::move(productShareGeneratorMap),
         prgFactory_->create(util::getRandomM128iFromSystemNoise()),

--- a/fbpcf/engine/tuple_generator/TwoPartyTupleGenerator.cpp
+++ b/fbpcf/engine/tuple_generator/TwoPartyTupleGenerator.cpp
@@ -76,6 +76,12 @@ TwoPartyTupleGenerator::getCompositeTuple(
             std::move(sender0Messages),
             std::move(receiverMessages),
             tupleSize));
+    if (tupleSize > kCompositeTupleExpansionThreshold) {
+      recorder_->addCompositeTuplesRequiringExpansionRequested(
+          count, tupleSize);
+    } else {
+      recorder_->addCompositeTuplesWithoutExpansionRequested(count, tupleSize);
+    }
   }
   return tuples;
 }
@@ -214,7 +220,7 @@ TwoPartyTupleGenerator::expandRCOTResults(
       result[i] = BooleanTuple(a, b, c);
     }
   } else {
-    if (requestedTupleSize <= 128) {
+    if (requestedTupleSize <= kCompositeTupleExpansionThreshold) {
       // H(k0) / H(l0)
       hashFromAes_.inPlaceHash(sender0Messages);
       // H(k1) / H(l1)

--- a/fbpcf/engine/tuple_generator/TwoPartyTupleGeneratorFactory.h
+++ b/fbpcf/engine/tuple_generator/TwoPartyTupleGeneratorFactory.h
@@ -25,8 +25,10 @@ class TwoPartyTupleGeneratorFactory final : public ITupleGeneratorFactory {
           rcotFactory,
       communication::IPartyCommunicationAgentFactory& agentFactory,
       int myId,
-      uint64_t bufferSize)
-      : rcotFactory_{std::move(rcotFactory)},
+      uint64_t bufferSize,
+      std::shared_ptr<fbpcf::util::MetricCollector> metricCollector)
+      : ITupleGeneratorFactory(metricCollector),
+        rcotFactory_{std::move(rcotFactory)},
         agentFactory_{agentFactory},
         myId_(myId),
         bufferSize_(bufferSize) {}
@@ -61,6 +63,7 @@ class TwoPartyTupleGeneratorFactory final : public ITupleGeneratorFactory {
               otherId, "two_party_tuple_generator_traffic_as_ot_sender"));
     }
     auto recorder = std::make_shared<TuplesMetricRecorder>();
+    metricCollector_->addNewRecorder("tuple_generator", recorder);
 
     return std::make_unique<TwoPartyTupleGenerator>(
         std::move(senderRcot),

--- a/fbpcf/engine/tuple_generator/test/TupleGeneratorTestHelper.h
+++ b/fbpcf/engine/tuple_generator/test/TupleGeneratorTestHelper.h
@@ -49,15 +49,20 @@ const uint64_t kTestBufferSize = 1024;
 inline std::unique_ptr<ITupleGeneratorFactory> createDummyTupleGeneratorFactory(
     int /*numberOfParty*/,
     int /*myId*/,
-    communication::IPartyCommunicationAgentFactory& /*agentFactory*/) {
-  return std::make_unique<insecure::DummyTupleGeneratorFactory>();
+    communication::IPartyCommunicationAgentFactory& /*agentFactory*/,
+    std::shared_ptr<fbpcf::util::MetricCollector> metricCollector =
+        std::make_shared<fbpcf::util::MetricCollector>("tuple_generator")) {
+  return std::make_unique<insecure::DummyTupleGeneratorFactory>(
+      metricCollector);
 }
 
 inline std::unique_ptr<ITupleGeneratorFactory>
 createTupleGeneratorFactoryWithDummyProductShareGenerator(
     int numberOfParty,
     int myId,
-    communication::IPartyCommunicationAgentFactory& agentFactory) {
+    communication::IPartyCommunicationAgentFactory& agentFactory,
+    std::shared_ptr<fbpcf::util::MetricCollector> metricCollector =
+        std::make_shared<fbpcf::util::MetricCollector>("tuple_generator")) {
   return std::make_unique<TupleGeneratorFactory>(
       std::unique_ptr<IProductShareGeneratorFactory>(
           std::make_unique<insecure::DummyProductShareGeneratorFactory>(
@@ -65,14 +70,17 @@ createTupleGeneratorFactoryWithDummyProductShareGenerator(
       std::make_unique<util::AesPrgFactory>(kTestBufferSize),
       kTestBufferSize,
       myId,
-      numberOfParty);
+      numberOfParty,
+      metricCollector);
 }
 
 inline std::unique_ptr<ITupleGeneratorFactory>
 createTupleGeneratorFactoryWithRealProductShareGenerator(
     int numberOfParty,
     int myId,
-    communication::IPartyCommunicationAgentFactory& agentFactory) {
+    communication::IPartyCommunicationAgentFactory& agentFactory,
+    std::shared_ptr<fbpcf::util::MetricCollector> metricCollector =
+        std::make_shared<fbpcf::util::MetricCollector>("tuple_generator")) {
   auto otFactory = std::make_unique<
       oblivious_transfer::RcotBasedBidirectionObliviousTransferFactory>(
       myId,
@@ -90,7 +98,8 @@ createTupleGeneratorFactoryWithRealProductShareGenerator(
       std::make_unique<util::AesPrgFactory>(kTestBufferSize),
       kTestBufferSize,
       myId,
-      numberOfParty);
+      numberOfParty,
+      metricCollector);
 }
 
 inline std::unique_ptr<IArithmeticTupleGeneratorFactory>
@@ -137,7 +146,9 @@ inline std::unique_ptr<ITupleGeneratorFactory>
 createTwoPartyTupleGeneratorFactoryWithDummyRcot(
     int /*numberOfParty*/,
     int myId,
-    communication::IPartyCommunicationAgentFactory& agentFactory) {
+    communication::IPartyCommunicationAgentFactory& agentFactory,
+    std::shared_ptr<fbpcf::util::MetricCollector> metricCollector =
+        std::make_shared<fbpcf::util::MetricCollector>("tuple_generator")) {
   auto rcot = std::unique_ptr<
       oblivious_transfer::IRandomCorrelatedObliviousTransferFactory>(
       std::make_unique<oblivious_transfer::insecure::
@@ -147,28 +158,34 @@ createTwoPartyTupleGeneratorFactoryWithDummyRcot(
       std::reference_wrapper<communication::IPartyCommunicationAgentFactory>(
           agentFactory),
       myId,
-      kTestBufferSize);
+      kTestBufferSize,
+      metricCollector);
 }
 
 inline std::unique_ptr<ITupleGeneratorFactory>
 createTwoPartyTupleGeneratorFactoryWithRealOt(
     int /*numberOfParty*/,
     int myId,
-    communication::IPartyCommunicationAgentFactory& agentFactory) {
+    communication::IPartyCommunicationAgentFactory& agentFactory,
+    std::shared_ptr<fbpcf::util::MetricCollector> metricCollector =
+        std::make_shared<fbpcf::util::MetricCollector>("tuple_generator")) {
   auto rcot = oblivious_transfer::createClassicRcotFactory();
   return std::make_unique<TwoPartyTupleGeneratorFactory>(
       std::move(rcot),
       std::reference_wrapper<communication::IPartyCommunicationAgentFactory>(
           agentFactory),
       myId,
-      kTestBufferSize);
+      kTestBufferSize,
+      metricCollector);
 }
 
 inline std::unique_ptr<ITupleGeneratorFactory>
 createTwoPartyTupleGeneratorFactoryWithRcotExtender(
     int /*numberOfParty*/,
     int myId,
-    communication::IPartyCommunicationAgentFactory& agentFactory) {
+    communication::IPartyCommunicationAgentFactory& agentFactory,
+    std::shared_ptr<fbpcf::util::MetricCollector> metricCollector =
+        std::make_shared<fbpcf::util::MetricCollector>("tuple_generator")) {
   auto rcot = oblivious_transfer::createFerretRcotFactory(
       kTestExtendedSize, kTestBaseSize, kTestWeight);
   return std::make_unique<TwoPartyTupleGeneratorFactory>(
@@ -176,14 +193,17 @@ createTwoPartyTupleGeneratorFactoryWithRcotExtender(
       std::reference_wrapper<communication::IPartyCommunicationAgentFactory>(
           agentFactory),
       myId,
-      kTestBufferSize);
+      kTestBufferSize,
+      metricCollector);
 }
 
 inline std::unique_ptr<ITupleGeneratorFactory>
 createTwoPartyTupleGeneratorFactoryWithRcotExtenderAndSmallBuffer(
     int /*numberOfParty*/,
     int myId,
-    communication::IPartyCommunicationAgentFactory& agentFactory) {
+    communication::IPartyCommunicationAgentFactory& agentFactory,
+    std::shared_ptr<fbpcf::util::MetricCollector> metricCollector =
+        std::make_shared<fbpcf::util::MetricCollector>("tuple_generator")) {
   auto rcot = oblivious_transfer::createFerretRcotFactory(
       kTestExtendedSize, kTestBaseSize, kTestWeight);
   return std::make_unique<TwoPartyTupleGeneratorFactory>(
@@ -191,7 +211,8 @@ createTwoPartyTupleGeneratorFactoryWithRcotExtenderAndSmallBuffer(
       std::reference_wrapper<communication::IPartyCommunicationAgentFactory>(
           agentFactory),
       myId,
-      1);
+      1,
+      metricCollector);
 }
 
 } // namespace fbpcf::engine::tuple_generator

--- a/fbpcf/engine/tuple_generator/test/benchmarks/TupleGeneratorBenchmark.cpp
+++ b/fbpcf/engine/tuple_generator/test/benchmarks/TupleGeneratorBenchmark.cpp
@@ -16,6 +16,7 @@
 #include "fbpcf/engine/util/AesPrgFactory.h"
 #include "fbpcf/engine/util/test/benchmarks/BenchmarkHelper.h"
 #include "fbpcf/engine/util/test/benchmarks/NetworkedBenchmark.h"
+#include "fbpcf/util/MetricCollector.h"
 
 namespace fbpcf::engine::tuple_generator {
 
@@ -161,7 +162,9 @@ class TupleGeneratorBenchmark final : public BaseTupleGeneratorBenchmark {
         std::make_unique<util::AesPrgFactory>(),
         bufferSize_,
         myId,
-        2);
+        2,
+        std::make_shared<fbpcf::util::MetricCollector>(
+            "tuple_generator_benchmark"));
   }
 };
 
@@ -180,7 +183,9 @@ class TwoPartyTupleGeneratorBenchmark final
         oblivious_transfer::createFerretRcotFactory(),
         agentFactory,
         myId,
-        bufferSize_);
+        bufferSize_,
+        std::make_shared<fbpcf::util::MetricCollector>(
+            "tuple_generator_benchmark"));
   }
 };
 
@@ -204,7 +209,9 @@ class TwoPartyCompositeTupleGeneratorBenchmark
         oblivious_transfer::createFerretRcotFactory(),
         agentFactory,
         myId,
-        bufferSize_);
+        bufferSize_,
+        std::make_shared<fbpcf::util::MetricCollector>(
+            "tuple_generator_benchmark"));
   }
   void runSender() override {
     sender_->getCompositeTuple(tupleSizes_);

--- a/fbpcf/scheduler/EagerSchedulerFactory.h
+++ b/fbpcf/scheduler/EagerSchedulerFactory.h
@@ -51,7 +51,7 @@ getEagerSchedulerFactoryWithInsecureEngine(
             "default_metric_collector")) {
   std::unique_ptr<engine::ISecretShareEngineFactory> engineFactory =
       engine::getInsecureEngineFactoryWithDummyTupleGenerator(
-          myId, 2, communicationAgentFactory);
+          myId, 2, communicationAgentFactory, metricCollector);
 
   return std::make_unique<EagerSchedulerFactory<unsafe>>(
       std::move(engineFactory), metricCollector);
@@ -67,7 +67,7 @@ getEagerSchedulerFactoryWithClassicOT(
             "default_metric_collector")) {
   std::unique_ptr<engine::ISecretShareEngineFactory> engineFactory =
       engine::getSecureEngineFactoryWithClassicOt(
-          myId, 2, communicationAgentFactory);
+          myId, 2, communicationAgentFactory, metricCollector);
 
   return std::make_unique<EagerSchedulerFactory</* unsafe */ true>>(
       std::move(engineFactory), metricCollector);
@@ -83,7 +83,7 @@ getEagerSchedulerFactoryWithRealEngine(
             "default_metric_collector")) {
   std::unique_ptr<engine::ISecretShareEngineFactory> engineFactory =
       engine::getSecureEngineFactoryWithFERRET(
-          myId, 2, communicationAgentFactory);
+          myId, 2, communicationAgentFactory, metricCollector);
 
   return std::make_unique<EagerSchedulerFactory</* unsafe */ true>>(
       std::move(engineFactory), metricCollector);

--- a/fbpcf/scheduler/LazySchedulerFactory.h
+++ b/fbpcf/scheduler/LazySchedulerFactory.h
@@ -58,7 +58,7 @@ getLazySchedulerFactoryWithInsecureEngine(
             "default_metric_collector")) {
   std::unique_ptr<engine::ISecretShareEngineFactory> engineFactory =
       engine::getInsecureEngineFactoryWithDummyTupleGenerator(
-          myId, 2, communicationAgentFactory);
+          myId, 2, communicationAgentFactory, metricCollector);
 
   return std::make_unique<LazySchedulerFactory<unsafe>>(
       std::move(engineFactory), metricCollector);
@@ -74,7 +74,7 @@ getLazySchedulerFactoryWithClassicOT(
             "default_metric_collector")) {
   std::unique_ptr<engine::ISecretShareEngineFactory> engineFactory =
       engine::getSecureEngineFactoryWithClassicOt(
-          myId, 2, communicationAgentFactory);
+          myId, 2, communicationAgentFactory, metricCollector);
 
   return std::make_unique<LazySchedulerFactory</* unsafe */ true>>(
       std::move(engineFactory), metricCollector);
@@ -90,7 +90,7 @@ getLazySchedulerFactoryWithRealEngine(
             "default_metric_collector")) {
   std::unique_ptr<engine::ISecretShareEngineFactory> engineFactory =
       engine::getSecureEngineFactoryWithFERRET(
-          myId, 2, communicationAgentFactory);
+          myId, 2, communicationAgentFactory, metricCollector);
 
   return std::make_unique<LazySchedulerFactory</* unsafe */ true>>(
       std::move(engineFactory), metricCollector);

--- a/fbpcf/util/MetricCollector.h
+++ b/fbpcf/util/MetricCollector.h
@@ -33,6 +33,10 @@ class MetricCollector {
     return result;
   }
 
+  std::string getPrefix() {
+    return prefix_;
+  }
+
   folly::dynamic aggregateMetrics() const {
     folly::dynamic result = folly::dynamic::object;
 


### PR DESCRIPTION
Summary:
We add metrics in the TuplesMetricRecorder for composite tuples.

Add the following metrics to the TuplesMetricRecorder:
number of RCOTs used (1-1 mapping to number of composite tuples requested)
total of mini tuples requested with size <= 128
total of mini tuples requested with size > 128
number of composite tuples requested with size <= 128 (no need for AES expansion)
number of composite tuples requested with size > 128
```
Example: if 3 request comes with sizes = 20, 40, 150. Then the metrics are
(3, 60, 150, 2, 1)
```
Verified the collector works correctly in TupleGeneratorTest.cpp

Reviewed By: RuiyuZhu

Differential Revision: D39452273

