### PR TITLE
Adding getTlsInfoFromArgs API in fbpcf & marking the one in fbpcs as depreciated (#1864)

### DIFF
--- a/fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.cpp
+++ b/fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.cpp
@@ -13,6 +13,30 @@
 
 namespace fbpcf::engine::communication {
 
+SocketPartyCommunicationAgent::TlsInfo getTlsInfoFromArgs(
+    bool useTls,
+    std::string ca_cert_path,
+    std::string server_cert_path,
+    std::string private_key_path,
+    std::string passphrase_path) {
+  const char* home_dir = std::getenv("HOME");
+  if (home_dir == nullptr) {
+    home_dir = "";
+  }
+
+  std::string home_dir_string(home_dir);
+
+  fbpcf::engine::communication::SocketPartyCommunicationAgent::TlsInfo tlsInfo;
+  tlsInfo.useTls = useTls;
+  tlsInfo.rootCaCertPath = useTls ? (home_dir_string + "/" + ca_cert_path) : "";
+  tlsInfo.certPath = useTls ? (home_dir_string + "/" + server_cert_path) : "";
+  tlsInfo.keyPath = useTls ? (home_dir_string + "/" + private_key_path) : "";
+  tlsInfo.passphrasePath =
+      useTls ? (home_dir_string + "/" + passphrase_path) : "";
+
+  return tlsInfo;
+}
+
 std::unique_ptr<IPartyCommunicationAgent>
 SocketPartyCommunicationAgentFactory::create(int id, std::string name) {
   if (id == myId_) {

--- a/fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h
+++ b/fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h
@@ -24,6 +24,13 @@
 
 namespace fbpcf::engine::communication {
 
+SocketPartyCommunicationAgent::TlsInfo getTlsInfoFromArgs(
+    bool useTls,
+    std::string ca_cert_path,
+    std::string server_cert_path,
+    std::string private_key_path,
+    std::string passphrase_path);
+
 /**
  * An communication factory API
  */

--- a/fbpcf/engine/communication/test/PartyCommunicationAgentTest.cpp
+++ b/fbpcf/engine/communication/test/PartyCommunicationAgentTest.cpp
@@ -302,4 +302,45 @@ TEST(SocketPartyCommunicationAgentTest, testTimeout) {
       std::runtime_error);
 }
 
+TEST(UtilTest, TestGetTlsInfoFromArguments) {
+  auto tlsInfo = getTlsInfoFromArgs(
+      false,
+      "cert_path",
+      "server_cert_path",
+      "private_key_path",
+      "passphrase_path");
+
+  EXPECT_FALSE(tlsInfo.useTls);
+  EXPECT_STREQ(tlsInfo.rootCaCertPath.c_str(), "");
+  EXPECT_STREQ(tlsInfo.certPath.c_str(), "");
+  EXPECT_STREQ(tlsInfo.keyPath.c_str(), "");
+  EXPECT_STREQ(tlsInfo.passphrasePath.c_str(), "");
+
+  const char* home_dir = std::getenv("HOME");
+  if (home_dir == nullptr) {
+    home_dir = "";
+  }
+
+  std::string home_dir_string(home_dir);
+
+  tlsInfo = getTlsInfoFromArgs(
+      true,
+      "cert_path",
+      "server_cert_path",
+      "private_key_path",
+      "passphrase_path");
+
+  EXPECT_TRUE(tlsInfo.useTls);
+  EXPECT_STREQ(
+      tlsInfo.rootCaCertPath.c_str(), (home_dir_string + "/cert_path").c_str());
+  EXPECT_STREQ(
+      tlsInfo.certPath.c_str(),
+      (home_dir_string + "/server_cert_path").c_str());
+  EXPECT_STREQ(
+      tlsInfo.keyPath.c_str(), (home_dir_string + "/private_key_path").c_str());
+  EXPECT_STREQ(
+      tlsInfo.passphrasePath.c_str(),
+      (home_dir_string + "/passphrase_path").c_str());
+}
+
 } // namespace fbpcf::engine::communication


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/fbpcs/pull/1864

As title.
This function will be used in multiple binaries (as opposite to only emp games). It makes more sense to add it in fbpcf folder.

Reviewed By: adshastri

Differential Revision: D40878071

