### PR TITLE
Update the FBPCF docker publish pipelines to publish new Major and Minor tags of the ubuntu docker image.

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -107,6 +107,9 @@ jobs:
     - name: Tag Docker image
       run: |
         docker tag ${{ env.REGISTRY_IMAGE_NAME }}:${{ github.sha }} ${{ env.REGISTRY_IMAGE_NAME }}:${{ steps.vars.outputs.ref }}
+        docker tag ${{ env.REGISTRY_IMAGE_NAME }}:${{ github.sha }} ${{ env.REGISTRY_IMAGE_NAME }}:${{ steps.create_version.outputs.major }}
+        docker tag ${{ env.REGISTRY_IMAGE_NAME }}:${{ github.sha }} ${{ env.REGISTRY_IMAGE_NAME }}:${{ steps.create_version.outputs.major }}.${{ steps.create_version.outputs.minor }}
+        docker tag ${{ env.REGISTRY_IMAGE_NAME }}:${{ github.sha }} ${{ env.REGISTRY_IMAGE_NAME }}:${{ steps.create_version.outputs.major }}.${{ steps.create_version.outputs.minor }}.${{ steps.create_version.outputs.patch }}
         docker tag ${{ env.REGISTRY_IMAGE_NAME }}:${{ github.sha }} ${{ env.REGISTRY_IMAGE_NAME }}:${{ steps.create_version.outputs.version_tag }}
         docker tag ${{ env.REGISTRY_IMAGE_NAME }}:${{ github.sha }} ${{ env.REGISTRY_IMAGE_NAME }}:latest
 


### PR DESCRIPTION
Summary:
## Background
We are making preparations to pin the FBPCF version in the FBPCS repository and build. As part of this, we want the ability to pin at not only the patch version, but even at the minor or major version. The create_version step that is used already outputs all of the values https://github.com/PaulHatch/semantic-version#outputs.

## This change
This change just updates the FBPCF docker image to match the standard Docker practice of publishing tags for each of the major, minor and patch versions for an image. This allows users to say they want `fbpcf:2.1` and they will get the latest patch version of `fbpcf:2.1.64`, but they will never get anything that is `2.2+`. The create_version step that is used already outputs all of the values https://github.com/PaulHatch/semantic-version#outputs, so I am using those for the tagging.

Examples of the new tags:

For the release of 2.1.66, we will have the four existing tags (latest, main, the commit hash, and 2.1.66) and now we will also tag it with 2 and 2.1.

Reviewed By: adshastri, gitfish77

Differential Revision: D39943915

