### PR TITLE
Add a benchmark for the COTWithRandomMessage

### DIFF
--- a/fbpcf/mpc_std_lib/walr_multiplication/DummyMatrixMultiplication.h
+++ b/fbpcf/mpc_std_lib/walr_multiplication/DummyMatrixMultiplication.h
@@ -29,12 +29,14 @@ class DummyMatrixMultiplication final
       std::unique_ptr<engine::communication::IPartyCommunicationAgent> agent)
       : myId_(myId), partnerId_(partnerId), agent_(std::move(agent)) {}
 
-  /**
-   * @inherit doc
-   */
-  std::vector<double> matrixVectorMultiplication(
+  std::pair<uint64_t, uint64_t> getNonEngineTrafficStatistics() const override {
+    return agent_->getTrafficStatistics();
+  }
+
+ protected:
+  std::vector<double> matrixVectorMultiplicationImpl(
       const std::vector<std::vector<double>>& features,
-      const frontend::Bit<true, schedulerId, true>& labels) const {
+      const frontend::Bit<true, schedulerId, true>& labels) const override {
     // Each features[i] represents a column vector of the feature matrix.
     // There are `nLabels` such column vectors.
     size_t nLabels = labels.getBatchSize();
@@ -75,12 +77,9 @@ class DummyMatrixMultiplication final
     return rst;
   }
 
-  /**
-   * @inherit doc
-   */
-  void matrixVectorMultiplication(
+  void matrixVectorMultiplicationImpl(
       const frontend::Bit<true, schedulerId, true>& labels,
-      const std::vector<double>& dpNoise) const {
+      const std::vector<double>& dpNoise) const override {
     labels.openToParty(partnerId_).getValue();
     agent_->sendT<double>(dpNoise);
   }

--- a/fbpcf/mpc_std_lib/walr_multiplication/DummyMatrixMultiplicationFactory.h
+++ b/fbpcf/mpc_std_lib/walr_multiplication/DummyMatrixMultiplicationFactory.h
@@ -25,13 +25,15 @@ class DummyMatrixMultiplicationFactory final
       : myId_(myId), partnerId_(partnerId), agentFactory_(agentFactory) {}
 
   std::unique_ptr<IWalrMatrixMultiplication<schedulerId>> create() override {
+    auto recorder = std::make_shared<WalrMatrixMultiplicationMetricRecorder>();
     return std::make_unique<DummyMatrixMultiplication<schedulerId>>(
         myId_,
         partnerId_,
         agentFactory_.create(
             partnerId_,
             "walr_matrix_multiplication_traffic_to_party " +
-                std::to_string(partnerId_)));
+                std::to_string(partnerId_)),
+        recorder);
   }
 
  private:

