### PR TITLE
Create new targets for `aws` and its test

### DIFF
--- a/fbpcf/aws/MockS3Client.h
+++ b/fbpcf/aws/MockS3Client.h
@@ -7,9 +7,9 @@
 
 #pragma once
 
-#include <aws/s3/S3Client.h>
-#include <aws/s3/model/GetObjectRequest.h>
-#include <aws/s3/model/PutObjectRequest.h>
+#include <aws/s3/S3Client.h> // @manual
+#include <aws/s3/model/GetObjectRequest.h> // @manual
+#include <aws/s3/model/PutObjectRequest.h> // @manual
 #include <gmock/gmock.h>
 
 namespace fbpcf {

--- a/fbpcf/aws/S3Util.cpp
+++ b/fbpcf/aws/S3Util.cpp
@@ -14,10 +14,10 @@
 #include <string>
 #include <vector>
 
-#include <aws/core/auth/AWSCredentials.h>
-#include <aws/core/client/ClientConfiguration.h>
-#include <aws/core/http/Scheme.h>
-#include <aws/s3/S3Client.h>
+#include <aws/core/auth/AWSCredentials.h> // @manual
+#include <aws/core/client/ClientConfiguration.h> // @manual
+#include <aws/core/http/Scheme.h> // @manual
+#include <aws/s3/S3Client.h> // @manual
 
 #include <boost/algorithm/string.hpp>
 #include <folly/Format.h>

--- a/fbpcf/aws/S3Util.h
+++ b/fbpcf/aws/S3Util.h
@@ -11,7 +11,7 @@
 #include <optional>
 #include <string>
 
-#include <aws/s3/S3Client.h>
+#include <aws/s3/S3Client.h> // @manual
 
 namespace fbpcf::aws {
 // referencee of environment variables:

--- a/fbpcf/aws/test/AwsSdkTest.cpp
+++ b/fbpcf/aws/test/AwsSdkTest.cpp
@@ -7,7 +7,7 @@
 
 #include "fbpcf/aws/AwsSdk.h"
 
-#include <aws/s3/S3Client.h>
+#include <aws/s3/S3Client.h> // @manual
 #include <gtest/gtest.h>
 
 namespace fbpcf {

--- a/fbpcf/aws/test/MockS3ClientTest.cpp
+++ b/fbpcf/aws/test/MockS3ClientTest.cpp
@@ -8,7 +8,7 @@
 #include "fbpcf/aws/MockS3Client.h"
 #include "fbpcf/aws/AwsSdk.h"
 
-#include <aws/s3/S3Client.h>
+#include <aws/s3/S3Client.h> // @manual
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
Summary:
# Context
We want to refactor the targets in fbpcf to follow the convention of one folder, one TARGETS file.

# This Diff
Create new target for the `aws` folder

# This Stack
This stack attacks the problem folder by folder, and removes pieces from the monolith target `lib_fbpcf`

Differential Revision: D40726138

