### PR TITLE
Add a Hotfix workflow for FBPCF

### DIFF
--- a/.github/workflows/build-and-publish-fbpcf-image.yml
+++ b/.github/workflows/build-and-publish-fbpcf-image.yml
@@ -1,0 +1,128 @@
+name: Build and Publish the FBPCF image
+
+on:
+  workflow_call:
+    inputs:
+      branch:
+        description: The branch we want to build.
+        required: true
+        type: string
+      version_tag:
+        description: The version tag to use for the new release. In the format of v{major}.{minor}.{patch}
+        required: true
+        type: string
+      docker_tags:
+        description: 'A comma separated list of tags to apply to the produced docker image. Example: latest,main,2.1,2.1.3'
+        required: true
+        type: string
+
+env:
+  BRANCH_NAME: ${{ inputs.branch }}
+  REGISTRY: ghcr.io
+  LOCAL_IMAGE_NAME: ${{ github.event.repository.name }}/ubuntu
+  REGISTRY_IMAGE_NAME: ghcr.io/${{ github.repository }}/ubuntu
+  VERSION_TAG: latest-build
+
+jobs:
+  build_and_publish_fbpcf_image:
+    if: startsWith(inputs.branch, 'hotfix/release-') || inputs.branch == 'main'
+    name: Build and Publish Hotfix Image
+    runs-on: [self-hosted, e2e_test_runner]
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ env.BRANCH_NAME }}
+
+      - name: Build fbpcf docker image
+        run: |
+          ./build-docker.sh -u
+
+      - name: Sanity check fbpcf library (v1)
+        timeout-minutes: 3
+        run: |
+          ./run-sanity_check.sh -u -v 1
+        working-directory: fbpcf/tests/github/
+
+      - name: Sanity check fbpcf library (v2)
+        timeout-minutes: 3
+        run: |
+          ./run-sanity_check.sh -u -v 2
+        working-directory: fbpcf/tests/github/
+
+      - name: Run Edit Distance E2E Test
+        timeout-minutes: 10
+        run: |
+          ./run-edit_distance_validation.sh -u
+          working-directory: fbpcf/tests/github/
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Clone latest stable fbpcs
+        run: |
+          git clone https://github.com/facebookresearch/fbpcs
+          cd fbpcs
+          git reset --hard $(curl \
+          --header 'content-type: application/json' \
+          "https://api.github.com/repos/facebookresearch/fbpcs/actions/workflows/12965519/runs?per_page=1&status=success" | jq \
+          ".workflow_runs[0] .head_sha" | tr -d '"')
+
+      - name: Build fbpcs image (this uses the locally built fbpcf image as a dependency)
+        run: |
+          cd fbpcs
+          ./build-docker.sh onedocker -t ${{ env.VERSION_TAG }}
+
+      - name: Tag fbpcf docker image
+        run: |
+          docker tag ${{ env.LOCAL_IMAGE_NAME }} ${{ env.REGISTRY_IMAGE_NAME }}:${{ github.sha }}
+
+      - name: Push fbpcf image to registry
+        run: |
+          docker push --all-tags ${{ env.REGISTRY_IMAGE_NAME }}
+
+      - name: Add tag to commit
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          custom_tag: ${{ inputs.version_tag }}
+          tag_prefix: ""
+
+      - name: Pull image for this commit from registry
+        run: |
+          docker pull ${{ env.REGISTRY_IMAGE_NAME }}:${{ github.sha }}
+
+      - name: Tag Docker image
+        run: |
+          tags=($(echo ${{ inputs.docker_tags }} | tr ',' ' '))
+          for t in ${tags[@]}; do
+            docker tag ${{ env.REGISTRY_IMAGE_NAME }}:${{ github.sha }} ${{ env.REGISTRY_IMAGE_NAME }}:$t
+          done
+
+      - name: Push Docker image
+        run: |
+          docker push --all-tags ${{ env.REGISTRY_IMAGE_NAME }}
+
+      - name: Create release
+        uses: "actions/create-release@v1"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          release_name: ${{ inputs.version_tag }}
+          tag_name: ${{ inputs.version_tag }}
+
+      - name: Cleanup
+        run: |
+          # remove all images
+          docker image prune -af
+
+          # stop and remove all containers
+          docker kill $(docker ps -q) || echo "No running containers to stop."
+          docker rm $(docker ps -a -q) || echo "No containers to delete."

