### PR TITLE
Fix -Wbitwise-instead-of-logical in 5 files starting w/ fbpcf/engine/tuple_generator/TwoPartyTupleGenerator.cpp

### DIFF
--- a/fbpcf/engine/tuple_generator/TwoPartyTupleGenerator.cpp
+++ b/fbpcf/engine/tuple_generator/TwoPartyTupleGenerator.cpp
@@ -214,7 +214,7 @@ TwoPartyTupleGenerator::expandRCOTResults(
       //    = H(kr) + H(lr) /
       // c2 = (H(l0) ^ H(l1)) & p ^ H(l0) + H(kp)
       //    = H(lp) + H(kp)
-      auto c = (a & b) ^ util::getLsb(sender0Messages.at(i)) ^
+      auto c = (a && b) ^ util::getLsb(sender0Messages.at(i)) ^
           util::getLsb(receiverMessages.at(i));
 
       result[i] = BooleanTuple(a, b, c);
@@ -266,7 +266,7 @@ TwoPartyTupleGenerator::expandRCOTResults(
         std::vector<bool> c(requestedTupleSize);
         for (size_t j = 0; j < requestedTupleSize; j++) {
           b[j] = sender0Gen[j] ^ sender1Gen[j];
-          c[j] = (b[j] & a) ^ sender0Gen[j] ^ receiverGen[j];
+          c[j] = (b[j] && a) ^ sender0Gen[j] ^ receiverGen[j];
         }
         result[i] = CompositeBooleanTuple(a, b, c);
       }

--- a/fbpcf/engine/tuple_generator/test/ProductShareGeneratorTest.cpp
+++ b/fbpcf/engine/tuple_generator/test/ProductShareGeneratorTest.cpp
@@ -70,7 +70,7 @@ void testGenerator(
   for (int i = 0; i < size; i++) {
     EXPECT_EQ(
         result0[i] ^ result1[i],
-        (left0[i] & right1[i]) ^ (left1[i] & right0[i]));
+        (left0[i] && right1[i]) ^ (left1[i] && right0[i]));
   }
 }
 

--- a/fbpcf/frontend/test/BitStringTest.cpp
+++ b/fbpcf/frontend/test/BitStringTest.cpp
@@ -183,11 +183,11 @@ TEST(StringTest, testAND) {
   auto t8 = (v4 & u4).getValue();
 
   for (size_t i = 0; i < testValue1.size(); i++) {
-    testValue1[i] = testValue1[i] & testValue2[i];
+    testValue1[i] = testValue1[i] && testValue2[i];
   }
   for (size_t i = 0; i < testBatchValue1.size(); i++) {
     for (size_t j = 0; j < testBatchValue1.at(0).size(); j++) {
-      testBatchValue1[i][j] = testBatchValue1[i][j] & testBatchValue2[i][j];
+      testBatchValue1[i][j] = testBatchValue1[i][j] && testBatchValue2[i][j];
     }
   }
 
@@ -437,11 +437,11 @@ TEST(StringTest, testResizeWithAND) {
   auto t8 = (v4 & u4).getValue();
 
   for (size_t i = 0; i < testValue1.size(); i++) {
-    testValue1[i] = testValue1[i] & testValue2[i];
+    testValue1[i] = testValue1[i] && testValue2[i];
   }
   for (size_t i = 0; i < testBatchValue1.size(); i++) {
     for (size_t j = 0; j < testBatchValue1.at(0).size(); j++) {
-      testBatchValue1[i][j] = testBatchValue1[i][j] & testBatchValue2[i][j];
+      testBatchValue1[i][j] = testBatchValue1[i][j] && testBatchValue2[i][j];
     }
   }
 

--- a/fbpcf/scheduler/PlaintextScheduler.cpp
+++ b/fbpcf/scheduler/PlaintextScheduler.cpp
@@ -174,7 +174,8 @@ IScheduler::WireId<IScheduler::Boolean> PlaintextScheduler::privateAndPrivate(
     WireId<IScheduler::Boolean> right) {
   nonFreeGates_++;
   return wireKeeper_->allocateBooleanValue(
-      wireKeeper_->getBooleanValue(left) & wireKeeper_->getBooleanValue(right));
+      wireKeeper_->getBooleanValue(left) &&
+      wireKeeper_->getBooleanValue(right));
 }
 
 IScheduler::WireId<IScheduler::Boolean>
@@ -189,7 +190,7 @@ PlaintextScheduler::privateAndPrivateBatch(
   nonFreeGates_ += leftValue.size();
   std::vector<bool> rst(leftValue.size());
   for (size_t i = 0; i < leftValue.size(); i++) {
-    rst[i] = leftValue[i] & rightValue[i];
+    rst[i] = leftValue[i] && rightValue[i];
   }
   return wireKeeper_->allocateBatchBooleanValue(rst, leftValue.size());
 }
@@ -199,7 +200,8 @@ IScheduler::WireId<IScheduler::Boolean> PlaintextScheduler::privateAndPublic(
     WireId<IScheduler::Boolean> right) {
   freeGates_++;
   return wireKeeper_->allocateBooleanValue(
-      wireKeeper_->getBooleanValue(left) & wireKeeper_->getBooleanValue(right));
+      wireKeeper_->getBooleanValue(left) &&
+      wireKeeper_->getBooleanValue(right));
 }
 
 IScheduler::WireId<IScheduler::Boolean>
@@ -214,7 +216,7 @@ PlaintextScheduler::privateAndPublicBatch(
   freeGates_ += leftValue.size();
   std::vector<bool> rst(leftValue.size());
   for (size_t i = 0; i < leftValue.size(); i++) {
-    rst[i] = leftValue.at(i) & rightValue.at(i);
+    rst[i] = leftValue.at(i) && rightValue.at(i);
   }
   return wireKeeper_->allocateBatchBooleanValue(rst, leftValue.size());
 }
@@ -547,7 +549,7 @@ PlaintextScheduler::computeCompositeAND(
   std::vector<IScheduler::WireId<IScheduler::Boolean>> rst;
   for (auto rightWire : rights) {
     rst.push_back(wireKeeper_->allocateBooleanValue(
-        leftValue & wireKeeper_->getBooleanValue(rightWire)));
+        leftValue && wireKeeper_->getBooleanValue(rightWire)));
   }
 
   return rst;
@@ -609,7 +611,7 @@ PlaintextScheduler::validateAndComputeBatchCompositeAND(
     }
     std::vector<bool> rst;
     for (size_t i = 0; i < leftValue.size(); i++) {
-      rst.push_back(leftValue[i] & rightValue[i]);
+      rst.push_back(leftValue[i] && rightValue[i]);
     }
     returnWires.push_back(
         wireKeeper_->allocateBatchBooleanValue(rst, leftValue.size()));


### PR DESCRIPTION
Summary:
With LLVM-15, `&&` and `||` are required for boolean operands, rather than `&` and `|` which can be confused for bitwise operations. Fixing such ambiguity helps makes our code more readable.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: meyering

Differential Revision: D42347736

