### PR TITLE
Create new targets for `mpc`, `millionaire`, and its tests

### DIFF
--- a/fbpcf/mpc/test/MpcAppExecutorTest.cpp
+++ b/fbpcf/mpc/test/MpcAppExecutorTest.cpp
@@ -13,7 +13,7 @@
 #include "folly/Random.h"
 
 #include "fbpcf/mpc/MpcAppExecutor.h"
-#include "test_apps/millionaire/MillionaireApp.h"
+#include "fbpcf/mpc/test/test_apps/millionaire/MillionaireApp.h"
 
 namespace fbpcf {
 class MpcAppExecutorTest : public ::testing::Test {

--- a/fbpcf/mpc/test/test_apps/millionaire/MillionaireApp.cpp
+++ b/fbpcf/mpc/test/test_apps/millionaire/MillionaireApp.cpp
@@ -7,7 +7,7 @@
 
 #include "folly/Random.h"
 
-#include "./MillionaireApp.h"
+#include "fbpcf/mpc/test/test_apps/millionaire/MillionaireApp.h"
 
 namespace fbpcf {
 

--- a/fbpcf/mpc/test/test_apps/millionaire/MillionaireApp.h
+++ b/fbpcf/mpc/test/test_apps/millionaire/MillionaireApp.h
@@ -9,8 +9,8 @@
 
 #include <emp-sh2pc/emp-sh2pc.h>
 
-#include "./MillionaireGame.h"
 #include "fbpcf/mpc/EmpApp.h"
+#include "fbpcf/mpc/test/test_apps/millionaire/MillionaireGame.h"
 
 namespace fbpcf {
 class MillionaireApp : public EmpApp<MillionaireGame<emp::NetIO>, int, bool> {

--- a/fbpcf/mpc/test/test_apps/millionaire/MillionaireGame.h
+++ b/fbpcf/mpc/test/test_apps/millionaire/MillionaireGame.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#pragma once
+
 #include <memory>
 
 #include "fbpcf/mpc/EmpGame.h"


### PR DESCRIPTION
Summary:
# Context
We want to refactor the targets in fbpcf to follow the convention of one folder, one TARGETS file.

# This Diff
Create new target for the `mpc` folder and also the `public_tld/.../millionaire` folder

# This Stack
This stack attacks the problem folder by folder, and removes pieces from the monolith target `lib_fbpcf`

Reviewed By: nguytc

Differential Revision: D40728133

