### PR TITLE
Change the shared lib to static link to enable GCS feature in PCF IO

### DIFF
--- a/docker/google-cloud-cpp/Dockerfile.ubuntu
+++ b/docker/google-cloud-cpp/Dockerfile.ubuntu
@@ -47,7 +47,8 @@ RUN curl -sSL https://github.com/abseil/abseil-cpp/archive/20210324.2.tar.gz | \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
       -DBUILD_TESTING=OFF \
-      -DBUILD_SHARED_LIBS=yes \
+      -DBUILD_SHARED_LIBS=OFF \
+      -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
       -DCMAKE_CXX_STANDARD=11 \
       -H. -Bcmake-out && \
     cmake --build cmake-out -- -j "$(nproc)" && \
@@ -61,7 +62,7 @@ RUN curl -sSL https://github.com/protocolbuffers/protobuf/archive/v3.19.0.tar.gz
     tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
-        -DBUILD_SHARED_LIBS=yes \
+        -DBUILD_SHARED_LIBS=OFF \
         -Dprotobuf_BUILD_TESTS=OFF \
         -Hcmake -Bcmake-out && \
     cmake --build cmake-out -- -j "$(nproc)" && \
@@ -75,6 +76,8 @@ RUN curl -sSL https://github.com/grpc/grpc/archive/v1.41.1.tar.gz | \
     tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=OFF \
+        -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
         -DgRPC_INSTALL=ON \
         -DgRPC_BUILD_TESTS=OFF \
         -DgRPC_ABSL_PROVIDER=package \
@@ -95,7 +98,7 @@ RUN curl -sSL https://github.com/google/crc32c/archive/1.1.2.tar.gz | \
     tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
-        -DBUILD_SHARED_LIBS=yes \
+        -DBUILD_SHARED_LIBS=OFF \
         -DCRC32C_BUILD_TESTS=OFF \
         -DCRC32C_BUILD_BENCHMARKS=OFF \
         -DCRC32C_USE_GLOG=OFF \
@@ -111,7 +114,7 @@ RUN curl -sSL https://github.com/nlohmann/json/archive/v3.10.4.tar.gz | \
     tar -xzf - --strip-components=1 && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
-      -DBUILD_SHARED_LIBS=yes \
+      -DBUILD_SHARED_LIBS=OFF \
       -DBUILD_TESTING=OFF \
       -H. -Bcmake-out/nlohmann/json && \
     cmake --build cmake-out/nlohmann/json --target install -- -j "$(nproc)" && \
@@ -121,6 +124,7 @@ RUN curl -sSL https://github.com/nlohmann/json/archive/v3.10.4.tar.gz | \
 WORKDIR ${HOME}/google-cloud-cpp
 RUN cmake \
         -DBUILD_TESTING=OFF \
+        -DBUILD_SHARED_LIBS=OFF \
         -DGOOGLE_CLOUD_CPP_ENABLE_BIGTABLE=OFF \
         -DGOOGLE_CLOUD_CPP_ENABLE_BIGQUERY=OFF \
         -DGOOGLE_CLOUD_CPP_ENABLE_SPANNER=OFF \

--- a/fbpcf/io/cloud_util/CloudFileUtil.cpp
+++ b/fbpcf/io/cloud_util/CloudFileUtil.cpp
@@ -14,6 +14,9 @@
 
 #include "fbpcf/aws/S3Util.h"
 #include "fbpcf/exception/PcfException.h"
+#include "fbpcf/gcp/GCSUtil.h"
+#include "fbpcf/io/cloud_util/GCSFileReader.h"
+#include "fbpcf/io/cloud_util/GCSFileUploader.h"
 #include "fbpcf/io/cloud_util/S3Client.h"
 #include "fbpcf/io/cloud_util/S3FileReader.h"
 #include "fbpcf/io/cloud_util/S3FileUploader.h"
@@ -63,6 +66,8 @@ std::unique_ptr<IFileReader> getCloudFileReader(const std::string& filePath) {
     const auto& ref = fbpcf::aws::uriToObjectReference(filePath);
     return std::make_unique<S3FileReader>(fbpcf::aws::createS3Client(
         fbpcf::aws::S3ClientOption{.region = ref.region}));
+  } else if (fileType == CloudFileType::GCS) {
+    return std::make_unique<GCSFileReader>(fbpcf::gcp::createGCSClient());
   } else {
     throw fbpcf::PcfException("Not supported yet.");
   }
@@ -78,6 +83,9 @@ std::unique_ptr<IFileUploader> getCloudFileUploader(
             fbpcf::aws::S3ClientOption{.region = ref.region})
             .getS3Client(),
         filePath);
+  } else if (fileType == CloudFileType::GCS) {
+    return std::make_unique<GCSFileUploader>(
+        fbpcf::gcp::createGCSClient(), filePath);
   } else {
     throw fbpcf::PcfException("Not supported yet.");
   }


### PR DESCRIPTION
Summary:
GCS feature was disabled in  D38156582 (https://github.com/facebookresearch/fbpcf/commit/4a1a85577c744076844a325f7d68ad03833203cc). To enable it and unblock GCS workstream, this diff is to change the shared link to static link for GCP dependencies.

For more context, see https://docs.google.com/document/d/1j0g1LdPF3RSt2bgj2Ko7ovc9FaiIOK822l9odjmngoI/edit?usp=sharing

Differential Revision: D40541003

