### PR TITLE
Adding a API to delete engine in scheduler

### DIFF
--- a/fbpcf/frontend/test/schedulerMock.h
+++ b/fbpcf/frontend/test/schedulerMock.h
@@ -337,6 +337,8 @@ class schedulerMock final : public scheduler::IScheduler {
           WireId<Boolean>,
           std::shared_ptr<std::vector<uint32_t>>));
 
+  MOCK_METHOD0(deleteEngine, void());
+
   std::pair<uint64_t, uint64_t> getTrafficStatistics() const override {
     return {0, 0};
   }

--- a/fbpcf/scheduler/EagerScheduler.cpp
+++ b/fbpcf/scheduler/EagerScheduler.cpp
@@ -665,7 +665,11 @@ std::vector<IScheduler::WireId<IScheduler::Boolean>> EagerScheduler::unbatching(
 }
 
 std::pair<uint64_t, uint64_t> EagerScheduler::getTrafficStatistics() const {
-  return engine_->getTrafficStatistics();
+  if (engine_) {
+    return engine_->getTrafficStatistics();
+  } else {
+    return engineTrafficStatisticsBuffer_;
+  }
 }
 
 size_t EagerScheduler::getBatchSize(
@@ -676,6 +680,11 @@ size_t EagerScheduler::getBatchSize(
 size_t EagerScheduler::getBatchSize(
     IScheduler::WireId<IScheduler::Arithmetic> id) const {
   return wireKeeper_->getBatchSize(id);
+}
+
+void EagerScheduler::deleteEngine() {
+  engineTrafficStatisticsBuffer_ = engine_->getTrafficStatistics();
+  engine_.reset(nullptr);
 }
 
 } // namespace fbpcf::scheduler

--- a/fbpcf/scheduler/EagerScheduler.h
+++ b/fbpcf/scheduler/EagerScheduler.h
@@ -530,8 +530,11 @@ class EagerScheduler final : public IArithmeticScheduler {
   size_t getBatchSize(
       IScheduler::WireId<IScheduler::Arithmetic> id) const override;
 
+  void deleteEngine() override;
+
  private:
   std::unique_ptr<engine::ISecretShareEngine> engine_;
+  std::pair<uint64_t, uint64_t> engineTrafficStatisticsBuffer_;
   std::unique_ptr<IWireKeeper> wireKeeper_;
   std::shared_ptr<util::MetricCollector> collector_;
 };

--- a/fbpcf/scheduler/IScheduler.h
+++ b/fbpcf/scheduler/IScheduler.h
@@ -386,6 +386,13 @@ class IScheduler {
   virtual size_t getBatchSize(
       IScheduler::WireId<IScheduler::Arithmetic> id) const = 0;
 
+  /*
+   * Waiting for all the computations in the engine to finish and delete the
+   * engine. This API should be called before retrieving the metrics for the
+   * last time to avoid race condition.
+   */
+  virtual void deleteEngine() = 0;
+
  protected:
   uint64_t nonFreeGates_ = 0;
   uint64_t freeGates_ = 0;
@@ -421,6 +428,10 @@ class SchedulerKeeper {
  public:
   static void setScheduler(std::unique_ptr<IScheduler> scheduler) {
     scheduler_ = std::move(scheduler);
+  }
+
+  static void deleteEngine() {
+    scheduler_->deleteEngine();
   }
 
   static void freeScheduler() {

--- a/fbpcf/scheduler/LazyScheduler.cpp
+++ b/fbpcf/scheduler/LazyScheduler.cpp
@@ -571,7 +571,11 @@ void LazyScheduler::decreaseReferenceCountBatch(
 }
 
 std::pair<uint64_t, uint64_t> LazyScheduler::getTrafficStatistics() const {
-  return engine_->getTrafficStatistics();
+  if (engine_) {
+    return engine_->getTrafficStatistics();
+  } else {
+    return engineTrafficStatisticsBuffer_;
+  }
 }
 
 // band a number of batches into one batch.
@@ -672,6 +676,11 @@ size_t LazyScheduler::getBatchSize(
 size_t LazyScheduler::getBatchSize(
     IScheduler::WireId<IScheduler::Arithmetic> id) const {
   return wireKeeper_->getBatchSize(id);
+}
+
+void LazyScheduler::deleteEngine() {
+  engineTrafficStatisticsBuffer_ = engine_->getTrafficStatistics();
+  engine_ = nullptr;
 }
 
 } // namespace fbpcf::scheduler

--- a/fbpcf/scheduler/LazyScheduler.h
+++ b/fbpcf/scheduler/LazyScheduler.h
@@ -533,8 +533,12 @@ class LazyScheduler final : public IArithmeticScheduler {
   size_t getBatchSize(
       IScheduler::WireId<IScheduler::Arithmetic> id) const override;
 
+  void deleteEngine() override;
+
  private:
   std::unique_ptr<engine::ISecretShareEngine> engine_;
+  std::pair<uint64_t, uint64_t> engineTrafficStatisticsBuffer_;
+
   std::shared_ptr<IWireKeeper> wireKeeper_;
   std::unique_ptr<IGateKeeper> gateKeeper_;
   std::shared_ptr<util::MetricCollector> collector_;

--- a/fbpcf/scheduler/NetworkPlaintextScheduler.h
+++ b/fbpcf/scheduler/NetworkPlaintextScheduler.h
@@ -135,6 +135,8 @@ class NetworkPlaintextScheduler final : public PlaintextScheduler {
   size_t getBatchSize(
       IScheduler::WireId<IScheduler::Arithmetic> id) const override;
 
+  void deleteEngine() override {}
+
  private:
   int myId_;
   std::

--- a/fbpcf/scheduler/PlaintextScheduler.h
+++ b/fbpcf/scheduler/PlaintextScheduler.h
@@ -534,6 +534,8 @@ class PlaintextScheduler : public IArithmeticScheduler {
   size_t getBatchSize(
       IScheduler::WireId<IScheduler::Arithmetic> id) const override;
 
+  void deleteEngine() override {}
+
  protected:
   std::unique_ptr<IWireKeeper> wireKeeper_;
   std::shared_ptr<util::MetricCollector> collector_;

--- a/fbpcf/scheduler/test/SchedulerTest.cpp
+++ b/fbpcf/scheduler/test/SchedulerTest.cpp
@@ -123,6 +123,7 @@ void testInputAndOutput(std::unique_ptr<IScheduler> scheduler, int8_t myID) {
   if (myID == 0) {
     EXPECT_TRUE(wire7);
   }
+  scheduler->deleteEngine();
   auto gateCount = scheduler->getGateStatistics();
   EXPECT_EQ(gateCount.first, 2);
   EXPECT_EQ(gateCount.second, 5);
@@ -162,6 +163,7 @@ void testIntegerInputAndOutput(
   if (myID == 0) {
     EXPECT_EQ(wire7, 79);
   }
+  scheduler->deleteEngine();
   auto gateCount = scheduler->getGateStatistics();
   EXPECT_EQ(gateCount.first, 2);
   EXPECT_EQ(gateCount.second, 5);
@@ -202,6 +204,7 @@ void testInputAndOutputBatch(
     testVectorEq(wire7, {true, false});
   }
 
+  scheduler->deleteEngine();
   auto gateCount = scheduler->getGateStatistics();
   EXPECT_EQ(gateCount.first, 4);
   EXPECT_EQ(gateCount.second, 10);
@@ -243,6 +246,7 @@ void testIntegerInputAndOutputBatch(
     testVectorEq(wire7, {1, 51});
   }
 
+  scheduler->deleteEngine();
   auto gateCount = scheduler->getGateStatistics();
   EXPECT_EQ(gateCount.first, 4);
   EXPECT_EQ(gateCount.second, 10);
@@ -283,6 +287,7 @@ void testAnd(std::unique_ptr<IScheduler> scheduler, int8_t myID) {
       }
     }
   }
+  scheduler->deleteEngine();
   auto gateCount = scheduler->getGateStatistics();
   EXPECT_EQ(gateCount.first, 12);
   EXPECT_EQ(gateCount.second, 32);
@@ -326,6 +331,7 @@ void testAndBatch(std::unique_ptr<IScheduler> scheduler, int8_t myID) {
     }
   }
 
+  scheduler->deleteEngine();
   auto gateCount = scheduler->getGateStatistics();
   EXPECT_EQ(gateCount.first, 24);
   EXPECT_EQ(gateCount.second, 64);
@@ -366,6 +372,7 @@ void testMult(std::unique_ptr<IArithmeticScheduler> scheduler, int8_t myID) {
       }
     }
   }
+  scheduler->deleteEngine();
   auto gateCount = scheduler->getGateStatistics();
   EXPECT_EQ(gateCount.first, 12);
   EXPECT_EQ(gateCount.second, 32);
@@ -411,6 +418,7 @@ void testMultBatch(
     }
   }
 
+  scheduler->deleteEngine();
   auto gateCount = scheduler->getGateStatistics();
   EXPECT_EQ(gateCount.first, 24);
   EXPECT_EQ(gateCount.second, 64);
@@ -451,6 +459,7 @@ void testXor(std::unique_ptr<IScheduler> scheduler, int8_t myID) {
       }
     }
   }
+  scheduler->deleteEngine();
   auto gateCount = scheduler->getGateStatistics();
   EXPECT_EQ(gateCount.first, 8);
   EXPECT_EQ(gateCount.second, 36);
@@ -494,6 +503,7 @@ void testXorBatch(std::unique_ptr<IScheduler> scheduler, int8_t myID) {
     }
   }
 