--- a/fbpcf/mpc_std_lib/walr_multiplication/DummyMatrixMultiplicationFactory.h
+++ b/fbpcf/mpc_std_lib/walr_multiplication/DummyMatrixMultiplicationFactory.h
@@ -17,15 +17,40 @@ namespace fbpcf::mpc_std_lib::walr::insecure {
 template <int schedulerId>
 class DummyMatrixMultiplicationFactory final
     : public IWalrMatrixMultiplicationFactory<schedulerId> {
+  using IWalrMatrixMultiplicationFactory<schedulerId>::metricCollector_;
+
  public:
+  const std::string metricRecorderNamePrefix = "dummy_matrix_multiplication";
+
+  // The following constructor will be deprecated once we updated all APP codes
   explicit DummyMatrixMultiplicationFactory(
       int myId,
       int partnerId,
       engine::communication::IPartyCommunicationAgentFactory& agentFactory)
-      : myId_(myId), partnerId_(partnerId), agentFactory_(agentFactory) {}
+      : IWalrMatrixMultiplicationFactory<schedulerId>(nullptr),
+        myId_(myId),
+        partnerId_(partnerId),
+        agentFactory_(agentFactory) {}
+
+  explicit DummyMatrixMultiplicationFactory(
+      int myId,
+      int partnerId,
+      engine::communication::IPartyCommunicationAgentFactory& agentFactory,
+      std::shared_ptr<fbpcf::util::MetricCollector> metricCollector)
+      : IWalrMatrixMultiplicationFactory<schedulerId>(metricCollector),
+        myId_(myId),
+        partnerId_(partnerId),
+        agentFactory_(agentFactory) {}
 
   std::unique_ptr<IWalrMatrixMultiplication<schedulerId>> create() override {
     auto recorder = std::make_shared<WalrMatrixMultiplicationMetricRecorder>();
+
+    // For backward compatibility we currently allow a null metric collector.
+    // The condition will be removed later when we change all apps to use a
+    // metric collector.
+    if (metricCollector_ != nullptr) {
+      metricCollector_->addNewRecorder(metricRecorderNamePrefix, recorder);
+    }
     return std::make_unique<DummyMatrixMultiplication<schedulerId>>(
         myId_,
         partnerId_,

--- a/fbpcf/mpc_std_lib/walr_multiplication/IWalrMatrixMultiplication.h
+++ b/fbpcf/mpc_std_lib/walr_multiplication/IWalrMatrixMultiplication.h
@@ -12,8 +12,35 @@
 
 #include "fbpcf/frontend/Bit.h"
 #include "fbpcf/scheduler/IScheduler.h"
+#include "fbpcf/util/IMetricRecorder.h"
 
 namespace fbpcf::mpc_std_lib::walr {
+
+/**
+ * The metric recorder for the IWalrMatrixMultiplication class
+ */
+class WalrMatrixMultiplicationMetricRecorder
+    : public fbpcf::util::IMetricRecorder {
+ public:
+  WalrMatrixMultiplicationMetricRecorder()
+      : featuresSent_(0), featuresReceived_(0) {}
+
+  void addFeaturesSent(uint64_t size) {
+    featuresSent_ += size;
+  }
+  void addFeaturesReceived(uint64_t size) {
+    featuresReceived_ += size;
+  }
+
+  folly::dynamic getMetrics() const override {
+    return folly::dynamic::object("features_sent", featuresSent_.load())(
+        "features_received", featuresReceived_.load());
+  }
+
+ protected:
+  std::atomic_uint64_t featuresSent_;
+  std::atomic_uint64_t featuresReceived_;
+};
 
 template <int schedulerId>
 class IWalrMatrixMultiplication {

--- a/fbpcf/mpc_std_lib/walr_multiplication/IWalrMatrixMultiplication.h
+++ b/fbpcf/mpc_std_lib/walr_multiplication/IWalrMatrixMultiplication.h
@@ -7,9 +7,11 @@
 
 #pragma once
 
+#include <cstdint>
 #include <vector>
 
 #include "fbpcf/frontend/Bit.h"
+#include "fbpcf/scheduler/IScheduler.h"
 
 namespace fbpcf::mpc_std_lib::walr {
 
@@ -29,18 +31,78 @@ class IWalrMatrixMultiplication {
    * labels.getBatchSize().
    * @return the product of feature matrix and the label vector.
    */
-  virtual std::vector<double> matrixVectorMultiplication(
+  std::vector<double> matrixVectorMultiplication(
       const std::vector<std::vector<double>>& features,
-      const frontend::Bit<true, schedulerId, true>& labels) const = 0;
+      const frontend::Bit<true, schedulerId, true>& labels) {
+    // Initialize engine traffic recording
+    auto initEngineTraffic =
+        scheduler::SchedulerKeeper<schedulerId>::getTrafficStatistics();
+
+    auto rst = matrixVectorMultiplicationImpl(features, labels);
+
+    // Calculate engine traffic
+    auto finalEngineTraffic =
+        scheduler::SchedulerKeeper<schedulerId>::getTrafficStatistics();
+    engineTraffic_.first += finalEngineTraffic.first - initEngineTraffic.first;
+    engineTraffic_.second +=
+        finalEngineTraffic.second - initEngineTraffic.second;
+
+    return rst;
+  }
 
   /**
    * The API for the caller with only label shares.
    * @param labels: the label vector consisting of only (secret) boolean labels.
    * @param dpNoise: the dp noise that would be imposed on the output.
    */
-  virtual void matrixVectorMultiplication(
+  void matrixVectorMultiplication(
+      const frontend::Bit<true, schedulerId, true>& labels,
+      const std::vector<double>& dpNoise) {
+    // Initialize engine traffic recording
+    auto initEngineTraffic =
+        scheduler::SchedulerKeeper<schedulerId>::getTrafficStatistics();
+
+    matrixVectorMultiplicationImpl(labels, dpNoise);
+
+    // Calculate engine traffic
+    auto finalEngineTraffic =
+        scheduler::SchedulerKeeper<schedulerId>::getTrafficStatistics();
+    engineTraffic_.first += finalEngineTraffic.first - initEngineTraffic.first;
+    engineTraffic_.second +=
+        finalEngineTraffic.second - initEngineTraffic.second;
+  }
+
+  /**
+   * Get the total amount of traffic transmitted.
+   * @return a pair of (sent, received) data in bytes.
+   */
+  std::pair<uint64_t, uint64_t> getTrafficStatistics() const {
+    auto nonEngineTraffic = getNonEngineTrafficStatistics();
+    return {
+        engineTraffic_.first + nonEngineTraffic.first,
+        engineTraffic_.second + nonEngineTraffic.second};
+  }
+
+  /**
+   * Get the total amount of non-engine traffic transmitted.
+   * @return a pair of (sent, received) data in bytes.
+   */
+  virtual std::pair<uint64_t, uint64_t> getNonEngineTrafficStatistics()
+      const = 0;
+
+ protected:
+  // The implementation API for the caller with feature and label shares.
+  virtual std::vector<double> matrixVectorMultiplicationImpl(
+      const std::vector<std::vector<double>>& features,
+      const frontend::Bit<true, schedulerId, true>& labels) const = 0;
+
+  // The implementation API for the caller with only label shares.
+  virtual void matrixVectorMultiplicationImpl(
       const frontend::Bit<true, schedulerId, true>& labels,
       const std::vector<double>& dpNoise) const = 0;
+
+ private:
+  std::pair<uint64_t, uint64_t> engineTraffic_{0, 0};
 };
 
 } // namespace fbpcf::mpc_std_lib::walr

--- a/fbpcf/mpc_std_lib/walr_multiplication/IWalrMatrixMultiplicationFactory.h
+++ b/fbpcf/mpc_std_lib/walr_multiplication/IWalrMatrixMultiplicationFactory.h
@@ -8,13 +8,21 @@
 #pragma once
 
 #include "fbpcf/mpc_std_lib/walr_multiplication/IWalrMatrixMultiplication.h"
+#include "fbpcf/util/MetricCollector.h"
+
 namespace fbpcf::mpc_std_lib::walr {
 
 template <int schedulerId>
 class IWalrMatrixMultiplicationFactory {
  public:
+  explicit IWalrMatrixMultiplicationFactory(
+      std::shared_ptr<fbpcf::util::MetricCollector> metricCollector)
+      : metricCollector_(metricCollector) {}
   virtual ~IWalrMatrixMultiplicationFactory() = default;
   virtual std::unique_ptr<IWalrMatrixMultiplication<schedulerId>> create() = 0;
+
+ protected:
+  std::shared_ptr<fbpcf::util::MetricCollector> metricCollector_;
 };
 
 } // namespace fbpcf::mpc_std_lib::walr

--- a/fbpcf/mpc_std_lib/walr_multiplication/OTBasedMatrixMultiplication.h
+++ b/fbpcf/mpc_std_lib/walr_multiplication/OTBasedMatrixMultiplication.h
@@ -47,19 +47,22 @@ class OTBasedMatrixMultiplication final
     numberMapper_.setDivisor(divisor);
   }
 
-  /**
-   * @inherit doc
-   */
-  std::vector<double> matrixVectorMultiplication(
-      const std::vector<std::vector<double>>& features,
-      const frontend::Bit<true, schedulerId, true>& labels) const;
+  std::pair<uint64_t, uint64_t> getNonEngineTrafficStatistics() const override {
+    auto cotWRMTraffic = cotWRM_->getTrafficStatistics();
+    auto otherTraffic = agent_->getTrafficStatistics();
+    return {
+        cotWRMTraffic.first + otherTraffic.first,
+        cotWRMTraffic.second + otherTraffic.second};
+  }
 
-  /**
-   * @inherit doc
-   */
-  void matrixVectorMultiplication(
+ protected:
+  std::vector<double> matrixVectorMultiplicationImpl(
+      const std::vector<std::vector<double>>& features,
+      const frontend::Bit<true, schedulerId, true>& labels) const override;
+
+  void matrixVectorMultiplicationImpl(
       const frontend::Bit<true, schedulerId, true>& labels,
-      const std::vector<double>& dpNoise) const;
+      const std::vector<double>& dpNoise) const override;
 
  private:
   int myId_;

--- a/fbpcf/mpc_std_lib/walr_multiplication/OTBasedMatrixMultiplicationFactory.h
+++ b/fbpcf/mpc_std_lib/walr_multiplication/OTBasedMatrixMultiplicationFactory.h
@@ -61,6 +61,8 @@ class OTBasedMatrixMultiplicationFactory final
           cotWRMFactory_->create(std::move(cotWRMAgent), std::move(rcotAgent));
     }
 
+    auto recorder =
+        std::make_shared<OTBasedMatrixMultiplicationMetricRecorder>();
     return std::make_unique<
         OTBasedMatrixMultiplication<schedulerId, FixedPointType>>(
         myId_,
@@ -72,7 +74,8 @@ class OTBasedMatrixMultiplicationFactory final
             "walr_matrix_multiplication_traffic_to_party " +
                 std::to_string(partnerId_)),
         std::move(prgFactory_),
-        std::move(cotWRM));
+        std::move(cotWRM),
+        recorder);
   }
 
  private:

--- a/fbpcf/mpc_std_lib/walr_multiplication/OTBasedMatrixMultiplication_impl.h
+++ b/fbpcf/mpc_std_lib/walr_multiplication/OTBasedMatrixMultiplication_impl.h
@@ -17,7 +17,7 @@ namespace fbpcf::mpc_std_lib::walr {
 
 template <int schedulerId, typename FixedPointType>
 std::vector<double> OTBasedMatrixMultiplication<schedulerId, FixedPointType>::
-    matrixVectorMultiplication(
+    matrixVectorMultiplicationImpl(
         const std::vector<std::vector<double>>& features,
         const frontend::Bit<true, schedulerId, true>& labels) const {
   if (!isFeatureOwner_) {
@@ -151,7 +151,7 @@ std::vector<double> OTBasedMatrixMultiplication<schedulerId, FixedPointType>::
 
 template <int schedulerId, typename FixedPointType>
 void OTBasedMatrixMultiplication<schedulerId, FixedPointType>::
-    matrixVectorMultiplication(
+    matrixVectorMultiplicationImpl(
         const frontend::Bit<true, schedulerId, true>& labels,
         const std::vector<double>& dpNoise) const {
   if (isFeatureOwner_) {

--- a/fbpcf/mpc_std_lib/walr_multiplication/test/benchmarks/WalrMatrixMultiplicationBenchmark.cpp
+++ b/fbpcf/mpc_std_lib/walr_multiplication/test/benchmarks/WalrMatrixMultiplicationBenchmark.cpp
@@ -1,0 +1,333 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <sys/types.h>
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <future>
+#include <memory>
+#include <random>
+#include <tuple>
+#include <vector>
+
+#include "common/init/Init.h"
+
+#include "fbpcf/engine/communication/test/AgentFactoryCreationHelper.h"
+#include "fbpcf/engine/tuple_generator/oblivious_transfer/DummyRandomCorrelatedObliviousTransferFactory.h"
+#include "fbpcf/engine/tuple_generator/oblivious_transfer/EmpShRandomCorrelatedObliviousTransferFactory.h"
+#include "fbpcf/engine/tuple_generator/oblivious_transfer/ExtenderBasedRandomCorrelatedObliviousTransferFactory.h"
+#include "fbpcf/engine/tuple_generator/oblivious_transfer/IknpShRandomCorrelatedObliviousTransferFactory.h"
+#include "fbpcf/engine/tuple_generator/oblivious_transfer/NpBaseObliviousTransferFactory.h"
+#include "fbpcf/engine/tuple_generator/oblivious_transfer/ferret/RcotExtenderFactory.h"
+#include "fbpcf/engine/tuple_generator/oblivious_transfer/ferret/RegularErrorMultiPointCotFactory.h"
+#include "fbpcf/engine/tuple_generator/oblivious_transfer/ferret/SinglePointCotFactory.h"
+#include "fbpcf/engine/tuple_generator/oblivious_transfer/ferret/TenLocalLinearMatrixMultiplierFactory.h"
+#include "fbpcf/engine/util/AesPrgFactory.h"
+#include "fbpcf/engine/util/test/benchmarks/BenchmarkHelper.h"
+#include "fbpcf/engine/util/test/benchmarks/NetworkedBenchmark.h"
+
+#include "fbpcf/mpc_std_lib/util/test/util.h"
+#include "fbpcf/mpc_std_lib/walr_multiplication/DummyMatrixMultiplication.h"
+#include "fbpcf/mpc_std_lib/walr_multiplication/DummyMatrixMultiplicationFactory.h"
+#include "fbpcf/mpc_std_lib/walr_multiplication/IWalrMatrixMultiplication.h"
+#include "fbpcf/mpc_std_lib/walr_multiplication/IWalrMatrixMultiplicationFactory.h"
+#include "fbpcf/mpc_std_lib/walr_multiplication/OTBasedMatrixMultiplication.h"
+#include "fbpcf/mpc_std_lib/walr_multiplication/OTBasedMatrixMultiplicationFactory.h"
+#include "fbpcf/mpc_std_lib/walr_multiplication/util/COTWithRandomMessageFactory.h"
+
+#include "fbpcf/scheduler/IScheduler.h"
+#include "fbpcf/scheduler/LazySchedulerFactory.h"
+#include "fbpcf/util/MetricCollector.h"
+
+namespace fbpcf::mpc_std_lib::walr {
+
+class WalrMatrixMultiplicationBenchmark
+    : public engine::util::NetworkedBenchmark {
+ public:
+  void setup() override {
+    // These agent factories are used for setting up the backend schedulers
+    auto [agentFactory0, agentFactory1] =
+        engine::util::getSocketAgentFactories();
+    agentFactory0_ = std::move(agentFactory0);
+    agentFactory1_ = std::move(agentFactory1);
+    auto [nFeatures, nLabels] = dataSize();
+    initData(nFeatures, nLabels);
+  }
+
+ protected:
+  void initSender() override {
+    scheduler::SchedulerKeeper<0>::setScheduler(
+        scheduler::getLazySchedulerFactoryWithRealEngine(0, *agentFactory0_)
+            ->create());
+    featureOwner_ = featureOwnerFactory_->create();
+  }
+
+  void runSender() override {
+    auto secLabel0 =
+        mpc_std_lib::util::MpcAdapters<bool, 0>::processSecretInputs(
+            labels_, 1);
+    featureOwner_->matrixVectorMultiplication(features_, secLabel0);
+  }
+
+  void initReceiver() override {
+    scheduler::SchedulerKeeper<1>::setScheduler(
+        scheduler::getLazySchedulerFactoryWithRealEngine(1, *agentFactory1_)
+            ->create());
+    labelOwner_ = labelOwnerFactory_->create();
+  }
+
+  void runReceiver() override {
+    auto secLabel1 =
+        mpc_std_lib::util::MpcAdapters<bool, 1>::processSecretInputs(
+            labels_, 1);
+    labelOwner_->matrixVectorMultiplication(secLabel1, dpNoise_);
+  }
+
+  std::pair<uint64_t, uint64_t> getTrafficStatistics() override {
+    return featureOwner_->getTrafficStatistics();
+  }
+
+  std::unique_ptr<engine::communication::IPartyCommunicationAgentFactory>
+      agentFactory0_;
+  std::unique_ptr<engine::communication::IPartyCommunicationAgentFactory>
+      agentFactory1_;
+
+  // feature owner always use scheduler 0, while label owner uses scheduler 1
+  std::unique_ptr<IWalrMatrixMultiplicationFactory<0>> featureOwnerFactory_;
+  std::unique_ptr<IWalrMatrixMultiplicationFactory<1>> labelOwnerFactory_;
+
+  virtual std::pair<size_t, size_t> dataSize() const = 0;
+
+ private:
+  inline void initData(size_t nFeatures, size_t nLabels) {
+    std::random_device rd;
+    std::mt19937_64 e(rd());
+    std::uniform_real_distribution<double> dist(0.0, 1.0);
+
+    // generate feature matrix
+    features_.reserve(nLabels);
+    for (int i = 0; i < nLabels; ++i) {
+      std::vector<double> column(nFeatures);
+      std::generate(
+          column.begin(), column.end(), [&dist, &e]() { return dist(e); });
+      features_.push_back(column);
+    }
+
+    // generate label vector
+    labels_ = mpc_std_lib::util::generateRandomBinary(nLabels);
+
+    // generate DP noise
+    dpNoise_.reserve(nFeatures);
+    std::generate_n(std::back_inserter(dpNoise_), nFeatures, [&dist, &e]() {
+      return dist(e);
+    });
+  }
+
+  std::vector<std::vector<double>> features_;
+  std::vector<bool> labels_;
+  std::vector<double> dpNoise_;
+
+  std::unique_ptr<IWalrMatrixMultiplication<0>> featureOwner_;
+  std::unique_ptr<IWalrMatrixMultiplication<1>> labelOwner_;
+};
+
+class DummyMatrixMultiplicationBenchmark
+    : public WalrMatrixMultiplicationBenchmark {
+ public:
+  void setup() override {
+    WalrMatrixMultiplicationBenchmark::setup();
+    auto [agentFactory0, agentFactory1] =
+        engine::util::getSocketAgentFactories();
+    senderAgentFactory_ = std::move(agentFactory0);
+    receiverAgentFactory_ = std::move(agentFactory1);
+
+    featureOwnerFactory_ =
+        std::make_unique<insecure::DummyMatrixMultiplicationFactory<0>>(
+            0,
+            1,
+            *senderAgentFactory_,
+            std::make_shared<fbpcf::util::MetricCollector>(
+                "dummy_matrix_multiplication_benchmark_0"));
+    labelOwnerFactory_ =
+        std::make_unique<insecure::DummyMatrixMultiplicationFactory<1>>(
+            1,
+            0,
+            *receiverAgentFactory_,
+            std::make_shared<fbpcf::util::MetricCollector>(
+                "dummy_matrix_multiplication_benchmark_1"));
+  }
+
+ protected:
+  std::pair<size_t, size_t> dataSize() const override {
+    return {100, 5000};
+  }
+
+ private:
+  std::unique_ptr<engine::communication::IPartyCommunicationAgentFactory>
+      senderAgentFactory_;
+  std::unique_ptr<engine::communication::IPartyCommunicationAgentFactory>
+      receiverAgentFactory_;
+};
+
+class OTBasedMatrixMultiplicationBenchmark
+    : public WalrMatrixMultiplicationBenchmark {
+ public:
+  void setup() override {
+    WalrMatrixMultiplicationBenchmark::setup();
+    auto [agentFactory0, agentFactory1] =
+        engine::util::getSocketAgentFactories();
+    senderAgentFactory_ = std::move(agentFactory0);
+    receiverAgentFactory_ = std::move(agentFactory1);
+
+    constexpr uint64_t divisor = static_cast<uint64_t>(1e9);
+
+    auto prgFactory0 = std::make_unique<engine::util::AesPrgFactory>();
+    auto prgFactory1 = std::make_unique<engine::util::AesPrgFactory>();
+
+    auto cotWRMFactory0 =
+        std::make_unique<util::COTWithRandomMessageFactory>(getRcotFactory());
+    auto cotWRMFactory1 =
+        std::make_unique<util::COTWithRandomMessageFactory>(getRcotFactory());
+
+    featureOwnerFactory_ =
+        std::make_unique<OTBasedMatrixMultiplicationFactory<0, uint64_t>>(
+            0,
+            1,
+            true,
+            divisor,
+            *senderAgentFactory_,
+            std::move(prgFactory0),
+            std::move(cotWRMFactory0),
+            std::make_shared<fbpcf::util::MetricCollector>(
+                "ot_based_matrix_multiplication_benchmark_0"));
+    labelOwnerFactory_ =
+        std::make_unique<OTBasedMatrixMultiplicationFactory<1, uint64_t>>(
+            1,
+            0,
+            false,
+            divisor,
+            *receiverAgentFactory_,
+            std::move(prgFactory1),
+            std::move(cotWRMFactory1),
+            std::make_shared<fbpcf::util::MetricCollector>(
+                "ot_based_matrix_multiplication_benchmark_1"));
+  }
+
+ protected:
+  std::pair<size_t, size_t> dataSize() const override {
+    return {100, 5000};
+  }
+
+  virtual std::unique_ptr<engine::tuple_generator::oblivious_transfer::
+                              IRandomCorrelatedObliviousTransferFactory>
+  getRcotFactory() = 0;
+
+ private:
+  std::unique_ptr<engine::communication::IPartyCommunicationAgentFactory>
+      senderAgentFactory_;
+  std::unique_ptr<engine::communication::IPartyCommunicationAgentFactory>
+      receiverAgentFactory_;
+};
+
+class OTBasedMatrixMultiplicationWithDummyRCOTBenchmark final
+    : public OTBasedMatrixMultiplicationBenchmark {
+ protected:
+  std::unique_ptr<engine::tuple_generator::oblivious_transfer::
+                      IRandomCorrelatedObliviousTransferFactory>
+  getRcotFactory() override {
+    return std::make_unique<
+        engine::tuple_generator::oblivious_transfer::insecure::
+            DummyRandomCorrelatedObliviousTransferFactory>();
+  }
+};
+
+class OTBasedMatrixMultiplicationWithEmpFerretBenchmark final
+    : public OTBasedMatrixMultiplicationBenchmark {
+ protected:
+  std::unique_ptr<engine::tuple_generator::oblivious_transfer::
+                      IRandomCorrelatedObliviousTransferFactory>
+  getRcotFactory() override {
+    return std::make_unique<
+        engine::tuple_generator::oblivious_transfer::
+            ExtenderBasedRandomCorrelatedObliviousTransferFactory>(
+        std::make_unique<engine::tuple_generator::oblivious_transfer::
+                             EmpShRandomCorrelatedObliviousTransferFactory>(
+            std::make_unique<engine::util::AesPrgFactory>(1024)),
+        std::make_unique<engine::tuple_generator::oblivious_transfer::ferret::
+                             RcotExtenderFactory>(
+            std::make_unique<
+                engine::tuple_generator::oblivious_transfer::ferret::
+                    TenLocalLinearMatrixMultiplierFactory>(),
+            std::make_unique<engine::tuple_generator::oblivious_transfer::
+                                 ferret::RegularErrorMultiPointCotFactory>(
+                std::make_unique<engine::tuple_generator::oblivious_transfer::
+                                     ferret::SinglePointCotFactory>())),
+        engine::tuple_generator::oblivious_transfer::ferret::kExtendedSize,
+        engine::tuple_generator::oblivious_transfer::ferret::kBaseSize,
+        engine::tuple_generator::oblivious_transfer::ferret::kWeight);
+  }
+};
+
+class OTBasedMatrixMultiplicationWithIknpFerretBenchmark final
+    : public OTBasedMatrixMultiplicationBenchmark {
+ protected:
+  std::unique_ptr<engine::tuple_generator::oblivious_transfer::
+                      IRandomCorrelatedObliviousTransferFactory>
+  getRcotFactory() override {
+    return std::make_unique<
+        engine::tuple_generator::oblivious_transfer::
+            ExtenderBasedRandomCorrelatedObliviousTransferFactory>(
+        std::make_unique<engine::tuple_generator::oblivious_transfer::
+                             IknpShRandomCorrelatedObliviousTransferFactory>(
+            std::make_unique<engine::tuple_generator::oblivious_transfer::
+                                 NpBaseObliviousTransferFactory>()),
+        std::make_unique<engine::tuple_generator::oblivious_transfer::ferret::
+                             RcotExtenderFactory>(
+            std::make_unique<
+                engine::tuple_generator::oblivious_transfer::ferret::
+                    TenLocalLinearMatrixMultiplierFactory>(),
+            std::make_unique<engine::tuple_generator::oblivious_transfer::
+                                 ferret::RegularErrorMultiPointCotFactory>(
+                std::make_unique<engine::tuple_generator::oblivious_transfer::
+                                     ferret::SinglePointCotFactory>())),
+        engine::tuple_generator::oblivious_transfer::ferret::kExtendedSize,
+        engine::tuple_generator::oblivious_transfer::ferret::kBaseSize,
+        engine::tuple_generator::oblivious_transfer::ferret::kWeight);
+  }
+};
+
+BENCHMARK_COUNTERS(DummyMatrixMultiplication, counters) {
+  DummyMatrixMultiplicationBenchmark benchmark;
+  benchmark.runBenchmark(counters);
+}
+
+BENCHMARK_COUNTERS(OTBasedMatrixMultiplicationWithDummyRCOT, counters) {
+  OTBasedMatrixMultiplicationWithDummyRCOTBenchmark benchmark;
+  benchmark.runBenchmark(counters);
+}
+
+BENCHMARK_COUNTERS(OTBasedMatrixMultiplicationWithIknpFerret, counters) {
+  OTBasedMatrixMultiplicationWithIknpFerretBenchmark benchmark;
+  benchmark.runBenchmark(counters);
+}
+
+BENCHMARK_COUNTERS(OTBasedMatrixMultiplicationWithEmpFerret, counters) {
+  OTBasedMatrixMultiplicationWithEmpFerretBenchmark benchmark;
+  benchmark.runBenchmark(counters);
+}
+
+} // namespace fbpcf::mpc_std_lib::walr
+
+int main(int argc, char* argv[]) {
+  facebook::initFacebook(&argc, &argv);
+  folly::runBenchmarks();
+  return 0;
+}

--- a/fbpcf/mpc_std_lib/walr_multiplication/util/COTWithRandomMessage.h
+++ b/fbpcf/mpc_std_lib/walr_multiplication/util/COTWithRandomMessage.h
@@ -61,7 +61,11 @@ class COTWithRandomMessage {
    * @return a pair of (sent, received) data in bytes.
    */
   std::pair<uint64_t, uint64_t> getTrafficStatistics() const {
-    return agent_->getTrafficStatistics();
+    auto rcotTraffic = rcot_->getTrafficStatistics();
+    auto nonRcotTraffic = agent_->getTrafficStatistics();
+    return {
+        rcotTraffic.first + nonRcotTraffic.first,
+        rcotTraffic.second + nonRcotTraffic.second};
   }
 
  private:

--- a/fbpcf/mpc_std_lib/walr_multiplication/util/test/benchmarks/COTWithRandomMessageBenchmark.cpp
+++ b/fbpcf/mpc_std_lib/walr_multiplication/util/test/benchmarks/COTWithRandomMessageBenchmark.cpp
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <sys/types.h>
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <future>
+#include <memory>
+#include <random>
+#include <tuple>
+#include <vector>
+
+#include "common/init/Init.h"
+
+#include "fbpcf/engine/communication/test/AgentFactoryCreationHelper.h"
+#include "fbpcf/engine/tuple_generator/oblivious_transfer/DummyRandomCorrelatedObliviousTransferFactory.h"
+#include "fbpcf/engine/tuple_generator/oblivious_transfer/EmpShRandomCorrelatedObliviousTransferFactory.h"
+#include "fbpcf/engine/tuple_generator/oblivious_transfer/ExtenderBasedRandomCorrelatedObliviousTransferFactory.h"
+#include "fbpcf/engine/tuple_generator/oblivious_transfer/IknpShRandomCorrelatedObliviousTransferFactory.h"
+#include "fbpcf/engine/tuple_generator/oblivious_transfer/NpBaseObliviousTransferFactory.h"
+#include "fbpcf/engine/tuple_generator/oblivious_transfer/ferret/RcotExtenderFactory.h"
+#include "fbpcf/engine/tuple_generator/oblivious_transfer/ferret/RegularErrorMultiPointCotFactory.h"
+#include "fbpcf/engine/tuple_generator/oblivious_transfer/ferret/SinglePointCotFactory.h"
+#include "fbpcf/engine/tuple_generator/oblivious_transfer/ferret/TenLocalLinearMatrixMultiplierFactory.h"
+#include "fbpcf/engine/util/AesPrgFactory.h"
+#include "fbpcf/engine/util/test/benchmarks/BenchmarkHelper.h"
+#include "fbpcf/engine/util/test/benchmarks/NetworkedBenchmark.h"
+
+#include "fbpcf/mpc_std_lib/util/test/util.h"
+#include "fbpcf/mpc_std_lib/walr_multiplication/util/COTWithRandomMessageFactory.h"
+
+namespace fbpcf::mpc_std_lib::walr::util {
+
+class COTWithRandomMessageBenchmark : public engine::util::NetworkedBenchmark {
+ public:
+  void setup() override {
+    auto [agent0, agent1] = engine::util::getSocketAgents();
+    agent0_ = std::move(agent0);
+    agent1_ = std::move(agent1);
+
+    auto [rcotAgent0, rcotAgent1] = engine::util::getSocketAgents();
+    rcotAgent0_ = std::move(rcotAgent0);
+    rcotAgent1_ = std::move(rcotAgent1);
+
+    std::random_device rd;
+    std::mt19937_64 e(rd());
+    std::uniform_int_distribution<uint64_t> dist(0, 0xFFFFFFFFFFFFFFFF);
+    delta_ = _mm_set_epi64x(dist(e), dist(e));
+    engine::util::setLsbTo1(delta_);
+
+    choice_ = engine::util::getRandomBoolVector(size_);
+
+    auto prgFactory0 = std::make_unique<engine::util::AesPrgFactory>();
+    auto prgFactory1 = std::make_unique<engine::util::AesPrgFactory>();
+
+    factory_ = std::make_unique<COTWithRandomMessageFactory>(getRcotFactory());
+  }
+
+ protected:
+  void initSender() override {
+    sender_ =
+        factory_->create(delta_, std::move(agent0_), std::move(rcotAgent0_));
+  }
+
+  void runSender() override {
+    sender_->send(size_);
+  }
+
+  void initReceiver() override {
+    receiver_ = factory_->create(std::move(agent1_), std::move(rcotAgent1_));
+  }
+
+  void runReceiver() override {
+    receiver_->receive(choice_);
+  }
+
+  std::pair<uint64_t, uint64_t> getTrafficStatistics() override {
+    return sender_->getTrafficStatistics();
+  }
+
+  virtual std::unique_ptr<engine::tuple_generator::oblivious_transfer::
+                              IRandomCorrelatedObliviousTransferFactory>
+  getRcotFactory() = 0;
+
+  std::unique_ptr<COTWithRandomMessageFactory> factory_;
+
+ private:
+  const size_t size_ = 1000000;
+  __m128i delta_;
+  std::vector<bool> choice_;
+
+  std::unique_ptr<engine::communication::IPartyCommunicationAgent> agent0_;
+  std::unique_ptr<engine::communication::IPartyCommunicationAgent> agent1_;
+
+  std::unique_ptr<engine::communication::IPartyCommunicationAgent> rcotAgent0_;
+  std::unique_ptr<engine::communication::IPartyCommunicationAgent> rcotAgent1_;
+
+  std::unique_ptr<COTWithRandomMessage> sender_;
+  std::unique_ptr<COTWithRandomMessage> receiver_;
+};
+
+class DummyRCOTBasedCOTwRMBenchmark final
+    : public COTWithRandomMessageBenchmark {
+ protected:
+  std::unique_ptr<engine::tuple_generator::oblivious_transfer::
+                      IRandomCorrelatedObliviousTransferFactory>
+  getRcotFactory() override {
+    return std::make_unique<
+        engine::tuple_generator::oblivious_transfer::insecure::
+            DummyRandomCorrelatedObliviousTransferFactory>();
+  }
+};
+
+class EmpFerretBasedCOTwRMBenchmark final
+    : public COTWithRandomMessageBenchmark {
+ protected:
+  std::unique_ptr<engine::tuple_generator::oblivious_transfer::
+                      IRandomCorrelatedObliviousTransferFactory>
+  getRcotFactory() override {
+    return std::make_unique<
+        engine::tuple_generator::oblivious_transfer::
+            ExtenderBasedRandomCorrelatedObliviousTransferFactory>(
+        std::make_unique<engine::tuple_generator::oblivious_transfer::
+                             EmpShRandomCorrelatedObliviousTransferFactory>(
+            std::make_unique<engine::util::AesPrgFactory>(1024)),
+        std::make_unique<engine::tuple_generator::oblivious_transfer::ferret::
+                             RcotExtenderFactory>(
+            std::make_unique<
+                engine::tuple_generator::oblivious_transfer::ferret::
+                    TenLocalLinearMatrixMultiplierFactory>(),
+            std::make_unique<engine::tuple_generator::oblivious_transfer::
+                                 ferret::RegularErrorMultiPointCotFactory>(
+                std::make_unique<engine::tuple_generator::oblivious_transfer::
+                                     ferret::SinglePointCotFactory>())),
+        engine::tuple_generator::oblivious_transfer::ferret::kExtendedSize,
+        engine::tuple_generator::oblivious_transfer::ferret::kBaseSize,
+        engine::tuple_generator::oblivious_transfer::ferret::kWeight);
+  }
+};
+
+class IknpFerretBasedCOTwRMBenchmark final
+    : public COTWithRandomMessageBenchmark {
+ protected:
+  std::unique_ptr<engine::tuple_generator::oblivious_transfer::
+                      IRandomCorrelatedObliviousTransferFactory>
+  getRcotFactory() override {
+    return std::make_unique<
+        engine::tuple_generator::oblivious_transfer::
+            ExtenderBasedRandomCorrelatedObliviousTransferFactory>(
+        std::make_unique<engine::tuple_generator::oblivious_transfer::
+                             IknpShRandomCorrelatedObliviousTransferFactory>(
+            std::make_unique<engine::tuple_generator::oblivious_transfer::
+                                 NpBaseObliviousTransferFactory>()),
+        std::make_unique<engine::tuple_generator::oblivious_transfer::ferret::
+                             RcotExtenderFactory>(
+            std::make_unique<
+                engine::tuple_generator::oblivious_transfer::ferret::
+                    TenLocalLinearMatrixMultiplierFactory>(),
+            std::make_unique<engine::tuple_generator::oblivious_transfer::
+                                 ferret::RegularErrorMultiPointCotFactory>(
+                std::make_unique<engine::tuple_generator::oblivious_transfer::
+                                     ferret::SinglePointCotFactory>())),
+        engine::tuple_generator::oblivious_transfer::ferret::kExtendedSize,
+        engine::tuple_generator::oblivious_transfer::ferret::kBaseSize,
+        engine::tuple_generator::oblivious_transfer::ferret::kWeight);
+  }
+};
+
+BENCHMARK_COUNTERS(DummyRCOTBasedCOTwRM, counters) {
+  DummyRCOTBasedCOTwRMBenchmark benchmark;
+  benchmark.runBenchmark(counters);
+}
+
+BENCHMARK_COUNTERS(EmpFerretBasedCOTwRM, counters) {
+  EmpFerretBasedCOTwRMBenchmark benchmark;
+  benchmark.runBenchmark(counters);
+}
+
+BENCHMARK_COUNTERS(IknpFerretBasedCOTwRM, counters) {
+  IknpFerretBasedCOTwRMBenchmark benchmark;
+  benchmark.runBenchmark(counters);
+}
+
+} // namespace fbpcf::mpc_std_lib::walr::util
+
+int main(int argc, char* argv[]) {
+  facebook::initFacebook(&argc, &argv);
+  folly::runBenchmarks();
+  return 0;
+}


### PR DESCRIPTION
Summary:
## Why
Micro-benchmarks for monitoring performance regression.

## What
We add two benchmarks

* COTwRM using DummyRCOT: as a baseline. **Only this one should be ran on ServiceLab.**
* COTwRM using EMP-based Ferret as underlying RCOT.
* COTwRM using IKNP-based Ferret as underlying RCOT.

Reviewed By: RuiyuZhu

Differential Revision: D39593244

