### PR TITLE
Add argument validation for unionMaps

### DIFF
--- a/fbpcf/mpc_std_lib/permuter/AsWaksmanPermuter.h
+++ b/fbpcf/mpc_std_lib/permuter/AsWaksmanPermuter.h
@@ -26,9 +26,10 @@ class AsWaksmanPermuter final
   AsWaksmanPermuter(int myId, int partnerId)
       : myId_(myId), partnerId_(partnerId) {}
 
-  SecBatchType permute(const SecBatchType& src, size_t size) const override;
+  SecBatchType permute_impl(const SecBatchType& src, size_t size)
+      const override;
 
-  SecBatchType permute(
+  SecBatchType permute_impl(
       const SecBatchType& src,
       size_t size,
       const std::vector<uint32_t>& order) const override;

--- a/fbpcf/mpc_std_lib/permuter/AsWaksmanPermuterForBitString_impl.h
+++ b/fbpcf/mpc_std_lib/permuter/AsWaksmanPermuterForBitString_impl.h
@@ -30,11 +30,11 @@ class AsWaksmanPermuter<std::vector<bool>, schedulerId> final
   AsWaksmanPermuter(int myId, int partnerId)
       : myId_(myId), partnerId_(partnerId) {}
 
-  frontend::BitString<true, schedulerId, true> permute(
+  frontend::BitString<true, schedulerId, true> permute_impl(
       const frontend::BitString<true, schedulerId, true>& src,
       size_t size) const override;
 
-  frontend::BitString<true, schedulerId, true> permute(
+  frontend::BitString<true, schedulerId, true> permute_impl(
       const frontend::BitString<true, schedulerId, true>& src,
       size_t size,
       const std::vector<uint32_t>& order) const override;
@@ -43,7 +43,7 @@ class AsWaksmanPermuter<std::vector<bool>, schedulerId> final
   std::vector<std::vector<bool>> computingBatchAndWithMpc(
       const std::vector<bool>& left,
       const std::vector<std::vector<bool>>& right) const;
-  void permute(
+  void permute_impl(
       std::vector<std::vector<bool>>& src,
       std::vector<size_t> batches,
       size_t totalSize,
@@ -82,7 +82,7 @@ class AsWaksmanPermuter<std::vector<bool>, schedulerId> final
 
 template <int schedulerId>
 frontend::BitString<true, schedulerId, true>
-AsWaksmanPermuter<std::vector<bool>, schedulerId>::permute(
+AsWaksmanPermuter<std::vector<bool>, schedulerId>::permute_impl(
     const frontend::BitString<true, schedulerId, true>& src,
     size_t size) const {
   std::vector<std::vector<bool>> vectorOfVectors =
@@ -93,7 +93,8 @@ AsWaksmanPermuter<std::vector<bool>, schedulerId>::permute(
   auto length = vectorOfVectors.at(0).size();
   std::vector<std::vector<bool>> dummyChoice;
 
-  permute(vectorOfVectors, std::vector<size_t>(1, length), length, dummyChoice);
+  permute_impl(
+      vectorOfVectors, std::vector<size_t>(1, length), length, dummyChoice);
   return frontend::BitString<true, schedulerId, true>(
       typename frontend::BitString<true, schedulerId, true>::ExtractedString(
           vectorOfVectors));
@@ -101,7 +102,7 @@ AsWaksmanPermuter<std::vector<bool>, schedulerId>::permute(
 
 template <int schedulerId>
 frontend::BitString<true, schedulerId, true>
-AsWaksmanPermuter<std::vector<bool>, schedulerId>::permute(
+AsWaksmanPermuter<std::vector<bool>, schedulerId>::permute_impl(
     const frontend::BitString<true, schedulerId, true>& src,
     size_t size,
     const std::vector<uint32_t>& order) const {
@@ -117,7 +118,7 @@ AsWaksmanPermuter<std::vector<bool>, schedulerId>::permute(
   computeChoiceVectors(
       std::vector<std::vector<uint32_t>>(1, order), rst, order.size());
 
-  permute(vectorOfVectors, std::vector<size_t>(1, length), length, rst);
+  permute_impl(vectorOfVectors, std::vector<size_t>(1, length), length, rst);
   return frontend::BitString<true, schedulerId, true>(
       typename frontend::BitString<true, schedulerId, true>::ExtractedString(
           vectorOfVectors));
@@ -147,7 +148,7 @@ AsWaksmanPermuter<std::vector<bool>, schedulerId>::computingBatchAndWithMpc(
 }
 
 template <int schedulerId>
-void AsWaksmanPermuter<std::vector<bool>, schedulerId>::permute(
+void AsWaksmanPermuter<std::vector<bool>, schedulerId>::permute_impl(
     std::vector<std::vector<bool>>& src,
     std::vector<size_t> batches,
     size_t totalSize,
@@ -166,7 +167,7 @@ void AsWaksmanPermuter<std::vector<bool>, schedulerId>::permute(
 
     // do some pre-swap
     swapInALayer(src, batches, givenChoices, false);
-    permute(src, newBatches, totalSize, givenChoices);
+    permute_impl(src, newBatches, totalSize, givenChoices);
     // do some post-swap
     swapInALayer(src, batches, givenChoices, true);
   }

--- a/fbpcf/mpc_std_lib/permuter/AsWaksmanPermuter_impl.h
+++ b/fbpcf/mpc_std_lib/permuter/AsWaksmanPermuter_impl.h
@@ -15,8 +15,9 @@ namespace fbpcf::mpc_std_lib::permuter {
 
 template <typename T, int schedulerId>
 typename AsWaksmanPermuter<T, schedulerId>::SecBatchType
-AsWaksmanPermuter<T, schedulerId>::permute(const SecBatchType& src, size_t size)
-    const {
+AsWaksmanPermuter<T, schedulerId>::permute_impl(
+    const SecBatchType& src,
+    size_t size) const {
   if (size == 1) {
     return src;
   }
@@ -32,8 +33,8 @@ AsWaksmanPermuter<T, schedulerId>::permute(const SecBatchType& src, size_t size)
 
   auto [first, second] =
       preSubPermutationSwap(src, std::move(firstSwapConditions), size);
-  auto permutedFirst = permute(std::move(first), size / 2);
-  auto permutedSecond = permute(std::move(second), size - size / 2);
+  auto permutedFirst = permute_impl(std::move(first), size / 2);
+  auto permutedSecond = permute_impl(std::move(second), size - size / 2);
 
   placeHolder.resize((size - 1) / 2);
   frontend::Bit<true, schedulerId, true> secondSwapConditions(
@@ -48,7 +49,7 @@ AsWaksmanPermuter<T, schedulerId>::permute(const SecBatchType& src, size_t size)
 
 template <typename T, int schedulerId>
 typename AsWaksmanPermuter<T, schedulerId>::SecBatchType
-AsWaksmanPermuter<T, schedulerId>::permute(
+AsWaksmanPermuter<T, schedulerId>::permute_impl(
     const SecBatchType& src,
     size_t size,
     const std::vector<uint32_t>& order) const {
@@ -68,10 +69,10 @@ AsWaksmanPermuter<T, schedulerId>::permute(
   auto [first, second] =
       preSubPermutationSwap(src, std::move(firstSwapConditions), size);
 
-  auto permutedFirst =
-      permute(std::move(first), size / 2, calculator.getFirstSubPermuteOrder());
+  auto permutedFirst = permute_impl(
+      std::move(first), size / 2, calculator.getFirstSubPermuteOrder());
 
-  auto permutedSecond = permute(
+  auto permutedSecond = permute_impl(
       std::move(second),
       size - size / 2,
       calculator.getSecondSubPermuteOrder());

--- a/fbpcf/mpc_std_lib/permuter/DummyPermuter.h
+++ b/fbpcf/mpc_std_lib/permuter/DummyPermuter.h
@@ -24,7 +24,8 @@ class DummyPermuter final
   using SecBatchType = typename util::SecBatchType<T, schedulerId>::type;
   DummyPermuter(int myId, int partnerId) : myId_(myId), partnerId_(partnerId) {}
 
-  SecBatchType permute(const SecBatchType& src, size_t size) const override {
+  SecBatchType permute_impl(const SecBatchType& src, size_t size)
+      const override {
     std::vector<SecBatchType> unbatched =
         util::MpcAdapters<T, schedulerId>::unbatching(
             src, std::make_shared<std::vector<uint32_t>>(size, 1));
@@ -45,7 +46,7 @@ class DummyPermuter final
     return util::MpcAdapters<T, schedulerId>::batchingWith(front, permuted);
   }
 
-  SecBatchType permute(
+  SecBatchType permute_impl(
       const SecBatchType& src,
       size_t size,
       const std::vector<uint32_t>& order) const override {


### PR DESCRIPTION
Summary:
In T139445158 the NCC brought to our attention that the permuter library does not actually verify that the user has provided a valid permutation (i.e. same size as dataset, each index from [0 to n-1] appears exactly once. This diff adds that input validation.

Note: The other party that calls permute or adapt will just hang and timeout when this happens as it has no way to know the other party aborted.

Differential Revision: D42462081