+  scheduler->deleteEngine();
   auto gateCount = scheduler->getGateStatistics();
   EXPECT_EQ(gateCount.first, 16);
   EXPECT_EQ(gateCount.second, 72);
@@ -534,6 +544,7 @@ void testPlus(std::unique_ptr<IArithmeticScheduler> scheduler, int8_t myID) {
       }
     }
   }
+  scheduler->deleteEngine();
   auto gateCount = scheduler->getGateStatistics();
   EXPECT_EQ(gateCount.first, 8);
   EXPECT_EQ(gateCount.second, 36);
@@ -579,6 +590,7 @@ void testPlusBatch(
     }
   }
 
+  scheduler->deleteEngine();
   auto gateCount = scheduler->getGateStatistics();
   EXPECT_EQ(gateCount.first, 16);
   EXPECT_EQ(gateCount.second, 72);
@@ -601,6 +613,7 @@ void testNot(std::unique_ptr<IScheduler> scheduler, int8_t myID) {
     auto wire2 = scheduler->notPublic(scheduler->publicBooleanInput(v1));
     EXPECT_EQ(scheduler->getBooleanValue(wire2), !v1);
   }
+  scheduler->deleteEngine();
   auto gateCount = scheduler->getGateStatistics();
   EXPECT_EQ(gateCount.first, 2);
   EXPECT_EQ(gateCount.second, 8);
