### PR TITLE
Pass metric collectors to matrix multiplication factories

### DIFF
--- a/fbpcf/mpc_std_lib/walr_multiplication/DummyMatrixMultiplication.h
+++ b/fbpcf/mpc_std_lib/walr_multiplication/DummyMatrixMultiplication.h
@@ -29,12 +29,14 @@ class DummyMatrixMultiplication final
       std::unique_ptr<engine::communication::IPartyCommunicationAgent> agent)
       : myId_(myId), partnerId_(partnerId), agent_(std::move(agent)) {}
 
-  /**
-   * @inherit doc
-   */
-  std::vector<double> matrixVectorMultiplication(
+  std::pair<uint64_t, uint64_t> getNonEngineTrafficStatistics() const override {
+    return agent_->getTrafficStatistics();
+  }
+
+ protected:
+  std::vector<double> matrixVectorMultiplicationImpl(
       const std::vector<std::vector<double>>& features,
-      const frontend::Bit<true, schedulerId, true>& labels) const {
+      const frontend::Bit<true, schedulerId, true>& labels) const override {
     // Each features[i] represents a column vector of the feature matrix.
     // There are `nLabels` such column vectors.
     size_t nLabels = labels.getBatchSize();
@@ -75,12 +77,9 @@ class DummyMatrixMultiplication final
     return rst;
   }
 
-  /**
-   * @inherit doc
-   */
-  void matrixVectorMultiplication(
+  void matrixVectorMultiplicationImpl(
       const frontend::Bit<true, schedulerId, true>& labels,
-      const std::vector<double>& dpNoise) const {
+      const std::vector<double>& dpNoise) const override {
     labels.openToParty(partnerId_).getValue();
     agent_->sendT<double>(dpNoise);
   }

--- a/fbpcf/mpc_std_lib/walr_multiplication/DummyMatrixMultiplicationFactory.h
+++ b/fbpcf/mpc_std_lib/walr_multiplication/DummyMatrixMultiplicationFactory.h
@@ -25,13 +25,15 @@ class DummyMatrixMultiplicationFactory final
       : myId_(myId), partnerId_(partnerId), agentFactory_(agentFactory) {}
 
   std::unique_ptr<IWalrMatrixMultiplication<schedulerId>> create() override {
+    auto recorder = std::make_shared<WalrMatrixMultiplicationMetricRecorder>();
     return std::make_unique<DummyMatrixMultiplication<schedulerId>>(
         myId_,
         partnerId_,
         agentFactory_.create(
             partnerId_,
             "walr_matrix_multiplication_traffic_to_party " +
-                std::to_string(partnerId_)));
+                std::to_string(partnerId_)),
+        recorder);
   }
 
  private:

