### PR TITLE
extract random permuation generation from PermutaeBasedShuffler

### DIFF
--- a/fbpcf/mpc_std_lib/util/secureRandomPermutation.cpp
+++ b/fbpcf/mpc_std_lib/util/secureRandomPermutation.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "fbpcf/mpc_std_lib/util/secureRandomPermutation.h"
+
+namespace fbpcf::mpc_std_lib::util {
+std::vector<uint32_t> secureRandomPermutation(
+    uint32_t size,
+    engine::util::IPrg& prg) {
+  std::vector<uint32_t> rst(size);
+  for (size_t i = 0; i < size; i++) {
+    rst[i] = i;
+  }
+
+  BN_CTX* ctx = BN_CTX_new();
+  if (ctx == nullptr) {
+    throw std::runtime_error(
+        "BN_CTX initialization failed: " + std::to_string(ERR_get_error()));
+  }
+
+  for (size_t i = size; i > 1; i--) {
+    // Max permutation size + 128 bit security parameter
+    auto randomBytes = prg.getRandomBytes(
+        sizeof(uint32_t) + RANDOM_PERMUTATION_SECURITY_BITS / 8);
+    auto position = engine::util::mod(randomBytes, i, ctx);
+    std::swap(rst[position], rst[i - 1]);
+  }
+  BN_CTX_free(ctx);
+  return rst;
+}
+} // namespace fbpcf::mpc_std_lib::util

--- a/fbpcf/mpc_std_lib/util/secureRandomPermutation.h
+++ b/fbpcf/mpc_std_lib/util/secureRandomPermutation.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "fbpcf/engine/util/IPrg.h"
+
+namespace fbpcf::mpc_std_lib::util {
+
+const uint32_t RANDOM_PERMUTATION_SECURITY_BITS = 128;
+
+/**
+ *This method generates a random indexes permutation in range [0, size - 1].
+ *This method required a prg to generate secure random bytes.
+ */
+
+std::vector<uint32_t> secureRandomPermutation(
+    uint32_t size,
+    engine::util::IPrg& prg);
+
+} // namespace fbpcf::mpc_std_lib::util

--- a/fbpcf/mpc_std_lib/util/test/secureRandomPermutationTest.cpp
+++ b/fbpcf/mpc_std_lib/util/test/secureRandomPermutationTest.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "fbpcf/mpc_std_lib/util/secureRandomPermutation.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "fbpcf/engine/util/AesPrgFactory.h"
+#include "fbpcf/engine/util/util.h"
+#include "fbpcf/test/TestHelper.h"
+
+namespace fbpcf::mpc_std_lib::util {
+void permutationTest(engine::util::IPrg& prg) {
+  std::random_device rd;
+  std::mt19937_64 e(rd());
+  std::uniform_int_distribution<uint32_t> dist(1, 0xFFF);
+  uint32_t size = dist(e);
+  const std::vector<uint32_t>& permutation = secureRandomPermutation(size, prg);
+  EXPECT_EQ(size, permutation.size());
+  for (uint32_t i = 0; i < size; i++) {
+    EXPECT_TRUE(
+        std::find(permutation.begin(), permutation.end(), i) !=
+        permutation.end());
+  }
+}
+
+TEST(permutationTest, testPermutationWithAesPrg) {
+  auto prgFactory = std::make_unique<engine::util::AesPrgFactory>();
+  auto prg = prgFactory->create(engine::util::getRandomM128iFromSystemNoise());
+  permutationTest(*prg);
+}
+
+} // namespace fbpcf::mpc_std_lib::util


### PR DESCRIPTION
Summary:
= Why
We need to generate a secure random permutation in UDP.
= What
For reusing this functionality and also reducing the risk of code splitting, this diff moved the private method `generateRandomPermutation()` from `PermutaeBasedShuffler.h` into `fbpcf/mpc_std_lib/util/secureRandomPermutation.h`.

This diff also added a separate test file for `secureRandomPermutation()`.

Reviewed By: robotal

Differential Revision: D40705655

