### PR TITLE
aarch64 doesn't have cpuid

### DIFF
--- a/fbpcf/system/CpuUtil.cpp
+++ b/fbpcf/system/CpuUtil.cpp
@@ -13,9 +13,13 @@ namespace fbpcf::system {
 // reference: https://bduvenhage.me/rng/2019/04/06/the-intel-drng.html
 CpuId getCpuId(const uint64_t& eax) {
   CpuId info;
+#ifdef __aarch64__
+  std::memset(&info, 0, sizeof(info));
+#else
   asm volatile("cpuid"
                : "=a"(info.eax), "=b"(info.ebx), "=c"(info.ecx), "=d"(info.edx)
                : "a"(eax), "c"(0));
+#endif
 
   return info;
 }


### PR DESCRIPTION
Summary: cpuid does not exist on aarch64, so just return 0 for it.

Reviewed By: andrewjcg

Differential Revision: D40420082

