### PR TITLE
Copy UDP library to fbpcf

### DIFF
--- a/fbpcf/mpc_std_lib/unified_data_process/adapter/Adapter.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/adapter/Adapter.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "fbpcf/frontend/BitString.h"
+#include "fbpcf/mpc_std_lib/shuffler/IShuffler.h"
+#include "fbpcf/mpc_std_lib/unified_data_process/adapter/IAdapter.h"
+
+namespace fbpcf::mpc_std_lib::unified_data_process::adapter {
+
+template <int schedulerId>
+class Adapter final : public IAdapter {
+  using SecBit = frontend::Bit<true, schedulerId, true>;
+  using PubBit = frontend::Bit<false, schedulerId, true>;
+  using SecString = frontend::BitString<true, schedulerId, true>;
+
+ public:
+  Adapter(
+      bool amIParty0,
+      int32_t party0Id,
+      int32_t party1Id,
+      std::unique_ptr<shuffler::IShuffler<SecString>> shuffler)
+      : amIParty0_(amIParty0),
+        party0Id_(party0Id),
+        party1Id_(party1Id),
+        shuffler_(std::move(shuffler)) {}
+
+  std::vector<int32_t> adapt(
+      const std::vector<int32_t>& unionMap) const override;
+
+ private:
+  bool amIParty0_;
+  int32_t party0Id_;
+  int32_t party1Id_;
+  std::unique_ptr<shuffler::IShuffler<SecString>> shuffler_;
+};
+
+} // namespace fbpcf::mpc_std_lib::unified_data_process::adapter
+
+#include "fbpcf/mpc_std_lib/unified_data_process/adapter/Adapter_impl.h"

--- a/fbpcf/mpc_std_lib/unified_data_process/adapter/AdapterFactory.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/adapter/AdapterFactory.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <memory>
+#include "fbpcf/engine/util/AesPrgFactory.h"
+#include "fbpcf/mpc_std_lib/permuter/AsWaksmanPermuterFactory.h"
+#include "fbpcf/mpc_std_lib/permuter/DummyPermuterFactory.h"
+#include "fbpcf/mpc_std_lib/shuffler/IShufflerFactory.h"
+#include "fbpcf/mpc_std_lib/shuffler/NonShufflerFactory.h"
+#include "fbpcf/mpc_std_lib/shuffler/PermuteBasedShufflerFactory.h"
+#include "fbpcf/mpc_std_lib/unified_data_process/adapter/Adapter.h"
+#include "fbpcf/mpc_std_lib/unified_data_process/adapter/IAdapterFactory.h"
+
+namespace fbpcf::mpc_std_lib::unified_data_process::adapter {
+
+template <int schedulerId>
+class AdapterFactory final : public IAdapterFactory {
+ public:
+  using SecString = frontend::BitString<true, schedulerId, true>;
+
+  AdapterFactory(
+      bool amIParty0,
+      int32_t party0Id,
+      int32_t party1Id,
+      std::unique_ptr<shuffler::IShufflerFactory<SecString>> shufflerFactory)
+      : amIParty0_(amIParty0),
+        party0Id_(party0Id),
+        party1Id_(party1Id),
+        shufflerFactory_(std::move(shufflerFactory)) {}
+  std::unique_ptr<IAdapter> create() override {
+    return std::make_unique<Adapter<schedulerId>>(
+        amIParty0_, party0Id_, party1Id_, shufflerFactory_->create());
+  }
+
+ private:
+  bool amIParty0_;
+  int32_t party0Id_;
+  int32_t party1Id_;
+  std::unique_ptr<shuffler::IShufflerFactory<SecString>> shufflerFactory_;
+};
+
+template <int schedulerId>
+inline std::unique_ptr<AdapterFactory<schedulerId>>
+getAdapterFactoryWithAsWaksmanBasedShuffler(
+    bool amIParty0,
+    int myId,
+    int partnerId) {
+  auto permuterFactory = std::make_unique<
+      permuter::AsWaksmanPermuterFactory<std::vector<bool>, schedulerId>>(
+      myId, partnerId);
+  auto shufflerfactory = std::make_unique<shuffler::PermuteBasedShufflerFactory<
+      typename AdapterFactory<schedulerId>::SecString>>(
+      myId,
+      partnerId,
+      std::move(permuterFactory),
+      std::make_unique<engine::util::AesPrgFactory>());
+
+  return std::make_unique<AdapterFactory<schedulerId>>(
+      amIParty0,
+      amIParty0 ? myId : partnerId,
+      amIParty0 ? partnerId : myId,
+      std::move(shufflerfactory));
+}
+
+template <int schedulerId>
+inline std::unique_ptr<AdapterFactory<schedulerId>>
+getAdapterFactoryWithInsecureShuffler(bool amIParty0, int myId, int partnerId) {
+  auto permuterFactory = std::make_unique<
+      permuter::insecure::DummyPermuterFactory<std::vector<bool>, schedulerId>>(
+      myId, partnerId);
+  auto shufflerfactory = std::make_unique<shuffler::PermuteBasedShufflerFactory<
+      typename AdapterFactory<schedulerId>::SecString>>(
+      myId,
+      partnerId,
+      std::move(permuterFactory),
+      std::make_unique<engine::util::AesPrgFactory>());
+
+  return std::make_unique<AdapterFactory<schedulerId>>(
+      amIParty0,
+      amIParty0 ? myId : partnerId,
+      amIParty0 ? partnerId : myId,
+      std::move(shufflerfactory));
+}
+
+template <int schedulerId>
+inline std::unique_ptr<AdapterFactory<schedulerId>>
+getAdapterFactoryWithNonShuffler(bool amIParty0, int myId, int partnerId) {
+  auto shufflerfactory =
+      std::make_unique<shuffler::insecure::NonShufflerFactory<
+          typename AdapterFactory<schedulerId>::SecString>>();
+
+  return std::make_unique<AdapterFactory<schedulerId>>(
+      amIParty0,
+      amIParty0 ? myId : partnerId,
+      amIParty0 ? partnerId : myId,
+      std::move(shufflerfactory));
+}
+
+} // namespace fbpcf::mpc_std_lib::unified_data_process::adapter

