### PR TITLE
Add parameter check to Single and Multi-Point COT

### DIFF
--- a/fbpcf/engine/tuple_generator/oblivious_transfer/ferret/DummyMultiPointCot.cpp
+++ b/fbpcf/engine/tuple_generator/oblivious_transfer/ferret/DummyMultiPointCot.cpp
@@ -20,6 +20,9 @@ void DummyMultiPointCot::senderInit(
     __m128i delta,
     int64_t length,
     int64_t weight) {
+  if (!util::getLsb(delta)) {
+    throw std::invalid_argument("The LSB of delta must be 1.");
+  }
   delta_ = delta;
   length_ = length;
   weight_ = weight;

--- a/fbpcf/engine/tuple_generator/oblivious_transfer/ferret/DummySinglePointCot.cpp
+++ b/fbpcf/engine/tuple_generator/oblivious_transfer/ferret/DummySinglePointCot.cpp
@@ -17,6 +17,9 @@
 namespace fbpcf::engine::tuple_generator::oblivious_transfer::ferret::insecure {
 
 void DummySinglePointCot::senderInit(__m128i delta) {
+  if (!util::getLsb(delta)) {
+    throw std::invalid_argument("The LSB of delta must be 1.");
+  }
   delta_ = delta;
   role_ = util::Role::sender;
 }

--- a/fbpcf/engine/tuple_generator/oblivious_transfer/ferret/RegularErrorMultiPointCot.cpp
+++ b/fbpcf/engine/tuple_generator/oblivious_transfer/ferret/RegularErrorMultiPointCot.cpp
@@ -34,6 +34,9 @@ void RegularErrorMultiPointCot::senderInit(
     __m128i delta,
     int64_t length,
     int64_t weight) {
+  if (!util::getLsb(delta)) {
+    throw std::invalid_argument("The LSB of delta must be 1.");
+  }
   init(length, weight);
   role_ = util::Role::sender;
   delta_ = delta;

--- a/fbpcf/engine/tuple_generator/oblivious_transfer/ferret/SinglePointCot.cpp
+++ b/fbpcf/engine/tuple_generator/oblivious_transfer/ferret/SinglePointCot.cpp
@@ -8,6 +8,7 @@
 #include <emmintrin.h>
 #include <string.h>
 #include <memory>
+#include <stdexcept>
 
 #include "fbpcf/engine/tuple_generator/oblivious_transfer/ferret/SinglePointCot.h"
 #include "fbpcf/engine/util/util.h"
@@ -61,6 +62,9 @@ std::vector<__m128i> SinglePointCot::constructALayerOfKeyForReceiver(
 }
 
 void SinglePointCot::senderInit(__m128i delta) {
+  if (!util::getLsb(delta)) {
+    throw std::invalid_argument("The LSB of delta must be 1.");
+  }
   delta_ = delta;
   role_ = util::Role::sender;
 }


### PR DESCRIPTION
Summary:
## Why
The current Single and Multi-Point COT implementation requires a parameter `delta` with LSB=1. However, when they accept an invalid `delta`, they do not raise any errors and just silently output incorrect result. This makes debugging quite difficult.

## What
We make the COTs throw an exception when receiving invalid `delta`.

Reviewed By: adshastri

Differential Revision: D39750694

