### PR TITLE
Fix a mock object leakage

### DIFF
--- a/fbpcf/io/cloud_util/test/S3ClientTest.cpp
+++ b/fbpcf/io/cloud_util/test/S3ClientTest.cpp
@@ -57,6 +57,7 @@ TEST(S3ClientTest, testGetInstance) {
       S3Client::getInstance(fbpcf::aws::S3ClientOption{.region = "us-east-1"});
 
   ASSERT_EQ(s3Client1, s3Client2);
+  S3Client::setS3ClientFactory(nullptr);
 }
 
 } // namespace fbpcf::cloudio


### PR DESCRIPTION
Summary: `mockFactory` was passed to a static variable that doesn't expire until the test finishes. This will cause the test to fail. This diff simply set that static variable to nullptr to release `mockFactory`.

Reviewed By: ramesc

Differential Revision: D42483477

