### PR TITLE
Re-write testWithJammedPort to be robust

### DIFF
--- a/fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.cpp
+++ b/fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.cpp
@@ -66,8 +66,10 @@ SocketPartyCommunicationAgentFactory::createSocketFromMaybeFreePort(
   // instead
   if (::bind(sockfd, (struct sockaddr*)&servAddr, sizeof(struct sockaddr_in)) <
       0) {
-    XLOG(INFO)
-        << "Failed to bind on the assigned port, binding to a free one instead.";
+    XLOGF(
+        INFO,
+        "Failed to bind on the assigned port: {}, binding to a free one instead.",
+        portNo);
     portNo = 0;
     servAddr.sin_port = htons(portNo);
     if (::bind(


### PR DESCRIPTION
Summary:
This is another flaky test. It is also relying on a non-atomic version of determining a free port, which will fail stress tests.

Instead, I have rewritten the test to create a guaranteed set of agent factories (set up in a previous stack of diffs). When we create agents, it will automatically try to connect to port 1. This isn't allowed, so it should test our functionality. Then, I create agents and ensure it doesn't time out.

Reviewed By: nguytc

Differential Revision: D39682065

