### PR TITLE
Add bitwise shift and getMsb in util

### DIFF
--- a/fbpcf/engine/util/util.h
+++ b/fbpcf/engine/util/util.h
@@ -28,6 +28,27 @@ inline bool getLsb(__m128i src) {
   return _mm_extract_epi8(src, 0) & 1;
 }
 
+inline bool getMsb(__m128i src) {
+  return (_mm_extract_epi8(src, 15) >> 7);
+}
+
+/*
+ * Left shift a value in m128i by an arbitery(offset) bits. This is needed as
+ * there's no instruction for this functionality AFAIK.
+ */
+inline void lShiftByBitsInPlace(__m128i& src, int offset) {
+  __m128i v1, v2;
+  if (offset >= 64) {
+    src = _mm_slli_si128(src, 8);
+    src = _mm_slli_epi64(src, offset - 64);
+  } else {
+    v1 = _mm_slli_epi64(src, offset);
+    v2 = _mm_slli_si128(src, 8);
+    v2 = _mm_srli_epi64(v2, 64 - offset);
+    src = _mm_or_si128(v1, v2);
+  }
+}
+
 inline uint64_t getLast64Bits(__m128i src) {
   return _mm_extract_epi64(src, 0);
 }


### PR DESCRIPTION
Summary:
In this diff, we added two new util functions:
1. `getMsb()`. This function simply returns the msb of a `__m128i` variable.

2. `lShiftByBitsInPlace(a, b)`. This function will left shift a `__m128i` variable `a` by `b` bits. There's no single instruction to perform this operation. We use two instruction to achieve this functionality:
In more detail:
- If offset is larger than 64, we first shift `a` by 8 bytes so that the right half of a will be moved to the left half. Then, we shift the rest amount of bits.
- If offset is not larger than 64, we first left shift each 64-bit integer in `a` by `offset` bits and store the value into `v1`. The only difference between `v1` and the expected result are the low `offset` bits in the left half of `v1`. The subsequent operations will take out that portion and combine it with `v1`.

`_mm_slli_si128(a, b)`: Left shift `a` by `b` bytes.
`_mm_slli_epi64(a, b)`: Left shift each 64-bit integer in `a` by `b` bits.
`_mm_srli_epi64(a, b)`: Right shift each 64-bit integer in `a` by `b` bits.

From https://stackoverflow.com/questions/17610696/shift-a-m128i-of-n-bits

Reviewed By: robotal, RuiyuZhu

Differential Revision: D42539298

