### PR TITLE
Stop copying input values in batch gates

### DIFF
--- a/fbpcf/engine/tuple_generator/ITupleGenerator.h
+++ b/fbpcf/engine/tuple_generator/ITupleGenerator.h
@@ -158,12 +158,12 @@ class ITupleGenerator {
     }
 
     // get the vector of B bit shares
-    std::vector<bool> getB() {
+    const std::vector<bool>& getB() {
       return b_;
     }
 
     // get the vector of C bit shares
-    std::vector<bool> getC() {
+    const std::vector<bool>& getC() {
       return c_;
     }
 

--- a/fbpcf/scheduler/IAllocator.h
+++ b/fbpcf/scheduler/IAllocator.h
@@ -21,7 +21,10 @@ class IAllocator {
  public:
   virtual ~IAllocator() = default;
 
-  // Allocate a value of type T and return an ID reference to it.
+  /* Allocate a value of type T and return an ID reference to it.
+   * This method invalidates any references returned by get or
+   * getWritableReference
+   */
   virtual uint64_t allocate(T&& value) = 0;
 
   // Free the object with the given ID reference.

--- a/fbpcf/scheduler/gate_keeper/BatchCompositeGate.h
+++ b/fbpcf/scheduler/gate_keeper/BatchCompositeGate.h
@@ -49,7 +49,7 @@ class BatchCompositeGate final : public ICompositeGate {
     switch (gateType_) {
         // Free gates
       case GateType::FreeAnd: {
-        auto leftValues = wireKeeper_.getBatchBooleanValue(left_);
+        auto& leftValues = wireKeeper_.getBatchBooleanValue(left_);
         numberOfResults_ = leftValues.size() * outputWireIDs_.size();
 
         for (size_t i = 0; i < outputWireIDs_.size(); i++) {
@@ -61,7 +61,7 @@ class BatchCompositeGate final : public ICompositeGate {
       }
 
       case GateType::NonFreeAnd: {
-        auto leftValues = wireKeeper_.getBatchBooleanValue(left_);
+        auto& leftValues = wireKeeper_.getBatchBooleanValue(left_);
         std::vector<std::vector<bool>> rightWireValues(outputWireIDs_.size());
         for (size_t i = 0; i < outputWireIDs_.size(); i++) {
           rightWireValues[i] = wireKeeper_.getBatchBooleanValue(rights_[i]);

--- a/fbpcf/scheduler/gate_keeper/BatchNormalGate.h
+++ b/fbpcf/scheduler/gate_keeper/BatchNormalGate.h
@@ -59,7 +59,7 @@ class BatchNormalGate final : public INormalGate {
     switch (gateType_) {
         // Free gates
       case GateType::AsymmetricNot: {
-        auto values = wireKeeper_.getBatchBooleanValue(left_);
+        auto& values = wireKeeper_.getBatchBooleanValue(left_);
         numberOfResults_ = values.size();
         wireKeeper_.setBatchBooleanValue(
             wireID_, engine.computeBatchAsymmetricNOT(values));
@@ -67,8 +67,8 @@ class BatchNormalGate final : public INormalGate {
       }
 
       case GateType::AsymmetricXOR: {
-        auto leftValues = wireKeeper_.getBatchBooleanValue(left_);
-        auto rightValues = wireKeeper_.getBatchBooleanValue(right_);
+        auto& leftValues = wireKeeper_.getBatchBooleanValue(left_);
+        auto& rightValues = wireKeeper_.getBatchBooleanValue(right_);
         numberOfResults_ = leftValues.size();
         wireKeeper_.setBatchBooleanValue(
             wireID_, engine.computeBatchAsymmetricXOR(leftValues, rightValues));
@@ -76,8 +76,8 @@ class BatchNormalGate final : public INormalGate {
       }
 
       case GateType::FreeAnd: {
-        auto leftValues = wireKeeper_.getBatchBooleanValue(left_);
-        auto rightValues = wireKeeper_.getBatchBooleanValue(right_);
+        auto& leftValues = wireKeeper_.getBatchBooleanValue(left_);
+        auto& rightValues = wireKeeper_.getBatchBooleanValue(right_);
         numberOfResults_ = leftValues.size();
         wireKeeper_.setBatchBooleanValue(
             wireID_, engine.computeBatchFreeAND(leftValues, rightValues));
@@ -88,7 +88,7 @@ class BatchNormalGate final : public INormalGate {
         break;
 
       case GateType::SymmetricNot: {
-        auto values = wireKeeper_.getBatchBooleanValue(left_);
+        auto& values = wireKeeper_.getBatchBooleanValue(left_);
         numberOfResults_ = values.size();
         wireKeeper_.setBatchBooleanValue(
             wireID_, engine.computeBatchSymmetricNOT(values));
@@ -96,8 +96,8 @@ class BatchNormalGate final : public INormalGate {
       }
 
       case GateType::SymmetricXOR: {
-        auto leftValues = wireKeeper_.getBatchBooleanValue(left_);
-        auto rightValues = wireKeeper_.getBatchBooleanValue(right_);
+        auto& leftValues = wireKeeper_.getBatchBooleanValue(left_);
+        auto& rightValues = wireKeeper_.getBatchBooleanValue(right_);
         numberOfResults_ = leftValues.size();
         wireKeeper_.setBatchBooleanValue(
             wireID_, engine.computeBatchSymmetricXOR(leftValues, rightValues));
@@ -114,15 +114,15 @@ class BatchNormalGate final : public INormalGate {
         auto& secretShares = secretSharesByParty.at(partyID_).booleanSecrets;
         scheduledResultIndex_ = secretShares.size();
 
-        auto values = wireKeeper_.getBatchBooleanValue(left_);
+        auto& values = wireKeeper_.getBatchBooleanValue(left_);
         numberOfResults_ = values.size();
         secretShares.insert(secretShares.end(), values.begin(), values.end());
         break;
       }
 
       case GateType::NonFreeAnd: {
-        auto leftValues = wireKeeper_.getBatchBooleanValue(left_);
-        auto rightValues = wireKeeper_.getBatchBooleanValue(right_);
+        auto& leftValues = wireKeeper_.getBatchBooleanValue(left_);
+        auto& rightValues = wireKeeper_.getBatchBooleanValue(right_);
 
         numberOfResults_ = leftValues.size();
         if (numberOfResults_ == 0) {


### PR DESCRIPTION
Summary:
From RuiyuZhu strobelight run we see that `std::copy_move` takes almost 37% of the time (https://fburl.com/strobelight/ejh2rf3m).

When zooming in on this function we see that `compute` takes up 20% of this. This is like a 7% win

{F788481230}

Differential Revision: D40907157

