### PR TITLE
Add methods to record traffic statistics

### DIFF
--- a/fbpcf/mpc_std_lib/walr_multiplication/DummyMatrixMultiplication.h
+++ b/fbpcf/mpc_std_lib/walr_multiplication/DummyMatrixMultiplication.h
@@ -29,12 +29,14 @@ class DummyMatrixMultiplication final
       std::unique_ptr<engine::communication::IPartyCommunicationAgent> agent)
       : myId_(myId), partnerId_(partnerId), agent_(std::move(agent)) {}
 
-  /**
-   * @inherit doc
-   */
-  std::vector<double> matrixVectorMultiplication(
+  std::pair<uint64_t, uint64_t> getNonEngineTrafficStatistics() const override {
+    return agent_->getTrafficStatistics();
+  }
+
+ protected:
+  std::vector<double> matrixVectorMultiplicationImpl(
       const std::vector<std::vector<double>>& features,
-      const frontend::Bit<true, schedulerId, true>& labels) const {
+      const frontend::Bit<true, schedulerId, true>& labels) const override {
     // Each features[i] represents a column vector of the feature matrix.
     // There are `nLabels` such column vectors.
     size_t nLabels = labels.getBatchSize();
@@ -75,12 +77,9 @@ class DummyMatrixMultiplication final
     return rst;
   }
 
-  /**
-   * @inherit doc
-   */
-  void matrixVectorMultiplication(
+  void matrixVectorMultiplicationImpl(
       const frontend::Bit<true, schedulerId, true>& labels,
-      const std::vector<double>& dpNoise) const {
+      const std::vector<double>& dpNoise) const override {
     labels.openToParty(partnerId_).getValue();
     agent_->sendT<double>(dpNoise);
   }

--- a/fbpcf/mpc_std_lib/walr_multiplication/IWalrMatrixMultiplication.h
+++ b/fbpcf/mpc_std_lib/walr_multiplication/IWalrMatrixMultiplication.h
@@ -7,9 +7,11 @@
 
 #pragma once
 
+#include <cstdint>
 #include <vector>
 
 #include "fbpcf/frontend/Bit.h"
+#include "fbpcf/scheduler/IScheduler.h"
 
 namespace fbpcf::mpc_std_lib::walr {
 
@@ -29,18 +31,78 @@ class IWalrMatrixMultiplication {
    * labels.getBatchSize().
    * @return the product of feature matrix and the label vector.
    */
-  virtual std::vector<double> matrixVectorMultiplication(
+  std::vector<double> matrixVectorMultiplication(
       const std::vector<std::vector<double>>& features,
-      const frontend::Bit<true, schedulerId, true>& labels) const = 0;
+      const frontend::Bit<true, schedulerId, true>& labels) {
+    // Initialize engine traffic recording
+    auto initEngineTraffic =
+        scheduler::SchedulerKeeper<schedulerId>::getTrafficStatistics();
+
+    auto rst = matrixVectorMultiplicationImpl(features, labels);
+
+    // Calculate engine traffic
+    auto finalEngineTraffic =
+        scheduler::SchedulerKeeper<schedulerId>::getTrafficStatistics();
+    engineTraffic_.first += finalEngineTraffic.first - initEngineTraffic.first;
+    engineTraffic_.second +=
+        finalEngineTraffic.second - initEngineTraffic.second;
+
+    return rst;
+  }
 
   /**
    * The API for the caller with only label shares.
    * @param labels: the label vector consisting of only (secret) boolean labels.
    * @param dpNoise: the dp noise that would be imposed on the output.
    */
-  virtual void matrixVectorMultiplication(
+  void matrixVectorMultiplication(
+      const frontend::Bit<true, schedulerId, true>& labels,
+      const std::vector<double>& dpNoise) {
+    // Initialize engine traffic recording
+    auto initEngineTraffic =
+        scheduler::SchedulerKeeper<schedulerId>::getTrafficStatistics();
+
+    matrixVectorMultiplicationImpl(labels, dpNoise);
+
+    // Calculate engine traffic
+    auto finalEngineTraffic =
+        scheduler::SchedulerKeeper<schedulerId>::getTrafficStatistics();
+    engineTraffic_.first += finalEngineTraffic.first - initEngineTraffic.first;
+    engineTraffic_.second +=
+        finalEngineTraffic.second - initEngineTraffic.second;
+  }
+
+  /**
+   * Get the total amount of traffic transmitted.
+   * @return a pair of (sent, received) data in bytes.
+   */
+  std::pair<uint64_t, uint64_t> getTrafficStatistics() const {
+    auto nonEngineTraffic = getNonEngineTrafficStatistics();
+    return {
+        engineTraffic_.first + nonEngineTraffic.first,
+        engineTraffic_.second + nonEngineTraffic.second};
+  }
+
+  /**
+   * Get the total amount of non-engine traffic transmitted.
+   * @return a pair of (sent, received) data in bytes.
+   */
+  virtual std::pair<uint64_t, uint64_t> getNonEngineTrafficStatistics()
+      const = 0;
+
+ protected:
+  // The implementation API for the caller with feature and label shares.
+  virtual std::vector<double> matrixVectorMultiplicationImpl(
+      const std::vector<std::vector<double>>& features,
+      const frontend::Bit<true, schedulerId, true>& labels) const = 0;
+
+  // The implementation API for the caller with only label shares.
+  virtual void matrixVectorMultiplicationImpl(
       const frontend::Bit<true, schedulerId, true>& labels,
       const std::vector<double>& dpNoise) const = 0;
+
+ private:
+  std::pair<uint64_t, uint64_t> engineTraffic_{0, 0};
 };
 
 } // namespace fbpcf::mpc_std_lib::walr

--- a/fbpcf/mpc_std_lib/walr_multiplication/OTBasedMatrixMultiplication.h
+++ b/fbpcf/mpc_std_lib/walr_multiplication/OTBasedMatrixMultiplication.h
@@ -47,19 +47,22 @@ class OTBasedMatrixMultiplication final
     numberMapper_.setDivisor(divisor);
   }
 
-  /**
-   * @inherit doc
-   */
-  std::vector<double> matrixVectorMultiplication(
-      const std::vector<std::vector<double>>& features,
-      const frontend::Bit<true, schedulerId, true>& labels) const;
+  std::pair<uint64_t, uint64_t> getNonEngineTrafficStatistics() const override {
+    auto cotWRMTraffic = cotWRM_->getTrafficStatistics();
+    auto otherTraffic = agent_->getTrafficStatistics();
+    return {
+        cotWRMTraffic.first + otherTraffic.first,
+        cotWRMTraffic.second + otherTraffic.second};
+  }
 
-  /**
-   * @inherit doc
-   */
-  void matrixVectorMultiplication(
+ protected:
+  std::vector<double> matrixVectorMultiplicationImpl(
+      const std::vector<std::vector<double>>& features,
+      const frontend::Bit<true, schedulerId, true>& labels) const override;
+
+  void matrixVectorMultiplicationImpl(
       const frontend::Bit<true, schedulerId, true>& labels,
-      const std::vector<double>& dpNoise) const;
+      const std::vector<double>& dpNoise) const override;
 
  private:
   int myId_;

--- a/fbpcf/mpc_std_lib/walr_multiplication/OTBasedMatrixMultiplication_impl.h
+++ b/fbpcf/mpc_std_lib/walr_multiplication/OTBasedMatrixMultiplication_impl.h
@@ -17,7 +17,7 @@ namespace fbpcf::mpc_std_lib::walr {
 
 template <int schedulerId, typename FixedPointType>
 std::vector<double> OTBasedMatrixMultiplication<schedulerId, FixedPointType>::
-    matrixVectorMultiplication(
+    matrixVectorMultiplicationImpl(
         const std::vector<std::vector<double>>& features,
         const frontend::Bit<true, schedulerId, true>& labels) const {
   if (!isFeatureOwner_) {
@@ -151,7 +151,7 @@ std::vector<double> OTBasedMatrixMultiplication<schedulerId, FixedPointType>::
 
 template <int schedulerId, typename FixedPointType>
 void OTBasedMatrixMultiplication<schedulerId, FixedPointType>::
-    matrixVectorMultiplication(
+    matrixVectorMultiplicationImpl(
         const frontend::Bit<true, schedulerId, true>& labels,
         const std::vector<double>& dpNoise) const {
   if (isFeatureOwner_) {

--- a/fbpcf/mpc_std_lib/walr_multiplication/util/COTWithRandomMessage.h
+++ b/fbpcf/mpc_std_lib/walr_multiplication/util/COTWithRandomMessage.h
@@ -61,7 +61,11 @@ class COTWithRandomMessage {
    * @return a pair of (sent, received) data in bytes.
    */
   std::pair<uint64_t, uint64_t> getTrafficStatistics() const {
-    return agent_->getTrafficStatistics();
+    auto rcotTraffic = rcot_->getTrafficStatistics();
+    auto nonRcotTraffic = agent_->getTrafficStatistics();
+    return {
+        rcotTraffic.first + nonRcotTraffic.first,
+        rcotTraffic.second + nonRcotTraffic.second};
   }
 
  private:


### PR DESCRIPTION
Summary:
## Why
The goal is to support micro-benchmark for the matrix-multiplication method in subsequent diffs. Therefore we need a way to report the network traffic.

## What
* Add `getTrafficStatistics` method for the `IWalrMatrixMultiplication` class and all its descendants.
  * The traffic has two possible sources, one is the MPC engine (since we accept an `frontend::Bit`-type label vector), the other is the traffic from the matrix multiplication protocol itself.
  * We refactored the `IWalrMatrixMultiplication::matrixVectorMultiplication` method to let it measure the engine traffic difference before and after running the matrix multiplication.

* Correct the `getTrafficStatistics` method of `COTwithRandomMessage` to include the traffic from its underlying RCOT.

## Note
Some offline tests show that, the current two implemented matrix multiplication classes (i.e. `DummyMM` and `OTBasedMM`) have minimal to zero engine traffic. This is expected, since the two do not conduct any arithmetics on the secret shares.

Reviewed By: chualynn

Differential Revision: D39527971

