### PR TITLE
Pass metric collectors into apps

### DIFF
--- a/example/edit_distance/MainUtil.h
+++ b/example/edit_distance/MainUtil.h
@@ -33,7 +33,10 @@ void startEditDistanceGame(
 
   auto communicationAgentFactory = std::make_unique<
       fbpcf::engine::communication::SocketPartyCommunicationAgentFactory>(
-      MyRole, partyInfos, tlsInfo, "Edit Distance Traffic for main thread");
+      MyRole,
+      partyInfos,
+      tlsInfo,
+      std::make_shared<fbpcf::util::MetricCollector>("edit_distance_metrics"));
 
   XLOG(INFO, "Creating Edit Distance App");
 

--- a/fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h
+++ b/fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h
@@ -104,7 +104,7 @@ establishing multiple connections (>3) between each party pair.
     setupInitialConnection(partyInfos);
   }
 
-  SocketPartyCommunicationAgentFactory(
+  [[deprecated("Use the constructor with metricCollector instead.")]] SocketPartyCommunicationAgentFactory(
       int myId,
       std::map<int, PartyInfo> partyInfos,
       SocketPartyCommunicationAgent::TlsInfo tlsInfo,

--- a/fbpcf/engine/util/test/benchmarks/BenchmarkHelper.h
+++ b/fbpcf/engine/util/test/benchmarks/BenchmarkHelper.h
@@ -57,11 +57,17 @@ getSocketAgents() {
   auto factory1Future = std::async([&partyInfo1, &tlsInfo]() {
     return std::make_unique<
         communication::SocketPartyCommunicationAgentFactory>(
-        1, partyInfo1, tlsInfo, "party_1_unit_test_traffic");
+        1,
+        partyInfo1,
+        std::make_shared<fbpcf::util::MetricCollector>(
+            "party_1_unit_test_metrics"));
   });
   auto factory0 =
       std::make_unique<communication::SocketPartyCommunicationAgentFactory>(
-          0, partyInfo0, tlsInfo, "party_0_unit_test_traffic");
+          0,
+          partyInfo0,
+          std::make_shared<fbpcf::util::MetricCollector>(
+              "party_0_unit_test_metrics"));
   auto factory1 = factory1Future.get();
 
   auto task = [](std::unique_ptr<communication::IPartyCommunicationAgentFactory>


### PR DESCRIPTION
Summary:
- Pass metric collectors into the apps: shard combiner, aggregation, attribution, and calculator
- Remove callsites to old SocketPartyCommunicationAgent constructors that takes a string "myname" as argument
- mark the old constructors as deprecated
-

Reviewed By: adshastri

Differential Revision: D39591456