--- a/fbpcf/mpc_std_lib/unified_data_process/adapter/Adapter_impl.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/adapter/Adapter_impl.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cmath>
+#include <stdexcept>
+#include "fbpcf/mpc_std_lib/unified_data_process/adapter/Adapter.h"
+
+namespace fbpcf::mpc_std_lib::unified_data_process::adapter {
+
+template <int schedulerId>
+std::vector<int32_t> Adapter<schedulerId>::adapt(
+    const std::vector<int32_t>& unionMap) const {
+  auto unionSize = unionMap.size();
+
+  if (unionSize == 0) {
+    throw std::runtime_error("Union size can not be 0.");
+  }
+  size_t indexWidth = std::ceil(std::log2(unionSize));
+
+  SecString ids(2 * indexWidth + 1);
+
+  std::vector<bool> hasValue(unionSize);
+  std::vector<uint32_t> myMap(unionSize);
+
+  for (size_t i = 0; i < unionSize; i++) {
+    hasValue[i] = unionMap.at(i) >= 0;
+    myMap[i] = unionMap.at(i) >= 0 ? unionMap.at(i) : 0;
+  }
+
+  // This bit indicates whether both parties have value. If only one party has
+  // value, then this bit will be 0; if both parties have value, this bit will
+  // be 1. It is impossible that neither party has value.
+  ids[0] = !SecBit(typename SecBit::ExtractedBit(hasValue));
+  for (size_t i = 0; i < indexWidth; i++) {
+    std::vector<bool> myShare(unionSize);
+    for (size_t j = 0; j < unionSize; j++) {
+      myShare[j] = (myMap[j] >> i) & 1;
+    }
+    ids[i + 1] = SecBit(myShare, party0Id_);
+    ids[1 + indexWidth + i] = SecBit(myShare, party1Id_);
+  }
+
+  auto shuffledIds = shuffler_->shuffle(std::move(ids), unionSize);
+  auto match0 = shuffledIds[0].openToParty(party0Id_);
+  auto match1 = shuffledIds[0].openToParty(party1Id_);
+  auto matchResult =
+      amIParty0_ ? std::move(match0).getValue() : std::move(match1).getValue();
+  int32_t intersectionSize = 0;
+  for (auto item : matchResult) {
+    intersectionSize += item;
+  }
+  std::vector<std::vector<bool>> share0Plaintext(
+      indexWidth, std::vector<bool>(intersectionSize));
+  std::vector<std::vector<bool>> share1Plaintext(
+      indexWidth, std::vector<bool>(intersectionSize));
+  for (size_t i = 0; i < indexWidth; i++) {
+    auto firstShare = shuffledIds[1 + i].extractBit().getValue();
+    auto secondShare = shuffledIds[indexWidth + 1 + i].extractBit().getValue();
+    int index = 0;
+    for (size_t j = 0; j < unionSize; j++) {
+      if (matchResult.at(j)) {
+        share0Plaintext[i][index] = firstShare.at(j);
+        share1Plaintext[i][index] = secondShare.at(j);
+        index++;
+      }
+    }
+  }
+
+  SecString share0(
+      typename SecString::ExtractedString(std::move(share0Plaintext)));
+  SecString share1(
+      typename SecString::ExtractedString(std::move(share1Plaintext)));
+  auto myShare0 = share0.openToParty(party1Id_);
+  auto myShare1 = share1.openToParty(party0Id_);
+  auto myShare = amIParty0_ ? std::move(myShare1).getValue()
+                            : std::move(myShare0).getValue();
+
+  std::vector<int32_t> rst(intersectionSize, 0);
+  for (size_t i = 0; i < intersectionSize; i++) {
+    for (size_t j = 0; j < indexWidth; j++) {
+      rst[i] += (myShare.at(j).at(i)) << j;
+    }
+  }
+  return rst;
+}
+
+} // namespace fbpcf::mpc_std_lib::unified_data_process::adapter

--- a/fbpcf/mpc_std_lib/unified_data_process/adapter/IAdapter.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/adapter/IAdapter.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <vector>
+
+namespace fbpcf::mpc_std_lib::unified_data_process::adapter {
+
+/*
+ * An adapter converts a union-like mapping result into an intersection-like
+ * mapping result.
+ */
+class IAdapter {
+ public:
+  virtual ~IAdapter() = default;
+
+  /**
+   * convert a union-like mapping result to an intersection-like mapping
+   * result.
+   * @param unionMap the union-like mapping result, no mapping is represented
+   * as -1. The i-th index in the input represents the index of this party's
+   * element that corresponds to the i-th element in the union.
+   * @return the corresponding intersection-like mapping result. The i-th index
+   * in the output represents the index of peer's element that corresponds to
+   * the i-th element in the intersection.
+   */
+  virtual std::vector<int32_t> adapt(
+      const std::vector<int32_t>& unionMap) const = 0;
+};
+
+} // namespace fbpcf::mpc_std_lib::unified_data_process::adapter

--- a/fbpcf/mpc_std_lib/unified_data_process/adapter/IAdapterFactory.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/adapter/IAdapterFactory.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <memory>
+
+#include "fbpcf/mpc_std_lib/unified_data_process/adapter/IAdapter.h"
+
+namespace fbpcf::mpc_std_lib::unified_data_process::adapter {
+
+class IAdapterFactory {
+ public:
+  virtual ~IAdapterFactory() = default;
+  virtual std::unique_ptr<IAdapter> create() = 0;
+};
+
+} // namespace fbpcf::mpc_std_lib::unified_data_process::adapter