--- a/fbpcf/mpc_std_lib/walr_multiplication/DummyMatrixMultiplicationFactory.h
+++ b/fbpcf/mpc_std_lib/walr_multiplication/DummyMatrixMultiplicationFactory.h
@@ -17,15 +17,40 @@ namespace fbpcf::mpc_std_lib::walr::insecure {
 template <int schedulerId>
 class DummyMatrixMultiplicationFactory final
     : public IWalrMatrixMultiplicationFactory<schedulerId> {
+  using IWalrMatrixMultiplicationFactory<schedulerId>::metricCollector_;
+
  public:
+  const std::string metricRecorderNamePrefix = "dummy_matrix_multiplication";
+
+  // The following constructor will be deprecated once we updated all APP codes
   explicit DummyMatrixMultiplicationFactory(
       int myId,
       int partnerId,
       engine::communication::IPartyCommunicationAgentFactory& agentFactory)
-      : myId_(myId), partnerId_(partnerId), agentFactory_(agentFactory) {}
+      : IWalrMatrixMultiplicationFactory<schedulerId>(nullptr),
+        myId_(myId),
+        partnerId_(partnerId),
+        agentFactory_(agentFactory) {}
+
+  explicit DummyMatrixMultiplicationFactory(
+      int myId,
+      int partnerId,
+      engine::communication::IPartyCommunicationAgentFactory& agentFactory,
+      std::shared_ptr<fbpcf::util::MetricCollector> metricCollector)
+      : IWalrMatrixMultiplicationFactory<schedulerId>(metricCollector),
+        myId_(myId),
+        partnerId_(partnerId),
+        agentFactory_(agentFactory) {}
 
   std::unique_ptr<IWalrMatrixMultiplication<schedulerId>> create() override {
     auto recorder = std::make_shared<WalrMatrixMultiplicationMetricRecorder>();
+
+    // For backward compatibility we currently allow a null metric collector.
+    // The condition will be removed later when we change all apps to use a
+    // metric collector.
+    if (metricCollector_ != nullptr) {
+      metricCollector_->addNewRecorder(metricRecorderNamePrefix, recorder);
+    }
     return std::make_unique<DummyMatrixMultiplication<schedulerId>>(
         myId_,
         partnerId_,

--- a/fbpcf/mpc_std_lib/walr_multiplication/IWalrMatrixMultiplication.h
+++ b/fbpcf/mpc_std_lib/walr_multiplication/IWalrMatrixMultiplication.h
@@ -12,8 +12,35 @@
 
 #include "fbpcf/frontend/Bit.h"
 #include "fbpcf/scheduler/IScheduler.h"
+#include "fbpcf/util/IMetricRecorder.h"
 
 namespace fbpcf::mpc_std_lib::walr {
+
+/**
+ * The metric recorder for the IWalrMatrixMultiplication class
+ */
+class WalrMatrixMultiplicationMetricRecorder
+    : public fbpcf::util::IMetricRecorder {
+ public:
+  WalrMatrixMultiplicationMetricRecorder()
+      : featuresSent_(0), featuresReceived_(0) {}
+
+  void addFeaturesSent(uint64_t size) {
+    featuresSent_ += size;
+  }
+  void addFeaturesReceived(uint64_t size) {
+    featuresReceived_ += size;
+  }
+
+  folly::dynamic getMetrics() const override {
+    return folly::dynamic::object("features_sent", featuresSent_.load())(
+        "features_received", featuresReceived_.load());
+  }
+
+ protected:
+  std::atomic_uint64_t featuresSent_;
+  std::atomic_uint64_t featuresReceived_;
+};
 
 template <int schedulerId>
 class IWalrMatrixMultiplication {

--- a/fbpcf/mpc_std_lib/walr_multiplication/IWalrMatrixMultiplication.h
+++ b/fbpcf/mpc_std_lib/walr_multiplication/IWalrMatrixMultiplication.h
@@ -7,9 +7,11 @@
 
 #pragma once
 
+#include <cstdint>
 #include <vector>
 
 #include "fbpcf/frontend/Bit.h"
+#include "fbpcf/scheduler/IScheduler.h"
 
 namespace fbpcf::mpc_std_lib::walr {
 
@@ -29,18 +31,78 @@ class IWalrMatrixMultiplication {
    * labels.getBatchSize().
    * @return the product of feature matrix and the label vector.
    */
-  virtual std::vector<double> matrixVectorMultiplication(
+  std::vector<double> matrixVectorMultiplication(
       const std::vector<std::vector<double>>& features,
-      const frontend::Bit<true, schedulerId, true>& labels) const = 0;
+      const frontend::Bit<true, schedulerId, true>& labels) {
+    // Initialize engine traffic recording
+    auto initEngineTraffic =
+        scheduler::SchedulerKeeper<schedulerId>::getTrafficStatistics();
+
+    auto rst = matrixVectorMultiplicationImpl(features, labels);
+
+    // Calculate engine traffic
+    auto finalEngineTraffic =
+        scheduler::SchedulerKeeper<schedulerId>::getTrafficStatistics();
+    engineTraffic_.first += finalEngineTraffic.first - initEngineTraffic.first;
+    engineTraffic_.second +=
+        finalEngineTraffic.second - initEngineTraffic.second;
+
+    return rst;
+  }
 
   /**
    * The API for the caller with only label shares.
    * @param labels: the label vector consisting of only (secret) boolean labels.
    * @param dpNoise: the dp noise that would be imposed on the output.
    */
-  virtual void matrixVectorMultiplication(
+  void matrixVectorMultiplication(
+      const frontend::Bit<true, schedulerId, true>& labels,
+      const std::vector<double>& dpNoise) {
+    // Initialize engine traffic recording
+    auto initEngineTraffic =
+        scheduler::SchedulerKeeper<schedulerId>::getTrafficStatistics();
+
+    matrixVectorMultiplicationImpl(labels, dpNoise);
+
+    // Calculate engine traffic
+    auto finalEngineTraffic =
+        scheduler::SchedulerKeeper<schedulerId>::getTrafficStatistics();
+    engineTraffic_.first += finalEngineTraffic.first - initEngineTraffic.first;
+    engineTraffic_.second +=
+        finalEngineTraffic.second - initEngineTraffic.second;
+  }
+
+  /**
+   * Get the total amount of traffic transmitted.
+   * @return a pair of (sent, received) data in bytes.
+   */
+  std::pair<uint64_t, uint64_t> getTrafficStatistics() const {
+    auto nonEngineTraffic = getNonEngineTrafficStatistics();
+    return {
+        engineTraffic_.first + nonEngineTraffic.first,
+        engineTraffic_.second + nonEngineTraffic.second};
+  }
+
+  /**
+   * Get the total amount of non-engine traffic transmitted.
+   * @return a pair of (sent, received) data in bytes.
+   */
+  virtual std::pair<uint64_t, uint64_t> getNonEngineTrafficStatistics()
+      const = 0;
+
+ protected:
+  // The implementation API for the caller with feature and label shares.
+  virtual std::vector<double> matrixVectorMultiplicationImpl(
+      const std::vector<std::vector<double>>& features,
+      const frontend::Bit<true, schedulerId, true>& labels) const = 0;
+
+  // The implementation API for the caller with only label shares.
+  virtual void matrixVectorMultiplicationImpl(
       const frontend::Bit<true, schedulerId, true>& labels,
       const std::vector<double>& dpNoise) const = 0;
+
+ private:
+  std::pair<uint64_t, uint64_t> engineTraffic_{0, 0};
 };
 
 } // namespace fbpcf::mpc_std_lib::walr

--- a/fbpcf/mpc_std_lib/walr_multiplication/IWalrMatrixMultiplicationFactory.h
+++ b/fbpcf/mpc_std_lib/walr_multiplication/IWalrMatrixMultiplicationFactory.h
@@ -8,13 +8,21 @@
 #pragma once
 
 #include "fbpcf/mpc_std_lib/walr_multiplication/IWalrMatrixMultiplication.h"
+#include "fbpcf/util/MetricCollector.h"
+
 namespace fbpcf::mpc_std_lib::walr {
 
 template <int schedulerId>
 class IWalrMatrixMultiplicationFactory {
  public:
+  explicit IWalrMatrixMultiplicationFactory(
+      std::shared_ptr<fbpcf::util::MetricCollector> metricCollector)
+      : metricCollector_(metricCollector) {}
   virtual ~IWalrMatrixMultiplicationFactory() = default;
   virtual std::unique_ptr<IWalrMatrixMultiplication<schedulerId>> create() = 0;
+
+ protected:
+  std::shared_ptr<fbpcf::util::MetricCollector> metricCollector_;
 };
 
 } // namespace fbpcf::mpc_std_lib::walr

--- a/fbpcf/mpc_std_lib/walr_multiplication/OTBasedMatrixMultiplication.h
+++ b/fbpcf/mpc_std_lib/walr_multiplication/OTBasedMatrixMultiplication.h
@@ -47,19 +47,22 @@ class OTBasedMatrixMultiplication final
     numberMapper_.setDivisor(divisor);
   }
 
-  /**
-   * @inherit doc
-   */
-  std::vector<double> matrixVectorMultiplication(
-      const std::vector<std::vector<double>>& features,
-      const frontend::Bit<true, schedulerId, true>& labels) const;
+  std::pair<uint64_t, uint64_t> getNonEngineTrafficStatistics() const override {
+    auto cotWRMTraffic = cotWRM_->getTrafficStatistics();
+    auto otherTraffic = agent_->getTrafficStatistics();
+    return {
+        cotWRMTraffic.first + otherTraffic.first,
+        cotWRMTraffic.second + otherTraffic.second};
+  }
 
-  /**
-   * @inherit doc
-   */
-  void matrixVectorMultiplication(
+ protected:
+  std::vector<double> matrixVectorMultiplicationImpl(
+      const std::vector<std::vector<double>>& features,
+      const frontend::Bit<true, schedulerId, true>& labels) const override;
+
+  void matrixVectorMultiplicationImpl(
       const frontend::Bit<true, schedulerId, true>& labels,
-      const std::vector<double>& dpNoise) const;
+      const std::vector<double>& dpNoise) const override;
 
  private:
   int myId_;

--- a/fbpcf/mpc_std_lib/walr_multiplication/OTBasedMatrixMultiplicationFactory.h
+++ b/fbpcf/mpc_std_lib/walr_multiplication/OTBasedMatrixMultiplicationFactory.h
@@ -61,6 +61,8 @@ class OTBasedMatrixMultiplicationFactory final
           cotWRMFactory_->create(std::move(cotWRMAgent), std::move(rcotAgent));
     }
 
+    auto recorder =
+        std::make_shared<OTBasedMatrixMultiplicationMetricRecorder>();
     return std::make_unique<
         OTBasedMatrixMultiplication<schedulerId, FixedPointType>>(
         myId_,
@@ -72,7 +74,8 @@ class OTBasedMatrixMultiplicationFactory final
             "walr_matrix_multiplication_traffic_to_party " +
                 std::to_string(partnerId_)),
         std::move(prgFactory_),
-        std::move(cotWRM));
+        std::move(cotWRM),
+        recorder);
   }
 
  private:

--- a/fbpcf/mpc_std_lib/walr_multiplication/OTBasedMatrixMultiplication_impl.h
+++ b/fbpcf/mpc_std_lib/walr_multiplication/OTBasedMatrixMultiplication_impl.h
@@ -17,7 +17,7 @@ namespace fbpcf::mpc_std_lib::walr {
 
 template <int schedulerId, typename FixedPointType>
 std::vector<double> OTBasedMatrixMultiplication<schedulerId, FixedPointType>::
-    matrixVectorMultiplication(
+    matrixVectorMultiplicationImpl(
         const std::vector<std::vector<double>>& features,
         const frontend::Bit<true, schedulerId, true>& labels) const {
   if (!isFeatureOwner_) {
@@ -151,7 +151,7 @@ std::vector<double> OTBasedMatrixMultiplication<schedulerId, FixedPointType>::
 
 template <int schedulerId, typename FixedPointType>
 void OTBasedMatrixMultiplication<schedulerId, FixedPointType>::
-    matrixVectorMultiplication(
+    matrixVectorMultiplicationImpl(
         const frontend::Bit<true, schedulerId, true>& labels,
         const std::vector<double>& dpNoise) const {
   if (isFeatureOwner_) {

--- a/fbpcf/mpc_std_lib/walr_multiplication/util/COTWithRandomMessage.h
+++ b/fbpcf/mpc_std_lib/walr_multiplication/util/COTWithRandomMessage.h
@@ -61,7 +61,11 @@ class COTWithRandomMessage {
    * @return a pair of (sent, received) data in bytes.
    */
   std::pair<uint64_t, uint64_t> getTrafficStatistics() const {
-    return agent_->getTrafficStatistics();
+    auto rcotTraffic = rcot_->getTrafficStatistics();
+    auto nonRcotTraffic = agent_->getTrafficStatistics();
+    return {
+        rcotTraffic.first + nonRcotTraffic.first,
+        rcotTraffic.second + nonRcotTraffic.second};
   }
 
  private:


### PR DESCRIPTION
Summary:
## Why
To support logging using metric collector for the matrix multiplication classes.

## What
We add new constructors for `DummyMatrixMultiplicationFactory` and `OTBasedMatrixMultiplicationFactory`, such that they can accept a metric collector argument.

Reviewed By: adshastri

Differential Revision: D39712334

