### PR TITLE
Add metric recorder for WALR matrix multiplication

### DIFF
--- a/fbpcf/mpc_std_lib/walr_multiplication/DummyMatrixMultiplicationFactory.h
+++ b/fbpcf/mpc_std_lib/walr_multiplication/DummyMatrixMultiplicationFactory.h
@@ -25,13 +25,15 @@ class DummyMatrixMultiplicationFactory final
       : myId_(myId), partnerId_(partnerId), agentFactory_(agentFactory) {}
 
   std::unique_ptr<IWalrMatrixMultiplication<schedulerId>> create() override {
+    auto recorder = std::make_shared<WalrMatrixMultiplicationMetricRecorder>();
     return std::make_unique<DummyMatrixMultiplication<schedulerId>>(
         myId_,
         partnerId_,
         agentFactory_.create(
             partnerId_,
             "walr_matrix_multiplication_traffic_to_party " +
-                std::to_string(partnerId_)));
+                std::to_string(partnerId_)),
+        recorder);
   }
 
  private:

--- a/fbpcf/mpc_std_lib/walr_multiplication/IWalrMatrixMultiplication.h
+++ b/fbpcf/mpc_std_lib/walr_multiplication/IWalrMatrixMultiplication.h
@@ -12,8 +12,35 @@
 
 #include "fbpcf/frontend/Bit.h"
 #include "fbpcf/scheduler/IScheduler.h"
+#include "fbpcf/util/IMetricRecorder.h"
 
 namespace fbpcf::mpc_std_lib::walr {
+
+/**
+ * The metric recorder for the IWalrMatrixMultiplication class
+ */
+class WalrMatrixMultiplicationMetricRecorder
+    : public fbpcf::util::IMetricRecorder {
+ public:
+  WalrMatrixMultiplicationMetricRecorder()
+      : featuresSent_(0), featuresReceived_(0) {}
+
+  void addFeaturesSent(uint64_t size) {
+    featuresSent_ += size;
+  }
+  void addFeaturesReceived(uint64_t size) {
+    featuresReceived_ += size;
+  }
+
+  folly::dynamic getMetrics() const override {
+    return folly::dynamic::object("features_sent", featuresSent_.load())(
+        "features_received", featuresReceived_.load());
+  }
+
+ protected:
+  std::atomic_uint64_t featuresSent_;
+  std::atomic_uint64_t featuresReceived_;
+};
 
 template <int schedulerId>
 class IWalrMatrixMultiplication {

--- a/fbpcf/mpc_std_lib/walr_multiplication/OTBasedMatrixMultiplicationFactory.h
+++ b/fbpcf/mpc_std_lib/walr_multiplication/OTBasedMatrixMultiplicationFactory.h
@@ -61,6 +61,8 @@ class OTBasedMatrixMultiplicationFactory final
           cotWRMFactory_->create(std::move(cotWRMAgent), std::move(rcotAgent));
     }
 
+    auto recorder =
+        std::make_shared<OTBasedMatrixMultiplicationMetricRecorder>();
     return std::make_unique<
         OTBasedMatrixMultiplication<schedulerId, FixedPointType>>(
         myId_,
@@ -72,7 +74,8 @@ class OTBasedMatrixMultiplicationFactory final
             "walr_matrix_multiplication_traffic_to_party " +
                 std::to_string(partnerId_)),
         std::move(prgFactory_),
-        std::move(cotWRM));
+        std::move(cotWRM),
+        recorder);
   }
 
  private:


### PR DESCRIPTION
Summary:
## Why

To support better metrics collection.

## What

Add a metric recorder for the WALR matrix multiplication classes.

Reviewed By: adshastri

Differential Revision: D39633470