--- a/fbpcf/mpc_std_lib/unified_data_process/adapter/test/AdapterTest.cpp
+++ b/fbpcf/mpc_std_lib/unified_data_process/adapter/test/AdapterTest.cpp
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <cmath>
+#include <future>
+#include <memory>
+#include <random>
+#include <unordered_map>
+
+#include "fbpcf/engine/communication/test/AgentFactoryCreationHelper.h"
+#include "fbpcf/mpc_std_lib/unified_data_process/adapter/AdapterFactory.h"
+#include "fbpcf/scheduler/SchedulerHelper.h"
+#include "fbpcf/test/TestHelper.h"
+
+namespace fbpcf::mpc_std_lib::unified_data_process::adapter {
+
+std::vector<int32_t> generateShuffledIndex(size_t size) {
+  std::vector<int32_t> rst(size);
+  for (size_t i = 0; i < size; i++) {
+    rst[i] = i;
+  }
+  std::random_shuffle(rst.begin(), rst.end());
+  return rst;
+}
+
+std::tuple<
+    std::vector<int32_t>,
+    std::vector<int32_t>,
+    std::unordered_map<int32_t, int32_t>>
+generateAdapterTestData() {
+  std::random_device rd;
+  std::mt19937_64 e(rd());
+  std::uniform_int_distribution<int32_t> randomUnionSize(3, 0xFF);
+  std::uniform_int_distribution<uint8_t> randomElement(0, 2);
+
+  auto unionSize = randomUnionSize(e);
+  size_t p0InputSize = 0;
+  size_t p1InputSize = 0;
+  std::vector<uint8_t> u(unionSize);
+  for (auto& item : u) {
+    item = randomElement(e);
+    if (item != 0) {
+      p0InputSize++;
+    }
+    if (item != 1) {
+      p1InputSize++;
+    }
+  }
+
+  std::vector<int32_t> p0Data = generateShuffledIndex(p0InputSize);
+  std::vector<int32_t> p1Data = generateShuffledIndex(p1InputSize);
+  std::vector<int32_t> p0Input(unionSize);
+  std::vector<int32_t> p1Input(unionSize);
+  size_t p0Index = 0;
+  size_t p1Index = 0;
+  std::unordered_map<int32_t, int32_t> expectedOutput;
+  for (size_t i = 0; i < unionSize; i++) {
+    if (u.at(i) == 2) {
+      expectedOutput[p0Data.at(p0Index)] = p1Data.at(p1Index);
+    }
+
+    if (u.at(i) != 0) {
+      p0Input[i] = p0Data.at(p0Index);
+      p0Index++;
+    } else {
+      p0Input[i] = -1;
+    }
+    if (u.at(i) != 1) {
+      p1Input[i] = p1Data.at(p1Index);
+      p1Index++;
+    } else {
+      p1Input[i] = -1;
+    }
+  }
+  return {p0Input, p1Input, expectedOutput};
+}
+
+void checkOutput(
+    const std::vector<int32_t>& p0Output,
+    const std::vector<int32_t>& p1Output,
+    const std::unordered_map<int32_t, int32_t>& expectedOutput) {
+  ASSERT_EQ(p0Output.size(), expectedOutput.size());
+  ASSERT_EQ(p1Output.size(), expectedOutput.size());
+  for (size_t i = 0; i < p0Output.size(); i++) {
+    ASSERT_TRUE(expectedOutput.find(p1Output.at(i)) != expectedOutput.end());
+    EXPECT_EQ(expectedOutput.at(p1Output.at(i)), p0Output.at(i));
+  }
+}
+
+void adapterTest(
+    std::unique_ptr<IAdapter> adapter0,
+    std::unique_ptr<IAdapter> adapter1) {
+  auto [p0Input, p1Input, expectedOutput] = generateAdapterTestData();
+  auto task = [](std::unique_ptr<IAdapter> adapter,
+                 const std::vector<int32_t>& input) {
+    return adapter->adapt(input);
+  };
+  auto future0 = std::async(task, std::move(adapter0), p0Input);
+  auto future1 = std::async(task, std::move(adapter1), p1Input);
+  auto rst0 = future0.get();
+  auto rst1 = future1.get();
+  checkOutput(rst0, rst1, expectedOutput);
+}
+
+TEST(AdapterTest, testAdapterWithNonShuffler) {
+  auto agentFactories =
+      fbpcf::engine::communication::getInMemoryAgentFactory(2);
+  fbpcf::setupRealBackend<0, 1>(*agentFactories[0], *agentFactories[1]);
+  auto factory0 = getAdapterFactoryWithNonShuffler<0>(true, 0, 1);
+  auto factory1 = getAdapterFactoryWithNonShuffler<1>(false, 1, 0);
+
+  adapterTest(factory0->create(), factory1->create());
+}
+
+TEST(AdapterTest, testAdapterWithPermuteBasedShufflerAndDummyPermuter) {
+  auto agentFactories =
+      fbpcf::engine::communication::getInMemoryAgentFactory(2);
+  fbpcf::setupRealBackend<0, 1>(*agentFactories[0], *agentFactories[1]);
+
+  auto factory0 = getAdapterFactoryWithInsecureShuffler<0>(true, 0, 1);
+  auto factory1 = getAdapterFactoryWithInsecureShuffler<1>(false, 1, 0);
+
+  adapterTest(factory0->create(), factory1->create());
+}
+
+TEST(AdapterTest, testAdapterWithSecurePermuteBasedShuffler) {
+  auto agentFactories =
+      fbpcf::engine::communication::getInMemoryAgentFactory(2);
+  fbpcf::setupRealBackend<0, 1>(*agentFactories[0], *agentFactories[1]);
+  auto factory0 = getAdapterFactoryWithAsWaksmanBasedShuffler<0>(true, 0, 1);
+  auto factory1 = getAdapterFactoryWithAsWaksmanBasedShuffler<1>(false, 1, 0);
+
+  adapterTest(factory0->create(), factory1->create());
+}
+
+} // namespace fbpcf::mpc_std_lib::unified_data_process::adapter

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/DataProcessor.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/DataProcessor.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <emmintrin.h>
+#include "fbpcf/engine/communication/IPartyCommunicationAgent.h"
+#include "fbpcf/engine/util/util.h"
+#include "fbpcf/mpc_std_lib/aes_circuit/IAesCircuitCtr.h"
+#include "fbpcf/mpc_std_lib/unified_data_process/data_processor/IDataProcessor.h"
+
+namespace fbpcf::mpc_std_lib::unified_data_process::data_processor {
+
+/**
+ * This is the implementation of UDP data processor.
+ */
+template <int schedulerId>
+class DataProcessor final : public IDataProcessor<schedulerId> {
+ public:
+  using AesCtr =
+      aes_circuit::IAesCircuitCtr<typename IDataProcessor<schedulerId>::SecBit>;
+
+  explicit DataProcessor(
+      int32_t myId,
+      int32_t partnerId,
+      std::unique_ptr<fbpcf::engine::communication::IPartyCommunicationAgent>
+          agent,
+      std::unique_ptr<AesCtr> aesCircuitCtr)
+      : myId_(myId),
+        partnerId_(partnerId),
+        agent_(std::move(agent)),
+        aesCircuitCtr_(std::move(aesCircuitCtr)) {}
+
+  /**
+   * @inherit doc
+   */
+  typename IDataProcessor<schedulerId>::SecString processMyData(
+      const std::vector<std::vector<unsigned char>>& plaintextData,
+      size_t outputSize) override;
+
+  /**
+   * @inherit doc
+   */
+  typename IDataProcessor<schedulerId>::SecString processPeersData(
+      size_t dataSize,
+      const std::vector<int32_t>& indexes,
+      size_t dataWidth) override;
+
+ private:
+  int32_t myId_;
+  int32_t partnerId_;
+  std::unique_ptr<fbpcf::engine::communication::IPartyCommunicationAgent>
+      agent_;
+  std::unique_ptr<AesCtr> aesCircuitCtr_;
+
+ protected:
+  // locally encrypt the plaintext, output expanded keys and ciphertext
+  std::tuple<std::array<__m128i, 11>, std::vector<std::vector<uint8_t>>>
+  localEncryption(const std::vector<std::vector<unsigned char>>& plaintextData);
+
+  // privately share the input byte stream from party inputPartyID into vector
+  // of batched Bit. Also padding the Bit vector to make its size be mulitple
+  // of 128
+  std::vector<typename IDataProcessor<schedulerId>::SecBit>
+  privatelyShareByteStream(
+      const std::vector<std::vector<unsigned char>>& localData,
+      int inputPartyID);
+
+  // privately share a 2d vector of __m128i from party inputPartyID into vector
+  // of batched Bit.
+  std::vector<typename IDataProcessor<schedulerId>::SecBit>
+  privatelyShareM128iStream(
+      const std::vector<std::vector<__m128i>>& localDataM128i,
+      int inputPartyID);
+
+  // privately share the expanded key from party inputPartyID into vector
+  // of batched Bit. Each bit from the expanded key will be convert into a
+  // batched Bit with a specified bathcSize
+  std::vector<typename IDataProcessor<schedulerId>::SecBit>
+  privatelyShareExpandedKey(
+      const std::vector<__m128i>& localKeyM128i,
+      size_t batchSize,
+      int inputPartyID);
+};
+
+} // namespace fbpcf::mpc_std_lib::unified_data_process::data_processor
+
+#include "fbpcf/mpc_std_lib/unified_data_process/data_processor/DataProcessor_impl.h"

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/DataProcessorFactory.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/DataProcessorFactory.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <memory>
+#include "fbpcf/engine/communication/IPartyCommunicationAgentFactory.h"
+#include "fbpcf/mpc_std_lib/aes_circuit/AesCircuitCtrFactory.h"
+#include "fbpcf/mpc_std_lib/unified_data_process/data_processor/DataProcessor.h"
+#include "fbpcf/mpc_std_lib/unified_data_process/data_processor/IDataProcessor.h"
+#include "fbpcf/mpc_std_lib/unified_data_process/data_processor/IDataProcessorFactory.h"
+
+namespace fbpcf::mpc_std_lib::unified_data_process::data_processor {
+
+template <int schedulerId>
+class DataProcessorFactory final : public IDataProcessorFactory<schedulerId> {
+ public:
+  using AesCtrFactory = aes_circuit::AesCircuitCtrFactory<
+      typename IDataProcessor<schedulerId>::SecBit>;
+
+  DataProcessorFactory(
+      int32_t myId,
+      int32_t partnerId,
+      fbpcf::engine::communication::IPartyCommunicationAgentFactory&
+          agentFactory,
+      std::unique_ptr<AesCtrFactory> aesCtrFactory)
+      : myId_(myId),
+        partnerId_(partnerId),
+        agentFactory_(agentFactory),
+        aesCtrFactory_(std::move(aesCtrFactory)) {}
+
+  std::unique_ptr<IDataProcessor<schedulerId>> create() {
+    return std::make_unique<DataProcessor<schedulerId>>(
+        myId_,
+        partnerId_,
+        agentFactory_.create(partnerId_, "data_processor_traffic"),
+        aesCtrFactory_->create());
+  }
+
+ private:
+  int32_t myId_;
+  int32_t partnerId_;
+  engine::communication::IPartyCommunicationAgentFactory& agentFactory_;
+  std::unique_ptr<AesCtrFactory> aesCtrFactory_;
+};
+
+template <int schedulerId>
+inline std::unique_ptr<DataProcessorFactory<schedulerId>>
+getDataProcessorFactoryWithAesCtr(
+    int myId,
+    int partnerId,
+    engine::communication::IPartyCommunicationAgentFactory& agentFactory) {
+  return std::make_unique<DataProcessorFactory<schedulerId>>(
+      myId,
+      partnerId,
+      agentFactory,
+      std::make_unique<aes_circuit::AesCircuitCtrFactory<
+          typename IDataProcessor<schedulerId>::SecBit>>());
+}
+
+} // namespace fbpcf::mpc_std_lib::unified_data_process::data_processor

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/DataProcessor_impl.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/DataProcessor_impl.h
@@ -1,0 +1,269 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "fbpcf/engine/util/aes.h"
+#include "fbpcf/mpc_std_lib/aes_circuit/AesCircuitCtr.h"
+#include "fbpcf/mpc_std_lib/unified_data_process/data_processor/DataProcessor.h"
+
+namespace fbpcf::mpc_std_lib::unified_data_process::data_processor {
+
+template <int schedulerId>
+typename IDataProcessor<schedulerId>::SecString
+DataProcessor<schedulerId>::processMyData(
+    const std::vector<std::vector<unsigned char>>& plaintextData,
+    size_t outputSize) {
+  size_t dataSize = plaintextData.size();
+  size_t dataWidth = plaintextData.at(0).size();
+
+  // 1a. encrypt my data locally
+  auto keyAndCiphertext = localEncryption(plaintextData);
+  auto& expandedKeyM128i = std::get<0>(keyAndCiphertext);
+  auto& ciphertextByte = std::get<1>(keyAndCiphertext);
+
+  // 2a. send encryted data to peer
+  for (auto& item : ciphertextByte) {
+    agent_->send(item);
+  }
+
+  // 1b. (peer)receive encryted data from peer
+  // 2b. (peer)pick desired ciphertext blocks
+  // 3a. share key
+  std::vector<__m128i> expandedKeyVectorM128i(
+      expandedKeyM128i.begin(), expandedKeyM128i.end());
+  auto keyString =
+      privatelyShareExpandedKey(expandedKeyVectorM128i, outputSize, myId_);
+
+  // 3b. (peer)share ciphertext and mask
+  std::vector<std::vector<unsigned char>> ciphertextPlaceholder(
+      outputSize, std::vector<unsigned char>(ciphertextByte.at(0).size()));
+  auto filteredCiphertext =
+      privatelyShareByteStream(ciphertextPlaceholder, partnerId_);
+
+  std::vector<std::vector<__m128i>> countersPlaceholderM128i(
+      outputSize, std::vector<__m128i>(filteredCiphertext.size() / 128));
+  auto filteredCounters =
+      privatelyShareM128iStream(countersPlaceholderM128i, partnerId_);
+
+  // 4a/b. decryt the data jointly (input my key privately)
+  auto decryptData =
+      aesCircuitCtr_->decrypt(filteredCiphertext, keyString, filteredCounters);
+
+  // reverse each byte from little endian into big endian order
+  std::vector<typename IDataProcessor<schedulerId>::SecBit> reversedData(
+      decryptData.size());
+  for (int i = 0; i < decryptData.size(); ++i) {
+    reversedData[8 * (i / 8) + (7 - i % 8)] = decryptData[i];
+  }
+  // 5a/b. output decrypted data
+  // remove the trailing padding bits
+  typename IDataProcessor<schedulerId>::SecString outputShare(dataWidth * 8);
+  for (size_t i = 0; i < dataWidth * 8; ++i) {
+    outputShare[i] = reversedData[i];
+  }
+  return outputShare;
+}
+
+template <int schedulerId>
+typename IDataProcessor<schedulerId>::SecString
+DataProcessor<schedulerId>::processPeersData(
+    size_t dataSize,
+    const std::vector<int32_t>& indexes,
+    size_t dataWidth) {
+  // 1a. (peer)encrypt my data locally
+  // 2a. (peer)send encryted data to peer
+  // 1b. receive encryted data from peer
+  size_t intersectionSize = indexes.size();
+  std::vector<std::vector<unsigned char>> ciphertextByte(
+      dataSize, std::vector<unsigned char>(dataWidth));
+  for (size_t i = 0; i < dataSize; i++) {
+    ciphertextByte[i] = agent_->receive(dataWidth);
+  }
+
+  // 2b. pick desired ciphertext blocks
+  std::vector<std::vector<unsigned char>> intersection(
+      intersectionSize, std::vector<unsigned char>(dataWidth));
+  for (size_t i = 0; i < intersectionSize; ++i) {
+    intersection[i] = ciphertextByte[indexes[i]];
+  }
+
+  // 3a. (peer)share key
+  std::vector<__m128i> keyPlaceholderM128i(11);
+  auto keyString = privatelyShareExpandedKey(
+      keyPlaceholderM128i, intersectionSize, partnerId_);
+
+  // 3b. share ciphertext and mask
+  size_t cipherWidth =
+      dataWidth % 16 == 0 ? dataWidth : dataWidth + 16 - dataWidth % 16;
+  size_t cipherBlocks = cipherWidth / 16;
+  auto filteredCiphertext = privatelyShareByteStream(intersection, myId_);
+
+  std::vector<std::vector<__m128i>> filteredCountersM128i(
+      intersectionSize, std::vector<__m128i>(cipherBlocks));
+  for (uint64_t i = 0; i < intersectionSize; ++i) {
+    for (uint64_t j = 0; j < cipherBlocks; ++j) {
+      filteredCountersM128i[i][j] =
+          _mm_set_epi64x(0, indexes[i] * cipherBlocks + j);
+    }
+  }
+  auto filteredCounters =
+      privatelyShareM128iStream(filteredCountersM128i, myId_);
+
+  // 4a/b. decryt the picked blocks jointly (input the ciphertext and mask
+  // privately)
+  auto decryptData =
+      aesCircuitCtr_->decrypt(filteredCiphertext, keyString, filteredCounters);
+
+  // reverse each byte from little endian into big endian order
+  std::vector<typename IDataProcessor<schedulerId>::SecBit> reversedData(
+      decryptData.size());
+  for (size_t i = 0; i < decryptData.size(); ++i) {
+    reversedData[8 * (i / 8) + (7 - i % 8)] = decryptData[i];
+  }
+
+  // 5a/b. output decrypted data
+  // remove the trailing padding bits
+  typename IDataProcessor<schedulerId>::SecString outputShare(dataWidth * 8);
+  for (size_t i = 0; i < dataWidth * 8; ++i) {
+    outputShare[i] = reversedData[i];
+  }
+  return outputShare;
+}
+
+template <int schedulerId>
+std::tuple<std::array<__m128i, 11>, std::vector<std::vector<uint8_t>>>
+DataProcessor<schedulerId>::localEncryption(
+    const std::vector<std::vector<unsigned char>>& plaintextData) {
+  size_t rowCounts = plaintextData.size();
+  size_t rowSize = plaintextData.at(0).size();
+  size_t rowBlocks = rowSize / 16 + (rowSize % 16 != 0);
+
+  __m128i keyM128i = fbpcf::engine::util::getRandomM128iFromSystemNoise();
+  fbpcf::engine::util::Aes localAes(keyM128i);
+  auto expandedKeyM128i = localAes.expandEncryptionKey(keyM128i);
+  // generate counters for each block
+  std::vector<__m128i> counterM128i(rowCounts * rowBlocks);
+  for (uint64_t i = 0; i < counterM128i.size(); ++i) {
+    counterM128i[i] = _mm_set_epi64x(0, i);
+  }
+  // encrypt counters
+  localAes.encryptInPlace(counterM128i);
+
+  std::vector<uint8_t> maskByte;
+  maskByte.reserve(counterM128i.size() * 16);
+  for (auto unit : counterM128i) {
+    uint8_t tmparray[16];
+    _mm_storeu_si128((__m128i*)tmparray, unit);
+    maskByte.insert(maskByte.end(), &tmparray[0], &tmparray[16]);
+  }
+
+  std::vector<std::vector<uint8_t>> ciphertextByte(
+      rowCounts, std::vector<uint8_t>(rowSize));
+  for (size_t i = 0; i < rowCounts; ++i) {
+    for (size_t j = 0; j < rowSize; ++j) {
+      ciphertextByte[i][j] =
+          plaintextData[i][j] ^ maskByte[i * rowBlocks * 16 + j];
+    }
+  }
+  return {expandedKeyM128i, ciphertextByte};
+}
+
+template <int schedulerId>
+std::vector<typename IDataProcessor<schedulerId>::SecBit>
+DataProcessor<schedulerId>::privatelyShareByteStream(
+    const std::vector<std::vector<unsigned char>>& localData,
+    int inputPartyID) {
+  size_t unitSize = sizeof(unsigned char) * 8;
+  size_t localDataWidth = localData.at(0).size() * unitSize;
+  size_t stringWidth = localDataWidth % 128 == 0
+      ? localDataWidth
+      : localDataWidth + 128 - localDataWidth % 128;
+  size_t inputSize = localData.size();
+  std::vector<typename IDataProcessor<schedulerId>::SecBit> sharedData(
+      stringWidth);
+  for (size_t i = 0; i < localDataWidth; i++) {
+    std::vector<bool> sharedBit(inputSize);
+    for (size_t j = 0; j < inputSize; j++) {
+      sharedBit[j] =
+          (localData[j][i / unitSize] >> (unitSize - 1 - i % unitSize)) & 1;
+    }
+    sharedData[i] =
+        typename IDataProcessor<schedulerId>::SecBit(sharedBit, inputPartyID);
+  }
+  // padding
+  for (size_t i = localDataWidth; i < stringWidth; ++i) {
+    std::vector<bool> sharedBit(inputSize);
+    sharedData[i] =
+        typename IDataProcessor<schedulerId>::SecBit(sharedBit, inputPartyID);
+  }
+  return sharedData;
+}
+
+template <int schedulerId>
+std::vector<typename IDataProcessor<schedulerId>::SecBit>
+DataProcessor<schedulerId>::privatelyShareM128iStream(
+    const std::vector<std::vector<__m128i>>& localDataM128i,
+    int inputPartyID) {
+  size_t unitSize = 128;
+  size_t batchSize = localDataM128i.size();
+  size_t rowSize = localDataM128i.at(0).size();
+  std::vector<std::vector<bool>> localDataBool(
+      batchSize * rowSize, std::vector<bool>(unitSize));
+  for (size_t i = 0; i < batchSize; ++i) {
+    for (size_t j = 0; j < rowSize; ++j) {
+      // The bits extracted from extractLnbToVector() is the following order:
+      // All bytes are in a order that from most significant byte to least
+      // significant bytes. The bits in each byte is in a order that from lsb to
+      // msb.
+      fbpcf::engine::util::extractLnbToVector(
+          localDataM128i[i][j], localDataBool[i * rowSize + j]);
+    }
+  }
+  std::vector<typename IDataProcessor<schedulerId>::SecBit> sharedDataBit(
+      rowSize * 128);
+  for (size_t i = 0; i < rowSize * 128; ++i) {
+    std::vector<bool> sharedBit(batchSize);
+    for (size_t j = 0; j < batchSize; ++j) {
+      sharedBit[j] =
+          localDataBool[j * rowSize + i / 128][i % 128 / 8 * 8 + (7 - i % 8)];
+    }
+    sharedDataBit[i] =
+        typename IDataProcessor<schedulerId>::SecBit(sharedBit, inputPartyID);
+  }
+  return sharedDataBit;
+}
+
+template <int schedulerId>
+std::vector<typename IDataProcessor<schedulerId>::SecBit>
+DataProcessor<schedulerId>::privatelyShareExpandedKey(
+    const std::vector<__m128i>& localKeyM128i,
+    size_t batchSize,
+    int inputPartyID) {
+  size_t unitSize = 128;
+  size_t blockNo = localKeyM128i.size(); // should be 11
+  std::vector<std::vector<bool>> localDataBool(
+      blockNo, std::vector<bool>(unitSize));
+  for (size_t i = 0; i < blockNo; ++i) {
+    // The bits extracted from extractLnbToVector() is the following order:
+    // All bytes are in a order that from most significant byte to least
+    // significant bytes. The bits in each byte is in a order that from lsb to
+    // msb.
+    fbpcf::engine::util::extractLnbToVector(localKeyM128i[i], localDataBool[i]);
+  }
+  std::vector<typename IDataProcessor<schedulerId>::SecBit> sharedKeyBit(
+      blockNo * unitSize);
+  for (size_t i = 0; i < blockNo * unitSize; ++i) {
+    std::vector<bool> sharedBit(
+        batchSize,
+        localDataBool[i / unitSize][i % unitSize / 8 * 8 + (7 - i % 8)]);
+    sharedKeyBit[i] =
+        typename IDataProcessor<schedulerId>::SecBit(sharedBit, inputPartyID);
+  }
+  return sharedKeyBit;
+}
+} // namespace fbpcf::mpc_std_lib::unified_data_process::data_processor

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/DummyDataProcessor.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/DummyDataProcessor.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "fbpcf/engine/communication/IPartyCommunicationAgent.h"
+#include "fbpcf/mpc_std_lib/unified_data_process/data_processor/IDataProcessor.h"
+
+namespace fbpcf::mpc_std_lib::unified_data_process::data_processor::insecure {
+
+/**
+ * This is an insecure implementation. This object is only meant to be used as a
+ * placeholder for testing.
+ */
+template <int schedulerId>
+class DummyDataProcessor final : public IDataProcessor<schedulerId> {
+ public:
+  explicit DummyDataProcessor(
+      int32_t myId,
+      int32_t partnerId,
+      std::unique_ptr<engine::communication::IPartyCommunicationAgent> agent)
+      : myId_(myId), partnerId_(partnerId), agent_(std::move(agent)) {}
+
+  /**
+   * @inherit doc
+   */
+  typename IDataProcessor<schedulerId>::SecString processMyData(
+      const std::vector<std::vector<unsigned char>>& plaintextData,
+      size_t outputSize) override;
+
+  /**
+   * @inherit doc
+   */
+  typename IDataProcessor<schedulerId>::SecString processPeersData(
+      size_t dataSize,
+      const std::vector<int32_t>& indexes,
+      size_t dataWidth) override;
+
+ private:
+  int32_t myId_;
+  int32_t partnerId_;
+  std::unique_ptr<engine::communication::IPartyCommunicationAgent> agent_;
+};
+
+} // namespace
+  // fbpcf::mpc_std_lib::unified_data_process::data_processor::insecure
+
+#include "fbpcf/mpc_std_lib/unified_data_process/data_processor/DummyDataProcessor_impl.h"

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/DummyDataProcessorFactory.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/DummyDataProcessorFactory.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <memory>
+#include "fbpcf/engine/communication/IPartyCommunicationAgentFactory.h"
+#include "fbpcf/mpc_std_lib/unified_data_process/data_processor/DummyDataProcessor.h"
+#include "fbpcf/mpc_std_lib/unified_data_process/data_processor/IDataProcessorFactory.h"
+
+namespace fbpcf::mpc_std_lib::unified_data_process::data_processor::insecure {
+
+template <int schedulerId>
+class DummyDataProcessorFactory final
+    : public IDataProcessorFactory<schedulerId> {
+ public:
+  DummyDataProcessorFactory(
+      int32_t myId,
+      int32_t partnerId,
+      engine::communication::IPartyCommunicationAgentFactory& agentFactory)
+      : myId_(myId), partnerId_(partnerId), agentFactory_(agentFactory) {}
+
+  std::unique_ptr<IDataProcessor<schedulerId>> create() {
+    return std::make_unique<DummyDataProcessor<schedulerId>>(
+        myId_,
+        partnerId_,
+        agentFactory_.create(partnerId_, "dummy_data_processor_traffic"));
+  }
+
+ private:
+  int32_t myId_;
+  int32_t partnerId_;
+  engine::communication::IPartyCommunicationAgentFactory& agentFactory_;
+};
+
+} // namespace
+  // fbpcf::mpc_std_lib::unified_data_process::data_processor::insecure

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/DummyDataProcessor_impl.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/DummyDataProcessor_impl.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "fbpcf/mpc_std_lib/unified_data_process/data_processor/DummyDataProcessor.h"
+
+namespace fbpcf::mpc_std_lib::unified_data_process::data_processor::insecure {
+
+template <int schedulerId>
+typename IDataProcessor<schedulerId>::SecString
+DummyDataProcessor<schedulerId>::processMyData(
+    const std::vector<std::vector<unsigned char>>& plaintextData,
+    size_t outputSize) {
+  if (plaintextData.size() == 0) {
+    throw std::runtime_error("payload can't be empty!");
+  }
+  if (outputSize == 0) {
+    throw std::runtime_error("output can't be empty!");
+  }
+  for (auto& item : plaintextData) {
+    agent_->send(item);
+  }
+  std::vector<std::vector<bool>> dummyShare(
+      plaintextData.at(0).size() * 8, std::vector<bool>(outputSize));
+  return
+      typename IDataProcessor<schedulerId>::SecString(dummyShare, partnerId_);
+}
+
+template <int schedulerId>
+typename IDataProcessor<schedulerId>::SecString
+DummyDataProcessor<schedulerId>::processPeersData(
+    size_t dataSize,
+    const std::vector<int32_t>& indexes,
+    size_t dataWidth) {
+  std::vector<std::vector<unsigned char>> plaintext;
+  for (size_t i = 0; i < dataSize; i++) {
+    plaintext.push_back(agent_->receive(dataWidth));
+  }
+  std::vector<std::vector<bool>> myShare(
+      dataWidth * 8, std::vector<bool>(indexes.size()));
+  for (size_t i = 0; i < dataWidth; i++) {
+    for (uint8_t j = 0; j < 8; j++) {
+      for (size_t k = 0; k < indexes.size(); k++) {
+        myShare[i * 8 + j][k] = (plaintext.at(indexes.at(k)).at(i) >> j) & 1;
+      }
+    }
+  }
+  return typename IDataProcessor<schedulerId>::SecString(myShare, myId_);
+}
+
+} // namespace
+  // fbpcf::mpc_std_lib::unified_data_process::data_processor::insecure

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/IDataProcessor.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/IDataProcessor.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <vector>
+#include "fbpcf/frontend/BitString.h"
+
+namespace fbpcf::mpc_std_lib::unified_data_process::data_processor {
+
+/**
+ * A data processor can generate the secret shares of the data of the matched
+ * rows based on the indexes of those rows provided by one party and the actual
+ * data provided by the other.
+ */
+template <int schedulerId>
+class IDataProcessor {
+ public:
+  using SecString = frontend::BitString<true, schedulerId, true>;
+  using PubString = frontend::BitString<false, schedulerId, true>;
+  using SecBit = frontend::Bit<true, schedulerId, true>;
+  virtual ~IDataProcessor() = default;
+
+  /**
+   * Process this party's data and generate the secret shares of the data of the
+   * matched rows. The other party will provide the indexes of those rows.
+   * @param plaintextData my data
+   * @param outputSize how many rows are expected to appear in the output
+   * @return the secret-shared values of the data of the matched rows
+   */
+  virtual SecString processMyData(
+      const std::vector<std::vector<unsigned char>>& plaintextData,
+      size_t outputSize) = 0;
+
+  /**
+   * Process the other party's data and generate the secret shares of the data
+   * of the matched rows. The other party will provide the data while this party
+   * will specify the indexes of the matched rows.
+   * @param dataSize how many rows are expected from the other party
+   * @param indexes the indexes of the matched rows, the order matters
+   * @param dataWidth how many bytes are there in the data.
+   * @return the secret-shared values of the data of the matched rows
+   */
+  virtual SecString processPeersData(
+      size_t dataSize,
+      const std::vector<int32_t>& indexes,
+      size_t dataWidth) = 0;
+};
+
+} // namespace fbpcf::mpc_std_lib::unified_data_process::data_processor

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/IDataProcessorFactory.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/IDataProcessorFactory.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <memory>
+#include "fbpcf/mpc_std_lib/unified_data_process/data_processor/IDataProcessor.h"
+
+namespace fbpcf::mpc_std_lib::unified_data_process::data_processor {
+
+template <int schedulerId>
+class IDataProcessorFactory {
+ public:
+  virtual ~IDataProcessorFactory() = default;
+  virtual std::unique_ptr<IDataProcessor<schedulerId>> create() = 0;
+};
+
+} // namespace fbpcf::mpc_std_lib::unified_data_process::data_processor

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/test/DataProcessorTest.cpp
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/test/DataProcessorTest.cpp
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <cmath>
+#include <future>
+#include <memory>
+#include <random>
+#include <unordered_map>
+
+#include "fbpcf/engine/communication/test/AgentFactoryCreationHelper.h"
+#include "fbpcf/mpc_std_lib/unified_data_process/data_processor/DataProcessor.h"
+#include "fbpcf/mpc_std_lib/unified_data_process/data_processor/DataProcessorFactory.h"
+#include "fbpcf/mpc_std_lib/unified_data_process/data_processor/DataProcessor_impl.h"
+#include "fbpcf/mpc_std_lib/unified_data_process/data_processor/DummyDataProcessorFactory.h"
+#include "fbpcf/mpc_std_lib/unified_data_process/data_processor/IDataProcessor.h"
+#include "fbpcf/scheduler/SchedulerHelper.h"
+#include "fbpcf/test/TestHelper.h"
+
+namespace fbpcf::mpc_std_lib::unified_data_process::data_processor {
+
+std::tuple<
+    std::vector<std::vector<uint8_t>>,
+    std::vector<int32_t>,
+    std::vector<std::vector<uint8_t>>>
+generateDataProcessorTestData() {
+  std::random_device rd;
+  std::mt19937_64 e(rd());
+  std::uniform_int_distribution<int32_t> randomSize(10, 0xFF);
+  std::uniform_int_distribution<uint8_t> randomData(0, 0xFF);
+  auto outputSize = randomSize(e);
+  auto inputSize = outputSize + randomSize(e);
+
+  size_t dataWidth = 20;
+  std::vector<std::vector<uint8_t>> inputData(
+      inputSize, std::vector<uint8_t>(dataWidth));
+
+  for (auto& item : inputData) {
+    for (auto& data : item) {
+      data = randomData(e);
+    }
+  }
+  std::vector<int32_t> index(inputSize);
+  for (size_t i = 0; i < inputSize; i++) {
+    index[i] = i;
+  }
+  std::random_shuffle(index.begin(), index.end());
+  index.erase(index.begin() + outputSize, index.end());
+
+  std::vector<std::vector<uint8_t>> expectedOutput(outputSize);
+  for (size_t i = 0; i < outputSize; i++) {
+    expectedOutput[i] = inputData.at(index.at(i));
+  }
+  return {inputData, index, expectedOutput};
+}
+
+void testDataProcessor(
+    std::unique_ptr<IDataProcessor<0>> processor0,
+    std::unique_ptr<IDataProcessor<1>> processor1) {
+  auto [data, index, expectedOutput] = generateDataProcessorTestData();
+  auto outputSize = index.size();
+  auto dataSize = data.size();
+  auto dataWidth = data.at(0).size();
+  auto task0 = [](std::unique_ptr<IDataProcessor<0>> processor,
+                  const std::vector<std::vector<unsigned char>>& plaintextData,
+                  size_t outputSize,
+                  size_t dataWidth) {
+    auto secretSharedOutput =
+        processor->processMyData(plaintextData, outputSize);
+    auto plaintextOutputBitString =
+        secretSharedOutput.openToParty(0).getValue();
+    std::vector<std::vector<uint8_t>> rst(
+        outputSize, std::vector<uint8_t>(dataWidth));
+    for (size_t i = 0; i < dataWidth; i++) {
+      for (uint8_t j = 0; j < 8; j++) {
+        for (size_t k = 0; k < outputSize; k++) {
+          rst[k][i] += (plaintextOutputBitString.at(i * 8 + j).at(k) << j);
+        }
+      }
+    }
+    return rst;
+  };
+  auto task1 = [](std::unique_ptr<IDataProcessor<1>> processor,
+                  size_t dataSize,
+                  const std::vector<int32_t>& indexes,
+                  size_t dataWidth) {
+    auto secretSharedOutput =
+        processor->processPeersData(dataSize, indexes, dataWidth);
+    secretSharedOutput.openToParty(0);
+  };
+
+  auto future0 =
+      std::async(task0, std::move(processor0), data, outputSize, dataWidth);
+  auto future1 =
+      std::async(task1, std::move(processor1), dataSize, index, dataWidth);
+  future1.get();
+  auto rst = future0.get();
+  for (size_t i = 0; i < outputSize; i++) {
+    fbpcf::testVectorEq(rst.at(i), expectedOutput.at(i));
+  }
+}
+
+TEST(DummyDataProcessor, testDummyDataProcessor) {
+  auto agentFactories = engine::communication::getInMemoryAgentFactory(2);
+  setupRealBackend<0, 1>(*agentFactories[0], *agentFactories[1]);
+
+  insecure::DummyDataProcessorFactory<0> factory0(0, 1, *agentFactories[0]);
+  insecure::DummyDataProcessorFactory<1> factory1(1, 0, *agentFactories[1]);
+  testDataProcessor(factory0.create(), factory1.create());
+}
+
+TEST(DataProcessor, testDataProcessor) {
+  auto agentFactories = engine::communication::getInMemoryAgentFactory(2);
+  setupRealBackend<0, 1>(*agentFactories[0], *agentFactories[1]);
+  auto factory0 =
+      getDataProcessorFactoryWithAesCtr<0>(0, 1, *agentFactories[0]);
+  auto factory1 =
+      getDataProcessorFactoryWithAesCtr<1>(1, 0, *agentFactories[1]);
+
+  testDataProcessor(factory0->create(), factory1->create());
+}
+
+} // namespace fbpcf::mpc_std_lib::unified_data_process::data_processor


### PR DESCRIPTION
Summary:
This diff copies the UDP library from FBPCS to FBPCF as we discussed. I would like to do this before modifying the B&R pipeline to use the UDP library in the new binary (https://fburl.com/code/o8fjub0z). Most likely if we try to use the `CompactionBasedInputProcessor` in the binary code it will break as the UDP library has not been added to clang yet.

This diff will automatically handle UDP code being available in fbpcf clang library (https://www.internalfb.com/code/)

Differential Revision: D40775439

