### PR TITLE
Create new targets for `gcp` and its test

### DIFF
--- a/fbpcf/gcp/GCSUtil.h
+++ b/fbpcf/gcp/GCSUtil.h
@@ -11,7 +11,7 @@
 #include <optional>
 #include <string>
 
-#include <google/cloud/storage/client.h>
+#include <google/cloud/storage/client.h> // @manual=fbsource//third-party/google-cloud-cpp/google/cloud/storage:google_cloud_cpp_storage
 
 namespace fbpcf::gcp {
 struct GCSClientOption {};

--- a/fbpcf/gcp/MockGCSClient.h
+++ b/fbpcf/gcp/MockGCSClient.h
@@ -8,10 +8,10 @@
 #pragma once
 
 #include <gmock/gmock.h>
-#include <google/cloud/storage/client.h>
-#include <google/cloud/storage/download_options.h>
-#include <google/cloud/storage/object_read_stream.h>
-#include <google/cloud/storage/object_write_stream.h>
+#include <google/cloud/storage/client.h> // @manual=fbsource//third-party/google-cloud-cpp/google/cloud/storage:google_cloud_cpp_storage
+#include <google/cloud/storage/download_options.h> // @manual=fbsource//third-party/google-cloud-cpp/google/cloud/storage:google_cloud_cpp_storage
+#include <google/cloud/storage/object_read_stream.h> // @manual=fbsource//third-party/google-cloud-cpp/google/cloud/storage:google_cloud_cpp_storage
+#include <google/cloud/storage/object_write_stream.h> // @manual=fbsource//third-party/google-cloud-cpp/google/cloud/storage:google_cloud_cpp_storage
 
 namespace gcs = ::google::cloud::storage;
 


### PR DESCRIPTION
Summary:
# Context
We want to refactor the targets in fbpcf to follow the convention of one folder, one TARGETS file.

# This Diff
Create new target for the `gcp` folder

# This Stack
This stack attacks the problem folder by folder, and removes pieces from the monolith target `lib_fbpcf`

Reviewed By: nguytc, robotal

Differential Revision: D40726018

