### PR TITLE
Disable AVX512 Instruction set since some AWS machines don't support it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ cd folly || exit
 git checkout v2020.10.12.00
 mkdir _build
 cd _build || exit
-cmake .. -DFOLLY_USE_JEMALLOC=0 -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-march=native"
+cmake .. -DFOLLY_USE_JEMALLOC=0 -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-march=haswell"
 make
 sudo make install
 ```

--- a/docker/CMakeLists.txt
+++ b/docker/CMakeLists.txt
@@ -10,6 +10,10 @@ set(EDIT_DISTANCE_NAME "fbpcf_edit_distance")
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+# Don't compile with AVX512 instructions since many of the AWS
+# instances won't have access to that instruction set.
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mno-avx512f")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mno-avx512f")
 
 include(cmake/fbpcf.cmake)
 install(DIRECTORY cmake/ DESTINATION cmake/)

--- a/docker/folly/Dockerfile.ubuntu
+++ b/docker/folly/Dockerfile.ubuntu
@@ -46,7 +46,9 @@ RUN git clone https://github.com/facebook/folly.git
 WORKDIR /root/build/folly
 RUN git checkout tags/v${folly_release} -b v${folly_release}
 
-RUN cmake DBUILD_SHARED_LIBS=OFF -DFOLLY_USE_JEMALLOC=0 -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-march=native" .
+# Don't compile with AVX512 instructions since many of the AWS
+# instances won't have access to that instruction set.
+RUN cmake DBUILD_SHARED_LIBS=OFF -DFOLLY_USE_JEMALLOC=0 -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-march=haswell" .
 RUN make && make install
 
 FROM ubuntu:${os_release}


### PR DESCRIPTION
Summary:
## Context
While investigating T1335011570, we found a couple of issues that would cause the binaries to fail with an "Invalid instruction" error. One was that we had incorrectly passed a flag to the EMP library so we weren't disabling rdseed like we meant to. That is fixed in D41375296. The other issue we saw was with the AVX512 instruction sets. We noticed that we were getting this invalid instruction error after fixing the rdseed flag:
{F800014629}

After some more digging, it seemed to be related to some AVX512 instructions that were enabled on the newer build machine, but didn't exist on the older one.
{F800015070}

Here are the flags from the current build machine:
```
flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx pdpe1gb rdtscp lm constant_tsc rep_good nopl xtopology cpuid tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer ae
s xsave avx f16c rdrand hypervisor lahf_lm abm cpuid_fault invpcid_single pti fsgsbase bmi1 avx2 smep bmi2 erms invpcid xsaveopt
```

These instructions were included in both the Folly and FBPCF libraries.

## This Diff
This diff disables the AVX512 instructions in the FBPCF library.

Differential Revision:
D41388765

LaMa Project: L416713

