### PR TITLE
Interface and implementation for AES-CMAC

### DIFF
--- a/fbpcf/engine/util/util.h
+++ b/fbpcf/engine/util/util.h
@@ -28,6 +28,27 @@ inline bool getLsb(__m128i src) {
   return _mm_extract_epi8(src, 0) & 1;
 }
 
+inline bool getMsb(__m128i src) {
+  return (_mm_extract_epi8(src, 15) >> 7);
+}
+
+/*
+ * Left shift a value in m128i by an arbitery(offset) bits. This is needed as
+ * there's no instruction for this functionality AFAIK.
+ */
+inline void lShiftByBitsInPlace(__m128i& src, int offset) {
+  __m128i v1, v2;
+  if (offset >= 64) {
+    src = _mm_slli_si128(src, 8);
+    src = _mm_slli_epi64(src, offset - 64);
+  } else {
+    v1 = _mm_slli_epi64(src, offset);
+    v2 = _mm_slli_si128(src, 8);
+    v2 = _mm_srli_epi64(v2, 64 - offset);
+    src = _mm_or_si128(v1, v2);
+  }
+}
+
 inline uint64_t getLast64Bits(__m128i src) {
   return _mm_extract_epi64(src, 0);
 }

--- a/fbpcf/primitive/mac/AesCmac.cpp
+++ b/fbpcf/primitive/mac/AesCmac.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "fbpcf/primitive/mac/AesCmac.h"
+#include <fbpcf/engine/util/util.h>
+namespace fbpcf::primitive::mac {
+
+__m128i AesCmac::getMacM128i(const std::vector<unsigned char>& text) const {
+  const std::vector<unsigned char> cmac = getMac128(text);
+  return engine::util::buildM128i(cmac);
+}
+
+std::vector<unsigned char> AesCmac::getMac128(
+    const std::vector<unsigned char>& text) const {
+  std::vector<unsigned char> cmac(16);
+  size_t mactlen;
+  CMAC_Init(ctx_, macKey_.data(), 16, EVP_aes_128_cbc(), nullptr);
+  CMAC_Update(ctx_, text.data(), sizeof(unsigned char) * text.size());
+  CMAC_Final(ctx_, cmac.data(), &mactlen);
+  return cmac;
+}
+} // namespace fbpcf::primitive::mac

--- a/fbpcf/primitive/mac/AesCmac.h
+++ b/fbpcf/primitive/mac/AesCmac.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+#include <emmintrin.h>
+#include <immintrin.h>
+#include <openssl/cmac.h>
+#include <smmintrin.h>
+#include <wmmintrin.h>
+#include <xmmintrin.h>
+
+#include "fbpcf/engine/util/aes.h"
+#include "fbpcf/primitive/mac/IMac.h"
+
+namespace fbpcf::primitive::mac {
+
+class AesCmac final : public IMac {
+ public:
+  /**
+   * Create a AesCmac that has an initial key and can generate 128-bit Mac for
+   * arbitrary inputs.
+   */
+  explicit AesCmac(const std::vector<unsigned char>& macKey) : macKey_(macKey) {
+    ctx_ = CMAC_CTX_new();
+  }
+
+  ~AesCmac() {
+    CMAC_CTX_free(ctx_);
+  }
+
+  /**
+   * @inherit doc
+   */
+  std::vector<unsigned char> getMac128(
+      const std::vector<unsigned char>& text) const override;
+
+  /**
+   * @inherit doc
+   */
+  __m128i getMacM128i(const std::vector<unsigned char>& text) const override;
+
+ private:
+  std::vector<unsigned char> macKey_;
+  CMAC_CTX* ctx_;
+};
+
+} // namespace fbpcf::primitive::mac

--- a/fbpcf/primitive/mac/AesCmacFactory.h
+++ b/fbpcf/primitive/mac/AesCmacFactory.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+#include "fbpcf/primitive/mac/AesCmac.h"
+#include "fbpcf/primitive/mac/IMacFactory.h"
+
+namespace fbpcf::primitive::mac {
+
+/**
+ * An AesCmac factory for creating 128-bit AesCmac.
+ */
+class AesCmacFactory final : public IMacFactory {
+ public:
+  std::unique_ptr<IMac> create(
+      const std::vector<unsigned char>& macKey) const override {
+    return std::make_unique<AesCmac>(macKey);
+  }
+};
+
+} // namespace fbpcf::primitive::mac

