### PR TITLE
Adding timeout on client side

### DIFF
--- a/fbpcf/engine/communication/SocketPartyCommunicationAgent.cpp
+++ b/fbpcf/engine/communication/SocketPartyCommunicationAgent.cpp
@@ -59,7 +59,9 @@ SocketPartyCommunicationAgent::SocketPartyCommunicationAgent(
     bool useTls,
     std::string tlsDir,
     std::shared_ptr<PartyCommunicationAgentTrafficRecorder> recorder)
-    : recorder_(recorder), ssl_(nullptr) {
+    : recorder_(recorder),
+      ssl_(nullptr),
+      timeoutInSec_(1800 /* use a defaule value to avoid error*/) {
   if (useTls) {
     openServerPortWithTls(sockFd, portNo, tlsDir);
   } else {
@@ -71,8 +73,12 @@ SocketPartyCommunicationAgent::SocketPartyCommunicationAgent(
     int sockFd,
     int portNo,
     TlsInfo tlsInfo,
-    std::shared_ptr<PartyCommunicationAgentTrafficRecorder> recorder)
-    : recorder_(recorder), ssl_(nullptr), tlsInfo_(tlsInfo) {
+    std::shared_ptr<PartyCommunicationAgentTrafficRecorder> recorder,
+    int timeoutInSec)
+    : recorder_(recorder),
+      ssl_(nullptr),
+      tlsInfo_(tlsInfo),
+      timeoutInSec_(timeoutInSec) {
   if (tlsInfo.useTls) {
     openServerPortWithTls(sockFd, portNo, tlsInfo);
   } else {
@@ -86,7 +92,9 @@ SocketPartyCommunicationAgent::SocketPartyCommunicationAgent(
     bool useTls,
     std::string tlsDir,
     std::shared_ptr<PartyCommunicationAgentTrafficRecorder> recorder)
-    : recorder_(recorder), ssl_(nullptr) {
+    : recorder_(recorder),
+      ssl_(nullptr),
+      timeoutInSec_(1800 /* use a defaule value to avoid error*/) {
   if (useTls) {
     openClientPortWithTls(serverAddress, portNo, tlsDir);
   } else {
@@ -98,8 +106,12 @@ SocketPartyCommunicationAgent::SocketPartyCommunicationAgent(
     const std::string& serverAddress,
     int portNo,
     TlsInfo tlsInfo,
-    std::shared_ptr<PartyCommunicationAgentTrafficRecorder> recorder)
-    : recorder_(recorder), ssl_(nullptr), tlsInfo_(tlsInfo) {
+    std::shared_ptr<PartyCommunicationAgentTrafficRecorder> recorder,
+    int timeoutInSec)
+    : recorder_(recorder),
+      ssl_(nullptr),
+      tlsInfo_(tlsInfo),
+      timeoutInSec_(timeoutInSec) {
   if (tlsInfo.useTls) {
     openClientPortWithTls(serverAddress, portNo, tlsInfo);
   } else {

--- a/fbpcf/engine/communication/SocketPartyCommunicationAgent.h
+++ b/fbpcf/engine/communication/SocketPartyCommunicationAgent.h
@@ -42,7 +42,8 @@ class SocketPartyCommunicationAgent final : public IPartyCommunicationAgent {
       int sockFd,
       int portNo,
       TlsInfo tlsInfo,
-      std::shared_ptr<PartyCommunicationAgentTrafficRecorder> recorder);
+      std::shared_ptr<PartyCommunicationAgentTrafficRecorder> recorder,
+      int timeoutInSec);
 
   /**
    * Created as socket client, optionally with TLS.
@@ -58,7 +59,8 @@ class SocketPartyCommunicationAgent final : public IPartyCommunicationAgent {
       const std::string& serverAddress,
       int portNo,
       TlsInfo tlsInfo,
-      std::shared_ptr<PartyCommunicationAgentTrafficRecorder> recorder);
+      std::shared_ptr<PartyCommunicationAgentTrafficRecorder> recorder,
+      int timeoutInSec);
 
   ~SocketPartyCommunicationAgent() override;
 
@@ -100,6 +102,8 @@ class SocketPartyCommunicationAgent final : public IPartyCommunicationAgent {
 
   SSL* ssl_;
   TlsInfo tlsInfo_;
+
+  int timeoutInSec_;
 };
 
 } // namespace fbpcf::engine::communication

--- a/fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.cpp
+++ b/fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.cpp
@@ -33,11 +33,15 @@ SocketPartyCommunicationAgentFactory::create(int id, std::string name) {
       auto [socket, portNo] = createSocketFromMaybeFreePort(assignedPortNo);
       iter->second.second->sendSingleT<int>(portNo);
       return std::make_unique<SocketPartyCommunicationAgent>(
-          socket, portNo, tlsInfo_, recorder);
+          socket, portNo, tlsInfo_, recorder, timeoutInSec_);
     } else {
       auto portNo = iter->second.second->receiveSingleT<int>();
       return std::make_unique<SocketPartyCommunicationAgent>(
-          iter->second.first.address, portNo, tlsInfo_, recorder);
+          iter->second.first.address,
+          portNo,
+          tlsInfo_,
+          recorder,
+          timeoutInSec_);
     }
   }
 }
@@ -131,7 +135,8 @@ void SocketPartyCommunicationAgentFactory::setupInitialConnection(
                    sockets_.at(partyId),
                    partyInfo.portNo,
                    tlsInfo_,
-                   recorder))});
+                   recorder,
+                   timeoutInSec_))});
 
     } else if (myId_ > partyId) {
       auto recorder =
@@ -144,7 +149,11 @@ void SocketPartyCommunicationAgentFactory::setupInitialConnection(
            std::make_pair(
                partyInfo,
                std::make_unique<SocketPartyCommunicationAgent>(
-                   partyInfo.address, partyInfo.portNo, tlsInfo_, recorder))});
+                   partyInfo.address,
+                   partyInfo.portNo,
+                   tlsInfo_,
+                   recorder,
+                   timeoutInSec_))});
     }
   }
 }

--- a/fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h
+++ b/fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h
@@ -53,7 +53,8 @@ establishing multiple connections (>3) between each party pair.
         myId_(myId),
         useTls_(false),
         tlsDir_(""),
-        partyInfos_(partyInfos) {
+        partyInfos_(partyInfos),
+        timeoutInSec_(1800 /* add a default value to avoid error*/) {
     SocketPartyCommunicationAgent::TlsInfo tlsInfo;
     tlsInfo.useTls = false;
     tlsInfo.certPath = "";
@@ -72,7 +73,8 @@ establishing multiple connections (>3) between each party pair.
         myId_(myId),
         useTls_(false),
         tlsDir_(""),
-        partyInfos_(partyInfos) {
+        partyInfos_(partyInfos),
+        timeoutInSec_(1800 /* add a default value to avoid error*/) {
     SocketPartyCommunicationAgent::TlsInfo tlsInfo;
     tlsInfo.useTls = false;
     tlsInfo.certPath = "";
@@ -93,7 +95,8 @@ establishing multiple connections (>3) between each party pair.
         myId_(myId),
         useTls_(useTls),
         tlsDir_(tlsDir),
-        partyInfos_(partyInfos) {
+        partyInfos_(partyInfos),
+        timeoutInSec_(1800 /* add a default value to avoid error*/) {
     SocketPartyCommunicationAgent::TlsInfo tlsInfo;
     tlsInfo.useTls = useTls;
     tlsInfo.certPath = tlsDir + "/cert.pem";
@@ -112,7 +115,8 @@ establishing multiple connections (>3) between each party pair.
       : IPartyCommunicationAgentFactory(myname),
         myId_(myId),
         tlsInfo_(tlsInfo),
-        partyInfos_(partyInfos) {
+        partyInfos_(partyInfos),
+        timeoutInSec_(1800 /* add a default value to avoid error*/) {
     setupInitialSockets(partyInfos);
     setupInitialConnection(partyInfos);
   }
@@ -125,7 +129,23 @@ establishing multiple connections (>3) between each party pair.
       : IPartyCommunicationAgentFactory(metricCollector),
         myId_(myId),
         tlsInfo_(tlsInfo),
-        partyInfos_(partyInfos) {
+        partyInfos_(partyInfos),
+        timeoutInSec_(1800 /* add a default value to avoid error*/) {
+    setupInitialSockets(partyInfos);
+    setupInitialConnection(partyInfos);
+  }
+
+  SocketPartyCommunicationAgentFactory(
+      int myId,
+      std::map<int, PartyInfo> partyInfos,
+      SocketPartyCommunicationAgent::TlsInfo tlsInfo,
+      std::shared_ptr<fbpcf::util::MetricCollector> metricCollector,
+      int timeoutInSec)
+      : IPartyCommunicationAgentFactory(metricCollector),
+        myId_(myId),
+        tlsInfo_(tlsInfo),
+        partyInfos_(partyInfos),
+        timeoutInSec_(timeoutInSec) {
     setupInitialSockets(partyInfos);
     setupInitialConnection(partyInfos);
   }
@@ -151,7 +171,8 @@ establishing multiple connections (>3) between each party pair.
       : IPartyCommunicationAgentFactory(metricCollector),
         myId_(myId),
         tlsInfo_(tlsInfo),
-        partyInfos_(partyInfos) {
+        partyInfos_(partyInfos),
+        timeoutInSec_(300 /* default value for test only */) {
     setupInitialSockets(partyInfos);
   }
 
@@ -184,6 +205,8 @@ establishing multiple connections (>3) between each party pair.
 
   SocketPartyCommunicationAgent::TlsInfo tlsInfo_;
   std::map<int, PartyInfo> partyInfos_;
+
+  int timeoutInSec_;
 };
 
 } // namespace fbpcf::engine::communication


### PR DESCRIPTION
Summary:
# Why
See last diff, this is a follow-up on S291746

# This diff

This diff add a timeout mechanism when creating a connection as the client.
The client will try to connect to the given server repeatedly. it will retry after a wait if an attempt failed. This diff specifies that the wait time is 100ms and number of retry is limited to 10 * timeout_time_in_secs.

Reviewed By: adshastri

Differential Revision: D39562698

