### PR TITLE
T133639006: Limit getRandomPermutation input size to 32 bits. Remove last loop iteration

### DIFF
--- a/fbpcf/mpc_std_lib/compactor/DummyCompactor.h
+++ b/fbpcf/mpc_std_lib/compactor/DummyCompactor.h
@@ -38,7 +38,7 @@ class DummyCompactor final
   std::pair<SecBatchType, SecBatchLabelType> compaction(
       const SecBatchType& src,
       const SecBatchLabelType& label,
-      size_t size,
+      uint32_t size,
       bool /*shouldRevealSize*/) const override {
     auto party0 =
         (myId_ < partnerId_) ? myId_ : partnerId_; // a party with a smaller id

--- a/fbpcf/mpc_std_lib/compactor/ICompactor.h
+++ b/fbpcf/mpc_std_lib/compactor/ICompactor.h
@@ -43,7 +43,7 @@ class ICompactor {
   virtual std::pair<T, LabelT> compaction(
       const T& src,
       const LabelT& label,
-      size_t size,
+      uint32_t size,
       bool shouldRevealSize) const = 0;
 };
 

--- a/fbpcf/mpc_std_lib/compactor/ShuffleBasedCompactor.h
+++ b/fbpcf/mpc_std_lib/compactor/ShuffleBasedCompactor.h
@@ -44,7 +44,7 @@ class ShuffleBasedCompactor final
   std::pair<SecBatchSrcType, SecBatchLabelType> compaction(
       const SecBatchSrcType& src,
       const SecBatchLabelType& label,
-      size_t size,
+      uint32_t size,
       bool shouldRevealSize) const {
     if (!shouldRevealSize) {
       throw std::runtime_error("shouldRevealSize should be true");

--- a/fbpcf/mpc_std_lib/compactor/test/CompactorTest.cpp
+++ b/fbpcf/mpc_std_lib/compactor/test/CompactorTest.cpp
@@ -69,7 +69,7 @@ std::pair<std::vector<T>, std::vector<bool>> task(
         typename util::SecBatchType<bool, schedulerId>::type>> compactor,
     const std::vector<T>& value,
     const std::vector<bool>& label,
-    size_t size,
+    uint32_t size,
     bool shouldRevealSize) {
   auto secValue =
       util::MpcAdapters<T, schedulerId>::processSecretInputs(value, 0);
@@ -98,7 +98,7 @@ void compactorTest(
   auto compactor0 = compactorFactory0.create();
   auto compactor1 = compactorFactory1.create();
 
-  size_t batchSize = 11;
+  uint32_t batchSize = 11;
   bool shouldRevealSize = true;
 
   // Generate test data

--- a/fbpcf/mpc_std_lib/permuter/AsWaksmanPermuter_impl.h
+++ b/fbpcf/mpc_std_lib/permuter/AsWaksmanPermuter_impl.h
@@ -8,6 +8,9 @@
 #pragma once
 
 #include <fbpcf/mpc_std_lib/util/util.h>
+
+#include "fbpcf/mpc_std_lib/permuter/AsWaksmanPermuter.h"
+
 namespace fbpcf::mpc_std_lib::permuter {
 
 template <typename T, int schedulerId>

--- a/fbpcf/mpc_std_lib/permuter/test/PermuterTest.cpp
+++ b/fbpcf/mpc_std_lib/permuter/test/PermuterTest.cpp
@@ -28,7 +28,7 @@ std::tuple<
     std::vector<std::vector<bool>>,
     std::vector<uint32_t>,
     std::vector<std::vector<bool>>>
-getPermuterTestData(size_t batchSize) {
+getPermuterTestData(uint32_t batchSize) {
   size_t width = util::Adapters<uint32_t>::widthForUint32;
   std::vector<std::vector<bool>> originalData(
       width, std::vector<bool>(batchSize));
@@ -79,7 +79,7 @@ void permuterTest(
   setupRealBackend<0, 1>(*agentFactories[0], *agentFactories[1]);
   auto permuter0 = permuterFactory0.create();
   auto permuter1 = permuterFactory1.create();
-  size_t size = 17;
+  uint32_t size = 17;
   auto [originalData, order, expectedOutput] = getPermuterTestData(size);
   auto future0 =
       std::async(party0Task, std::move(permuter0), originalData, order);

--- a/fbpcf/mpc_std_lib/shuffler/IShuffler.h
+++ b/fbpcf/mpc_std_lib/shuffler/IShuffler.h
@@ -33,7 +33,7 @@ class IShuffler {
    * @param size the size of the batch
    * @return the shuffled values in batch
    */
-  virtual T shuffle(const T& src, size_t size) const = 0;
+  virtual T shuffle(const T& src, uint32_t size) const = 0;
 };
 
 } // namespace fbpcf::mpc_std_lib::shuffler

--- a/fbpcf/mpc_std_lib/shuffler/NonShuffler.h
+++ b/fbpcf/mpc_std_lib/shuffler/NonShuffler.h
@@ -18,7 +18,7 @@ namespace fbpcf::mpc_std_lib::shuffler::insecure {
 template <typename T>
 class NonShuffler final : public IShuffler<T> {
  public:
-  T shuffle(const T& src, size_t /*size*/) const override {
+  T shuffle(const T& src, uint32_t /*size*/) const override {
     return src;
   }
 };

--- a/fbpcf/mpc_std_lib/shuffler/PermuteBasedShuffler.h
+++ b/fbpcf/mpc_std_lib/shuffler/PermuteBasedShuffler.h
@@ -30,7 +30,7 @@ class PermuteBasedShuffler final : public IShuffler<T> {
         permuter_(std::move(permuter)),
         prg_(std::move(prg)) {}
 
-  T shuffle(const T& src, size_t size) const override {
+  T shuffle(const T& src, uint32_t size) const override {
     auto myRandomPermutation = generateRandomPermutation(size);
     if (myId_ < partnerId_) {
       auto tmp = permuter_->permute(src, size, myRandomPermutation);
@@ -44,12 +44,12 @@ class PermuteBasedShuffler final : public IShuffler<T> {
   }
 
  private:
-  std::vector<uint32_t> generateRandomPermutation(size_t size) const {
+  std::vector<uint32_t> generateRandomPermutation(uint32_t size) const {
     std::vector<uint32_t> rst(size);
     for (size_t i = 0; i < size; i++) {
       rst[i] = i;
     }
-    for (size_t i = size; i > 0; i--) {
+    for (size_t i = size; i > 1; i--) {
       auto randomBytes = prg_->getRandomBytes(8);
       auto tmp = reinterpret_cast<uint64_t*>(randomBytes.data());
       auto position = (*tmp) % i;


### PR DESCRIPTION
Summary:
Implementing suggestions from NCC security review (T133639006). If the size of the vector passed to shuffler is `>2^32-1` then the permutation indexes will overflow and cause invalid result. I don't think we can expect this to support 4.3 billion rows anytime soon so I have opted to update the interface to require `sizeof(size_t) < 32`

It seems that PCS codebase still compiles with this change as compactor game test will continue to compile even without the changes I made to the diff in it. (See below where I ran `buck test //fbpcs/emp_games:compactor_test`, this was without the changes to CompactorGame.

Differential Revision: D40244828

