### PR TITLE
T133638721 Generate random permutation using higher modulus number

### DIFF
--- a/fbpcf/engine/util/test/utilTest.cpp
+++ b/fbpcf/engine/util/test/utilTest.cpp
@@ -49,4 +49,31 @@ TEST(UtilTest, setLsb) {
     EXPECT_EQ(util::getLsb(val), true);
   }
 }
+
+TEST(UtilTest, testBigNumMod) {
+  BN_CTX* ctx = BN_CTX_new();
+  std::vector<uint8_t> num{25};
+  EXPECT_EQ(mod(num, 4, ctx), 1);
+  EXPECT_EQ(mod(num, 7, ctx), 4);
+
+  for (uint64_t i = 0; i <= 251; i++) {
+    num = {
+        (uint8_t)i,
+        (uint8_t)(i + 1),
+        (uint8_t)(i + 2),
+        (uint8_t)(i + 3),
+        (uint8_t)(i + 4),
+    };
+
+    auto remainder = mod(num, 10000, ctx);
+
+    uint32_t expected = (i + ((i + 1) << 8) + ((i + 2) << 16) +
+                         ((i + 3) << 24) + ((i + 4) << 32)) %
+        10000;
+
+    EXPECT_EQ(remainder, expected);
+  }
+
+  BN_CTX_free(ctx);
+}
 } // namespace fbpcf::engine::util


### PR DESCRIPTION
Summary:
In T133638721 an issue was highlighted with the method of generating random permutation values.

> In general, generating a random number modulo n using k random bits is susceptible to biases if k is not big enough with respect to n.
Cryptographically, the goal is that the resulting distribution (from reducing k random bits modulo n) is statistically indistinguishable from a uniformly random distribution over the integers modulo n.
A distinguisher's advantage in distinguishing two distributions is at most their statistical distance, which leads to the general rule that k be at least 128 bits (or whatever security level is targeted) longer than n.

Here we are changing `n` from 64 bits to 160 bits. The modulus operation is accomplished by loading bytes into BIGNUM and taking the modulus of it. Memory management is done by calling `BN_free` after finishing operations.

BIGNUM docs: https://www.openssl.org/docs/man1.0.2/man3/bn.html

Differential Revision: D40249845

