### PR TITLE
Enable autodeps for millionaire example

### DIFF
--- a/example/millionaire/MillionaireApp.cpp
+++ b/example/millionaire/MillionaireApp.cpp
@@ -7,7 +7,7 @@
 
 #include "folly/Random.h"
 
-#include "./MillionaireApp.h"
+#include "./MillionaireApp.h" // @manual
 
 namespace fbpcf {
 

--- a/example/millionaire/MillionaireApp.h
+++ b/example/millionaire/MillionaireApp.h
@@ -9,7 +9,7 @@
 
 #include <emp-sh2pc/emp-sh2pc.h>
 
-#include "./MillionaireGame.h"
+#include "./MillionaireGame.h" // @manual
 #include "fbpcf/mpc/EmpApp.h"
 
 namespace fbpcf {

--- a/example/millionaire/main.cpp
+++ b/example/millionaire/main.cpp
@@ -12,7 +12,7 @@
 #include "folly/init/Init.h"
 #include "folly/logging/xlog.h"
 
-#include "./MillionaireApp.h"
+#include "./MillionaireApp.h" // @manual
 #include "fbpcf/exception/ExceptionBase.h"
 
 DEFINE_int32(role, 1, "1 = Alice, 2 = Bob");

--- a/example/millionaire/test/MillionaireAppTest.cpp
+++ b/example/millionaire/test/MillionaireAppTest.cpp
@@ -11,7 +11,7 @@
 
 #include "folly/Random.h"
 
-#include "../MillionaireApp.h"
+#include "../MillionaireApp.h" // @manual
 
 namespace fbpcf {
 

--- a/example/millionaire/test/MillionaireGameTest.cpp
+++ b/example/millionaire/test/MillionaireGameTest.cpp
@@ -10,7 +10,7 @@
 #include <emp-sh2pc/emp-sh2pc.h>
 #include <gtest/gtest.h>
 
-#include "../MillionaireGame.h"
+#include "../MillionaireGame.h" // @manual
 #include "fbpcf/mpc/EmpTestUtil.h"
 #include "fbpcf/system/CpuUtil.h"
 

--- a/fbpcf/io/GCSFileManager.h
+++ b/fbpcf/io/GCSFileManager.h
@@ -7,14 +7,14 @@
 
 #pragma once
 
-#include <google/cloud/storage/client.h>
+#include <google/cloud/storage/client.h> // @manual
 
 #include <fbpcf/exception/GcpException.h>
 #include <fbpcf/gcp/GCSUtil.h>
 #include "IInputStream.h"
 #include "fbpcf/io/IFileManager.h"
 
-#include <google/cloud/storage/download_options.h>
+#include <google/cloud/storage/download_options.h> // @manual
 #include <memory>
 #include <sstream>
 

--- a/fbpcf/io/GCSInputStream.h
+++ b/fbpcf/io/GCSInputStream.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <google/cloud/storage/object_read_stream.h>
+#include <google/cloud/storage/object_read_stream.h> // @manual
 #include <istream>
 
 #include "fbpcf/io/IInputStream.h"

--- a/fbpcf/io/S3FileManager.cpp
+++ b/fbpcf/io/S3FileManager.cpp
@@ -12,8 +12,8 @@
 #include <memory>
 #include <sstream>
 
-#include <aws/s3/model/GetObjectRequest.h>
-#include <aws/s3/model/PutObjectRequest.h>
+#include <aws/s3/model/GetObjectRequest.h> // @manual
+#include <aws/s3/model/PutObjectRequest.h> // @manual
 #include <string>
 
 #include "LocalFileManager.h"

--- a/fbpcf/io/S3FileManager.h
+++ b/fbpcf/io/S3FileManager.h
@@ -9,7 +9,7 @@
 
 #include <memory>
 
-#include <aws/s3/S3Client.h>
+#include <aws/s3/S3Client.h> // @manual
 #include <sstream>
 
 #include "IFileManager.h"

--- a/fbpcf/io/S3InputStream.h
+++ b/fbpcf/io/S3InputStream.h
@@ -9,7 +9,7 @@
 
 #include <istream>
 
-#include <aws/s3/model/GetObjectResult.h>
+#include <aws/s3/model/GetObjectResult.h> // @manual
 
 #include "IInputStream.h"
 

--- a/fbpcf/io/cloud_util/CloudFileUtil.cpp
+++ b/fbpcf/io/cloud_util/CloudFileUtil.cpp
@@ -9,7 +9,7 @@
 
 #include <string>
 
-#include <google/cloud/storage/client.h>
+#include <google/cloud/storage/client.h> // @manual
 #include <re2/re2.h>
 
 #include "fbpcf/aws/S3Util.h"

--- a/fbpcf/io/cloud_util/GCSFileReader.cpp
+++ b/fbpcf/io/cloud_util/GCSFileReader.cpp
@@ -7,7 +7,7 @@
 
 #include "fbpcf/io/cloud_util/GCSFileReader.h"
 #include <fbpcf/gcp/GCSUtil.h>
-#include <google/cloud/storage/download_options.h>
+#include <google/cloud/storage/download_options.h> // @manual
 #include "fbpcf/exception/GcpException.h"
 
 namespace fbpcf::cloudio {

--- a/fbpcf/io/cloud_util/GCSFileReader.h
+++ b/fbpcf/io/cloud_util/GCSFileReader.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <google/cloud/storage/client.h>
+#include <google/cloud/storage/client.h> // @manual
 
 #include <memory>
 #include <sstream>

--- a/fbpcf/io/cloud_util/GCSFileUploader.h
+++ b/fbpcf/io/cloud_util/GCSFileUploader.h
@@ -10,7 +10,7 @@
 #include <memory>
 #include <vector>
 
-#include <google/cloud/storage/client.h>
+#include <google/cloud/storage/client.h> // @manual
 #include "fbpcf/io/cloud_util/IFileUploader.h"
 
 namespace fbpcf::cloudio {

--- a/fbpcf/io/cloud_util/S3Client.cpp
+++ b/fbpcf/io/cloud_util/S3Client.cpp
@@ -7,8 +7,8 @@
 
 #include "fbpcf/io/cloud_util/S3Client.h"
 
-#include <aws/core/Aws.h>
-#include <aws/s3/S3Client.h>
+#include <aws/core/Aws.h> // @manual
+#include <aws/s3/S3Client.h> // @manual
 
 namespace fbpcf::cloudio {
 S3Client& S3Client::getInstance(const fbpcf::aws::S3ClientOption& option) {

--- a/fbpcf/io/cloud_util/S3Client.h
+++ b/fbpcf/io/cloud_util/S3Client.h
@@ -9,8 +9,8 @@
 
 #include <memory>
 
-#include <aws/core/Aws.h>
-#include <aws/s3/S3Client.h>
+#include <aws/core/Aws.h> // @manual
+#include <aws/s3/S3Client.h> // @manual
 #include "fbpcf/aws/S3Util.h"
 
 namespace fbpcf::cloudio {

--- a/fbpcf/io/cloud_util/S3FileReader.cpp
+++ b/fbpcf/io/cloud_util/S3FileReader.cpp
@@ -6,8 +6,8 @@
  */
 
 #include "fbpcf/io/cloud_util/S3FileReader.h"
-#include <aws/s3/model/GetObjectRequest.h>
-#include <aws/s3/model/HeadObjectRequest.h>
+#include <aws/s3/model/GetObjectRequest.h> // @manual
+#include <aws/s3/model/HeadObjectRequest.h> // @manual
 #include <string>
 #include "fbpcf/aws/S3Util.h"
 #include "fbpcf/exception/AwsException.h"

--- a/fbpcf/io/cloud_util/S3FileReader.h
+++ b/fbpcf/io/cloud_util/S3FileReader.h
@@ -9,7 +9,7 @@
 
 #include <memory>
 
-#include <aws/s3/S3Client.h>
+#include <aws/s3/S3Client.h> // @manual
 #include "fbpcf/io/cloud_util/IFileReader.h"
 
 namespace fbpcf::cloudio {

--- a/fbpcf/io/cloud_util/S3FileUploader.cpp
+++ b/fbpcf/io/cloud_util/S3FileUploader.cpp
@@ -6,11 +6,11 @@
  */
 
 #include "fbpcf/io/cloud_util/S3FileUploader.h"
-#include <aws/s3/model/AbortMultipartUploadRequest.h>
-#include <aws/s3/model/CompleteMultipartUploadRequest.h>
-#include <aws/s3/model/CompletedMultipartUpload.h>
-#include <aws/s3/model/CreateMultipartUploadRequest.h>
-#include <aws/s3/model/UploadPartRequest.h>
+#include <aws/s3/model/AbortMultipartUploadRequest.h> // @manual
+#include <aws/s3/model/CompleteMultipartUploadRequest.h> // @manual
+#include <aws/s3/model/CompletedMultipartUpload.h> // @manual
+#include <aws/s3/model/CreateMultipartUploadRequest.h> // @manual
+#include <aws/s3/model/UploadPartRequest.h> // @manual
 #include <folly/logging/xlog.h>
 #include "fbpcf/aws/S3Util.h"
 #include "fbpcf/exception/AwsException.h"

--- a/fbpcf/io/cloud_util/S3FileUploader.h
+++ b/fbpcf/io/cloud_util/S3FileUploader.h
@@ -7,8 +7,8 @@
 
 #pragma once
 
-#include <aws/s3/S3Client.h>
-#include <aws/s3/model/CompletedPart.h>
+#include <aws/s3/S3Client.h> // @manual
+#include <aws/s3/model/CompletedPart.h> // @manual
 #include <memory>
 #include "fbpcf/io/cloud_util/IFileUploader.h"
 


### PR DESCRIPTION
Summary: Enable autodeps for millionaire example by specifying `manual` for all the relative paths

Reviewed By: tgamal

Differential Revision: D40876882