@@ -628,6 +641,7 @@ void testNotBatch(std::unique_ptr<IScheduler> scheduler, int8_t myID) {
     testVectorEq(scheduler->getBooleanValueBatch(wire2), {!v1, v1});
   }
 
+  scheduler->deleteEngine();
   auto gateCount = scheduler->getGateStatistics();
   EXPECT_EQ(gateCount.first, 4);
   EXPECT_EQ(gateCount.second, 16);
@@ -650,6 +664,7 @@ void testNeg(std::unique_ptr<IArithmeticScheduler> scheduler, int8_t myID) {
     auto wire2 = scheduler->negPublic(scheduler->publicIntegerInput(v1));
     EXPECT_EQ(scheduler->getIntegerValue(wire2), -v1);
   }
+  scheduler->deleteEngine();
   auto gateCount = scheduler->getGateStatistics();
   EXPECT_EQ(gateCount.first, 2);
   EXPECT_EQ(gateCount.second, 8);
@@ -679,6 +694,7 @@ void testNegBatch(
     testVectorEq(scheduler->getIntegerValueBatch(wire2), {-v1, v1});
   }
 
+  scheduler->deleteEngine();
   auto gateCount = scheduler->getGateStatistics();
   EXPECT_EQ(gateCount.first, 4);
   EXPECT_EQ(gateCount.second, 16);
@@ -1073,6 +1089,7 @@ void testCompositeAND(
       }
     }
   }
+  scheduler->deleteEngine();
   auto gateCount = scheduler->getGateStatistics();
   EXPECT_EQ(gateCount.first, 8 * compositeSize);
   EXPECT_EQ(gateCount.second, 4 + 10 * compositeSize);
@@ -1181,6 +1198,7 @@ void testCompositeANDBatch(
       }
     }
   }
+  scheduler->deleteEngine();
   auto gateCount = scheduler->getGateStatistics();
   EXPECT_EQ(gateCount.first, 24 * compositeSize);
   EXPECT_EQ(gateCount.second, 12 + 30 * compositeSize);


### PR DESCRIPTION
Summary:
In our current architecture, there is such ownership chain:
scheduler->engine->tuple generator->OT->FERRET objects->network.
When collecting the metrics, the FERRET objects may still running and we get inaccurate results. We are going to explicitly wait for engines to finish before collecting any metrics by deleting the engine and call its destroyer implicitly.

This diff is adding the API of deleting the engine.

Reviewed By: adshastri

Differential Revision: D40072627