--- a/fbpcf/primitive/mac/IMac.h
+++ b/fbpcf/primitive/mac/IMac.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <assert.h>
+#include <emmintrin.h>
+#include <cstdint>
+#include <vector>
+#include "fbpcf/engine/util/util.h"
+
+namespace fbpcf::primitive::mac {
+
+class IMac {
+ public:
+  virtual ~IMac() = default;
+
+  /**
+   * Generate 128-bit MAC for the input text
+   * @param text the data on which the MAC is calculated.
+   * @return a MAC with 128 bits as a __m128i
+   */
+  virtual __m128i getMacM128i(const std::vector<unsigned char>& text) const = 0;
+
+  /**
+   * Generate 128-bit MAC for the input text
+   * @param text the data on which the MAC is calculated.
+   * @return a MAC with 16 bytes as an unsigned char vector
+   */
+  virtual std::vector<unsigned char> getMac128(
+      const std::vector<unsigned char>& text) const = 0;
+};
+
+} // namespace fbpcf::primitive::mac

--- a/fbpcf/primitive/mac/IMacFactory.h
+++ b/fbpcf/primitive/mac/IMacFactory.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+#include <emmintrin.h>
+#include "fbpcf/primitive/mac/IMac.h"
+
+namespace fbpcf::primitive::mac {
+
+/**
+ * MAC factory API, create a MAC generator with a given key
+ */
+class IMacFactory {
+ public:
+  virtual ~IMacFactory() = default;
+  virtual std::unique_ptr<IMac> create(
+      const std::vector<unsigned char>& macKey) const = 0;
+};
+
+} // namespace fbpcf::primitive::mac

