### PR TITLE
Fix FBPCF Hotfixing

### DIFF
--- a/.github/workflows/create-hotfix.yml
+++ b/.github/workflows/create-hotfix.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ssh-key: ${{ secrets.PUSH_KEY }}
 
       - name: Git config settings
         run: |
@@ -30,7 +31,7 @@ jobs:
           git config --global user.email "pc_release@fb.com"
 
       - name: Create and checkout hotfix branch
-        run: git show-branch remotes/origin/${{ env.BRANCH_NAME }} &>/dev/null && git checkout ${{ env.BRANCH_NAME }} || git checkout ${{ inputs.base_tag }} -b ${{ env.BRANCH_NAME }} && git push -u origin ${{ env.BRANCH_NAME }}
+        run: git show-branch remotes/origin/${{ env.BRANCH_NAME }} &>/dev/null && git checkout ${{ env.BRANCH_NAME }} || git checkout ${{ inputs.base_tag }} -b ${{ env.BRANCH_NAME }}
 
       - name: Cherry pick hotfix commit
         run: |
@@ -38,4 +39,4 @@ jobs:
           git cherry-pick $commits
 
       - name: Push hotfix commit to origin
-        run: git push origin ${{ env.BRANCH_NAME }}
+        run: git push -u origin ${{ env.BRANCH_NAME }}


### PR DESCRIPTION
Summary:
## Context
After a long search I finally found https://github.com/orgs/community/discussions/25702 which explains why when we run the "Create Hotfix" action, the subsequent push-based action is not triggered. It recommends using a personal access token, but I don't think that is a good idea for our use case as anyone whose token we might use could eventually be removed as a contributor and then our pipeline would stop working. The next best option is adding a deploy key. This is essentially an SSH key that can be used by anyone to deploy the repo. After it is added, I can update the checkout action to use that deploy key to push the hotfix and trigger the hotfix deployment.

## This diff
This diff updates the create hotfix workflow to use the new deploy key that will be created as part of T136993451. After that, the hotfix workflow should work as intended.

Differential Revision: D40987028

