### PR TITLE
change size type from int to size_t in IPartyCommunicationAgent::receiveBool()

### DIFF
--- a/fbpcf/engine/communication/IPartyCommunicationAgent.h
+++ b/fbpcf/engine/communication/IPartyCommunicationAgent.h
@@ -104,8 +104,8 @@ class IPartyCommunicationAgent {
    * @param size the expected size;
    * @return the received content
    */
-  std::vector<bool> receiveBool(int size) {
-    int compressedSize = (size + 7) >> 3;
+  std::vector<bool> receiveBool(size_t size) {
+    size_t compressedSize = (size + 7) >> 3;
     auto compressed = receive(compressedSize);
     auto decompressed = decompressToBits(std::move(compressed));
     decompressed.erase(decompressed.begin() + size, decompressed.end());


### PR DESCRIPTION
Summary:
This diff changed a size variable's type from int to size_t. An error 'std::length_error' happened when running a UDP with a large intersection size.

P537403247

Reviewed By: adshastri

Differential Revision: D40250620