--- a/fbpcf/primitive/mac/test/macTest.cpp
+++ b/fbpcf/primitive/mac/test/macTest.cpp
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <emmintrin.h>
+#include <fbpcf/primitive/mac/IMacFactory.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <cstddef>
+#include <iterator>
+#include <memory>
+#include <random>
+#include <vector>
+#include "fbpcf/engine/util/util.h"
+#include "fbpcf/primitive/mac/AesCmacFactory.h"
+
+namespace fbpcf::primitive::mac {
+
+std::vector<unsigned char> generateRandomText(size_t byteNum) {
+  std::random_device rd;
+  std::mt19937_64 e(rd());
+  std::uniform_int_distribution<unsigned char> dist(0, 0xFF);
+  std::vector<unsigned char> randomText(byteNum);
+  for (size_t j = 0; j < byteNum; ++j) {
+    randomText[j] = dist(e);
+  }
+  return randomText;
+}
+
+void testGetMacM128i(std::unique_ptr<IMacFactory> macFactory) {
+  std::random_device rd;
+  std::mt19937_64 e(rd());
+  std::uniform_int_distribution<size_t> dist(1, 2048);
+  for (size_t i = 0; i < 128; ++i) {
+    size_t byteNum = dist(e);
+    const std::vector<unsigned char> randomText1 = generateRandomText(byteNum);
+    const std::vector<unsigned char> randomText2 = generateRandomText(byteNum);
+    std::vector<unsigned char> randomKey1 = generateRandomText(16);
+    std::vector<unsigned char> randomKey2 = generateRandomText(16);
+
+    // same key and same text will give the same mac
+    const auto mac1 = macFactory->create(randomKey1);
+    const auto mac2 = macFactory->create(randomKey1);
+    const __m128i macRes1 = mac1->getMacM128i(randomText1);
+    const __m128i macRes2 = mac2->getMacM128i(randomText1);
+    EXPECT_EQ(_mm_extract_epi64(macRes1, 0), _mm_extract_epi64(macRes2, 0));
+    EXPECT_EQ(_mm_extract_epi64(macRes1, 1), _mm_extract_epi64(macRes2, 1));
+
+    // different key and same text will give the different mac
+    const auto mac3 = macFactory->create(randomKey2);
+    const __m128i macRes3 = mac3->getMacM128i(randomText1);
+    // The following check should be satisfactory as it is highly improbable
+    // that half of two Mac are equal.
+    EXPECT_NE(_mm_extract_epi64(macRes1, 0), _mm_extract_epi64(macRes3, 0));
+    EXPECT_NE(_mm_extract_epi64(macRes1, 1), _mm_extract_epi64(macRes3, 1));
+
+    // same key and different text will give the different mac
+    const __m128i macRes4 = mac2->getMacM128i(randomText2);
+    // The following check should be satisfactory as it is highly improbable
+    // that half of two Mac are equal.
+    EXPECT_NE(_mm_extract_epi64(macRes1, 0), _mm_extract_epi64(macRes4, 0));
+    EXPECT_NE(_mm_extract_epi64(macRes1, 1), _mm_extract_epi64(macRes4, 1));
+  }
+}
+
+void testGetMac128(std::unique_ptr<IMacFactory> macFactory) {
+  std::random_device rd;
+  std::mt19937_64 e(rd());
+  std::uniform_int_distribution<size_t> dist(1, 2048);
+  for (size_t i = 0; i < 128; ++i) {
+    size_t byteNum = dist(e);
+    const std::vector<unsigned char> randomText1 = generateRandomText(byteNum);
+    const std::vector<unsigned char> randomText2 = generateRandomText(byteNum);
+    std::vector<unsigned char> randomKey1 = generateRandomText(16);
+    std::vector<unsigned char> randomKey2 = generateRandomText(16);
+
+    // same key and same text will give the same mac
+    const auto mac1 = macFactory->create(randomKey1);
+    const auto mac2 = macFactory->create(randomKey1);
+    const std::vector<unsigned char> macRes1 = mac1->getMac128(randomText1);
+    const std::vector<unsigned char> macRes2 = mac2->getMac128(randomText1);
+    EXPECT_EQ(macRes1, macRes2);
+
+    // different key and same text will give the different mac
+    auto mac3 = macFactory->create(randomKey2);
+    const std::vector<unsigned char> macRes3 = mac3->getMac128(randomText1);
+    EXPECT_NE(macRes1, macRes3);
+
+    // same key and different text will give the different mac
+    const std::vector<unsigned char> macRes4 = mac2->getMac128(randomText2);
+    EXPECT_NE(macRes1, macRes4);
+  }
+}
+
+void testConsistency(std::unique_ptr<IMacFactory> macFactory) {
+  std::random_device rd;
+  std::mt19937_64 e(rd());
+  std::uniform_int_distribution<size_t> dist(1, 2048);
+  for (size_t i = 0; i < 128; ++i) {
+    size_t blockNum = dist(e);
+    const std::vector<unsigned char> randomText =
+        generateRandomText(blockNum * 16);
+    std::vector<unsigned char> randomKey = generateRandomText(16);
+    std::vector<__m128i> randomTextM128(blockNum);
+    for (size_t j = 0; j < randomTextM128.size(); ++j) {
+      std::vector<unsigned char> randomBlock(
+          randomText.begin() + j * 16, randomText.begin() + (j + 1) * 16);
+      randomTextM128[j] = engine::util::buildM128i(randomBlock);
+    }
+    const auto mac = macFactory->create(randomKey);
+    const __m128i macRes1 = mac->getMacM128i(randomText);
+    const __m128i macRes2 =
+        engine::util::buildM128i(mac->getMac128(randomText));
+    EXPECT_EQ(_mm_extract_epi64(macRes1, 0), _mm_extract_epi64(macRes2, 0));
+    EXPECT_EQ(_mm_extract_epi64(macRes1, 1), _mm_extract_epi64(macRes2, 1));
+  }
+}
+
+void testEmptyInput(std::unique_ptr<IMacFactory> macFactory) {
+  std::vector<unsigned char> randomKey = generateRandomText(16);
+  const std::vector<unsigned char> emptyText(0);
+  std::vector<__m128i> emptyTextM128(0);
+
+  const auto mac = macFactory->create(randomKey);
+
+  const __m128i macRes1 = mac->getMacM128i(emptyText);
+  const __m128i macRes2 = engine::util::buildM128i(mac->getMac128(emptyText));
+  EXPECT_EQ(_mm_extract_epi64(macRes1, 0), _mm_extract_epi64(macRes2, 0));
+  EXPECT_EQ(_mm_extract_epi64(macRes1, 1), _mm_extract_epi64(macRes2, 1));
+}
+
+TEST(AesCMacTest, testGetMacM128i) {
+  testGetMacM128i(std::make_unique<AesCmacFactory>());
+}
+
+TEST(AesCMacTest, testGetMac128) {
+  testGetMac128(std::make_unique<AesCmacFactory>());
+}
+
+TEST(AesCMacTest, testConsistency) {
+  testConsistency(std::make_unique<AesCmacFactory>());
+}
+
+TEST(AesCMacTest, testEmptyInput) {
+  testEmptyInput(std::make_unique<AesCmacFactory>());
+}
+} // namespace fbpcf::primitive::mac


### PR DESCRIPTION
Summary:
In this diff, we added an interface for `Mac` and corresponding implementation for AES-CMAC.

The AES-CMAC is implemented using cmac with aes-128-cbc from openssl.

More details for AES-CMAC, please refer to https://docs.google.com/document/d/1dBLXII233YDl25z2s-hK4OuahNAbBFCRjU-Dk0XyGxo/edit#heading=h.64pm7jtpc7uf
and https://www.rfc-editor.org/rfc/rfc4493#ref-XCBCa

Reviewed By: robotal

Differential Revision: D42539927