--- a/.github/workflows/create-hotfix.yml
+++ b/.github/workflows/create-hotfix.yml
@@ -1,0 +1,41 @@
+name: Create Hotfix
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_tag:
+        description: "The tag that we want to base the hotfix on. This should be in the format of v1.2.3."
+        required: true
+        type: string
+      hotfix_commits:
+        description: "A comma separated list of commits to patch into the base revision"
+        required: true
+        type: string
+
+env:
+  BRANCH_NAME: hotfix/release-${{ inputs.base_tag }}
+
+jobs:
+  create_hotfix:
+    name: Create hotfix commit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Git config settings
+        run: |
+          git config --global user.name "GithubActions CreateHotfix"
+          git config --global user.email "pc_release@fb.com"
+
+      - name: Create and checkout hotfix branch
+        run: git show-branch remotes/origin/${{ env.BRANCH_NAME }} &>/dev/null && git checkout ${{ env.BRANCH_NAME }} || git checkout ${{ inputs.base_tag }} -b ${{ env.BRANCH_NAME }} && git push -u origin ${{ env.BRANCH_NAME }}
+
+      - name: Cherry pick hotfix commit
+        run: |
+          commits=$(echo ${{ github.event.inputs.hotfix_commits }} | tr ',' ' ')
+          git cherry-pick $commits
+
+      - name: Push hotfix commit to origin
+        run: git push origin ${{ env.BRANCH_NAME }}

--- a/.github/workflows/publish-hotfix.yml
+++ b/.github/workflows/publish-hotfix.yml
@@ -1,0 +1,42 @@
+name: Publish Hotfix Image
+
+on:
+  push:
+    branches:
+      - hotfix/release-*
+
+jobs:
+  get_base_tag:
+    runs-on: ubuntu-latest
+    outputs:
+      base_tag: ${{ steps.get_base_tag.outputs.base_tag }}
+    steps:
+      - name: Get Base Tag
+        id: get_base_tag
+        run: echo "base_tag=$(echo ${{ github.ref_name }} | tr 'hotfix/release-' '')" >> $GITHUB_OUTPUT
+
+  create_version:
+    name: Create new Hotfix Version
+    runs-on: ubuntu-latest
+    needs: get_base_tag
+    outputs:
+      version_tag: ${{ steps.create_version.outputs.version_tag }}
+      docker_version_tag: ${{ steps.create_version.outputs.docker_version_tag }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Create version
+        id: create_version
+        run: |
+          increment="$(git rev-list --count ${{ needs.get_base_tag.outputs.base_tag }}..HEAD)"
+          version="${{ needs.get_base_tag.outputs.base_tag }}.${increment}"
+          echo "version_tag=${version}" >> $GITHUB_OUTPUT
+          echo "docker_version_tag="${version:1}"" >> $GITHUB_OUTPUT
+
+  build_and_publish_fbpcf_image:
+    name: Build and Publish Hotfix Image
+    needs: create_version
+    uses: ./.github/workflows/build-and-publish-fbpcf-image.yml
+    with:
+      branch: ${{ github.ref_name }}
+      version_tag: ${{ needs.create_version.outputs.version_tag }}
+      docker_tags: ${{ needs.create_version.outputs.docker_version_tag }}


### PR DESCRIPTION
Summary:
## Background
As of right now, there is not a good way for us to Hotfix any changes to FBPCF. It is a continuous release process and if there is a bug, the standard process right now is to fix the bug, land the change, and then bump the version. This presents an issue in the case where a given release (say 2.2.0 for example) includes a bug which has been deployed to Canary or Production. This could cause a SEV and lead to us needing to release a new hotfixed release. If 2.2.1 has already been released by the time that we figure out 2.2.0 has a bug and 2.2.1 also introduces a different unrelated bug, this means that we need to wait for resolutions* to the 2.2.0 bug and the 2.2.1 bug in the current flow before we can release 2.2.2 and update FBPCS. We also may be under a code freeze and want to release as small of a fix as possible to production, which means we either can’t land any new code to FBPCF after the last release of the year, or we need another solution.

## This diff
This diff adds a new workflow that can be used to create a hotfix release. It is intended to be used to apply fix commits directly on a release version that is in prod. It does this by creating a new branch off the base tag (v2.2.0) and cherry-picking a comma separated list of commit hashes onto the hotfix branch. It then builds and tests the resulting docker image and creates a release in the format of 'v{base_tag}.{commits_since_the_base_tag}'. From the example above, if there were one commit to cherry pick, the resulting version would be 2.2.0.1.

This workflow would also support a second hotfix to the same tag. In the event of a long lived release, we may find more than one issue that needs hotfixed. By inputing the same base tag, you are able to check out the existing hotfix branch and add the fixes to the branch.

Differential Revision: D40858259

