### PR TITLE
[B&R] Fix the FBPCF hotfix workflow

### DIFF
--- a/.github/workflows/publish-hotfix.yml
+++ b/.github/workflows/publish-hotfix.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Get Base Tag
         id: get_base_tag
-        run: echo "base_tag=$(echo ${{ github.ref_name }} | tr 'hotfix/release-' '')" >> $GITHUB_OUTPUT
+        run: echo "base_tag=$(echo ${{ github.ref_name }} | tr -d 'hotfix/release-')" >> $GITHUB_OUTPUT
 
   create_version:
     name: Create new Hotfix Version
@@ -24,13 +24,16 @@ jobs:
       docker_version_tag: ${{ steps.create_version.outputs.docker_version_tag }}
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
       - name: Create version
         id: create_version
         run: |
           increment="$(git rev-list --count ${{ needs.get_base_tag.outputs.base_tag }}..HEAD)"
           version="${{ needs.get_base_tag.outputs.base_tag }}.${increment}"
           echo "version_tag=${version}" >> $GITHUB_OUTPUT
-          echo "docker_version_tag="${version:1}"" >> $GITHUB_OUTPUT
+          echo "docker_version_tag=${version:1}" >> $GITHUB_OUTPUT
 
   build_and_publish_fbpcf_image:
     name: Build and Publish Hotfix Image


### PR DESCRIPTION
These changes fix the current FBPCF workflow for versioning and building the FBPCF hotfix package. It includes 2 changes:

1. Fix the translate command. Currenly we were trying to pass the translate command an empty string which causes it to fail.
2. Fix the fetch depth. In one of the checkouts, we were not fetching all of the tags which caused us to not be able to calculate the increment number.

# Test Plan
I ran the hotfix workflow in my fork and it was able to create a new version and upload the packages:

<img width="3007" alt="Screen Shot 2022-11-07 at 8 02 26 PM" src="https://user-images.githubusercontent.com/12445270/200449645-3c7da11d-e482-46c8-9c78-2f632eb111e7.png">
<img width="3008" alt="Screen Shot 2022-11-07 at 8 02 37 PM" src="https://user-images.githubusercontent.com/12445270/200449665-dd34d6ee-18be-4925-aa15-41cb049e8a55.png">
<img width="3005" alt="Screen Shot 2022-11-07 at 8 03 15 PM" src="https://user-images.githubusercontent.com/12445270/200449652-6b8f5a9f-afce-43dc-881d-a99f50388c1e.png">
<img width="2993" alt="Screen Shot 2022-11-07 at 8 03 02 PM" src="https://user-images.githubusercontent.com/12445270/200449660-c2b5204a-c614-48fc-b062-e329f3550366.png">

This time I am creating the diff directly from a Pull Request to make sure nothing is lost in the copy.