### PR TITLE
Fix incorrectly labeled CMake option for EMP

### DIFF
--- a/.github/workflows/folly-publish.yml
+++ b/.github/workflows/folly-publish.yml
@@ -3,9 +3,10 @@ name: Build and publish folly dependency
 on:
   workflow_dispatch:
     inputs:
-      name:
-        description: "Build and publish an fbpcf/folly image for a particular version"
-        default: "Run"
+      image_tag:
+        description: "The tag to apply to the folly image. Previously this was the folly version (e.g. 2021.03.29.00)"
+        required: true
+        type: string
       folly_release:
         description: "The folly version to build and publish (e.g. 2021.03.29.00)"
         required: true
@@ -17,12 +18,12 @@ on:
       os:
         description: "Which os to use. Currently only supports ubuntu"
         required: false
-        type: str
+        type: string
         default: "ubuntu"
       os_release:
         description: "The os version to use (e.g. 20.04 for ubuntu)"
         required: false
-        type: str
+        type: string
         default: "20.04"
 
 env:
@@ -48,17 +49,17 @@ jobs:
       - name: Build image
         run: |
           docker build \
-          --build-arg os_release=${{ github.event.inputs.os_release }} \
-          --build-arg folly_release=${{ github.event.inputs.folly_release }} \
-          --build-arg fmt_release=${{ github.event.inputs.fmt_release }} \
-          -t "fbpcf/${{ github.event.inputs.os }}-folly:${{ github.event.inputs.folly_release }}" \
-          -f "docker/folly/Dockerfile.${{ github.event.inputs.os }}" .
+          --build-arg os_release=${{ inputs.os_release }} \
+          --build-arg folly_release=${{ inputs.folly_release }} \
+          --build-arg fmt_release=${{ inputs.fmt_release }} \
+          -t "fbpcf/${{ inputs.os }}-folly:${{ inputs.image_tag }}" \
+          -f "docker/folly/Dockerfile.${{ inputs.os }}" .
 
       - name: Tag image
         run: |
-          docker tag fbpcf/${{ github.event.inputs.os }}-folly:${{ github.event.inputs.folly_release }} \
-          ${{ env.REGISTRY }}/${{ github.repository }}/${{ github.event.inputs.os }}-folly:${{ github.event.inputs.folly_release }}
+          docker tag fbpcf/${{ inputs.os }}-folly:${{ inputs.follimage_tagy_release }} \
+          ${{ env.REGISTRY }}/${{ github.repository }}/${{ inputs.os }}-folly:${{ inputs.image_tag }}
 
       - name: Publish image
         run: |
-          docker push --all-tags ${{ env.REGISTRY }}/${{ github.repository }}/${{ github.event.inputs.os }}-folly
+          docker push --all-tags ${{ env.REGISTRY }}/${{ github.repository }}/${{ inputs.os }}-folly

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ cd folly || exit
 git checkout v2020.10.12.00
 mkdir _build
 cd _build || exit
-cmake .. -DFOLLY_USE_JEMALLOC=0 -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-march=native"
+cmake .. -DFOLLY_USE_JEMALLOC=0 -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-march=x86-64"
 make
 sudo make install
 ```

--- a/docker/folly/Dockerfile.ubuntu
+++ b/docker/folly/Dockerfile.ubuntu
@@ -46,7 +46,7 @@ RUN git clone https://github.com/facebook/folly.git
 WORKDIR /root/build/folly
 RUN git checkout tags/v${folly_release} -b v${folly_release}
 
-RUN cmake DBUILD_SHARED_LIBS=OFF -DFOLLY_USE_JEMALLOC=0 -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-march=native" .
+RUN cmake DBUILD_SHARED_LIBS=OFF -DFOLLY_USE_JEMALLOC=0 -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-march=x86-64" .
 RUN make && make install
 
 FROM ubuntu:${os_release}


### PR DESCRIPTION
Summary:
We've been adding this option to CMake called "EMP_USE_RANDOM_DEVICE" -- the intention is to *force* EMP to use `std::random_device` instead of `x86intrin.h` since the former is guaranteed to exist on all systems but the latter is CPU-dependent.

Unfortunately... we named it incorrectly. We shouldn't be using the `EMP_` prefix. By doing so, we were letting EMP decide whether to use `std::random_device` or `x86intrin.h` by checking if the build machine had access to `rdseed` internally.

What this means is that in some cases (like the ones described in the linked SEV task), we built on a machine with access to `rdseed`, but later when running in ECS, `rdseed` wasn't present. This gives the cryptic "Invalid Instruction" error because we're trying to execute a CPU instruction that doesn't exist on the machine where the computation is actually running.

Since there's no major difference to use between using `random_device` and `rdseed` and since we can't guarantee that we'll be given access to a machine with `rdseed` capabilities at runtime, we want to force EMP to always use `random_device`. This diff fixes that issue.

Differential Revision: D41193207

