### PR TITLE
Update the FBPCF and dependent builds to use multi-threaded builds

### DIFF
--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -54,10 +54,12 @@ COPY docker/CMakeLists.txt .
 COPY docker/cmake/ ./cmake
 COPY fbpcf/ ./fbpcf
 COPY example/ ./example
+COPY docker/utils/get_make_options.sh .
+
 # Link all libraries post-install
 RUN ldconfig
 
 RUN cmake . -DTHREADING=ON -DEMP_USE_RANDOM_DEVICE=ON
-RUN make && make install
+RUN . /root/build/fbpcf/get_make_options.sh && make -j $MAKE_JOBS -l $MAKE_MAX_LOAD && make -j $MAKE_JOBS -l $MAKE_MAX_LOAD install
 
 CMD ["/bin/bash"]

--- a/docker/aws-s3-core/Dockerfile.ubuntu
+++ b/docker/aws-s3-core/Dockerfile.ubuntu
@@ -18,6 +18,8 @@ RUN apt-get -y update && apt-get install --no-install-recommends -y \
 RUN mkdir /root/build
 WORKDIR /root/build
 
+COPY docker/utils/get_make_options.sh .
+
 # aws s3/core build and install
 RUN git clone https://github.com/aws/aws-sdk-cpp.git
 WORKDIR /root/build/aws-sdk-cpp
@@ -25,7 +27,7 @@ RUN git checkout tags/${aws_release} -b ${aws_release}
 # -DCUSTOM_MEMORY_MANAGEMENT=0 is added to avoid Aws::String and std::string issue
 # -DENABLE_TESTING=OFF for a weird failing test HttpClientTest.TestRandomURLWithProxyAndOtherDeclaredAsNonProxyHost
 RUN cmake . -DBUILD_ONLY="s3;core" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_SHARED_LIBS=OFF -DCUSTOM_MEMORY_MANAGEMENT=0 -DENABLE_TESTING=OFF
-RUN make && make install
+RUN . /root/build/get_make_options.sh && make -j $MAKE_JOBS -l $MAKE_MAX_LOAD && make install -j $MAKE_JOBS -l $MAKE_MAX_LOAD
 
 FROM ubuntu:${os_release}
 COPY --from=builder /usr/local/include/. /usr/local/include/.

--- a/docker/emp/Dockerfile.ubuntu
+++ b/docker/emp/Dockerfile.ubuntu
@@ -19,6 +19,7 @@ WORKDIR /root/build
 
 # Build and install emp packages
 FROM dev-environment AS emp-builder
+COPY docker/utils/get_make_options.sh .
 ARG emp_tool_release="0.2.3"
 ARG emp_release="0.2.2"
 ARG DEBIAN_FRONTEND=noninteractive
@@ -32,21 +33,21 @@ RUN git clone -b${emp_tool_release} https://github.com/emp-toolkit/emp-tool.git
 WORKDIR /root/build/emp-tool
 RUN sed -i "s/SHARED/STATIC/" CMakeLists.txt
 RUN cmake -DBUILD_SHARED_LIBS=OFF -DTHREADING=ON .
-RUN make && make install
+RUN . /root/build/get_make_options.sh && make -j $MAKE_JOBS -l $MAKE_MAX_LOAD && make -j $MAKE_JOBS -l $MAKE_MAX_LOAD install
 
 # emp-ot build and install
 WORKDIR /root/build
 RUN git clone -b${emp_release} https://github.com/emp-toolkit/emp-ot.git
 WORKDIR /root/build/emp-ot
 RUN cmake -DBUILD_SHARED_LIBS=OFF -DTHREADING=ON .
-RUN make && make install
+RUN . /root/build/get_make_options.sh && make -j $MAKE_JOBS -l $MAKE_MAX_LOAD && make -j $MAKE_JOBS -l $MAKE_MAX_LOAD install
 
 # emp-sh2pc build and install
 WORKDIR /root/build
 RUN git clone -b${emp_release} https://github.com/emp-toolkit/emp-sh2pc.git
 WORKDIR /root/build/emp-sh2pc
 RUN cmake -DBUILD_SHARED_LIBS=OFF -DTHREADING=ON .
-RUN make && make install
+RUN . /root/build/get_make_options.sh && make -j $MAKE_JOBS -l $MAKE_MAX_LOAD && make -j $MAKE_JOBS -l $MAKE_MAX_LOAD install
 
 FROM ubuntu:${os_release}
 RUN mkdir /usr/local/cmake

--- a/docker/folly/Dockerfile.ubuntu
+++ b/docker/folly/Dockerfile.ubuntu
@@ -18,13 +18,14 @@ RUN apt-get -y update && apt-get install --no-install-recommends -y \
 RUN mkdir /root/build
 WORKDIR /root/build
 
+COPY docker/utils/get_make_options.sh .
+
 # fmt build and install
 RUN git clone https://github.com/fmtlib/fmt.git
 WORKDIR /root/build/fmt
 RUN git checkout tags/${fmt_release} -b ${fmt_release}
 RUN cmake .
-RUN make
-RUN make install
+RUN . /root/build/get_make_options.sh && make -j $MAKE_JOBS -l $MAKE_MAX_LOAD && make -j $MAKE_JOBS -l $MAKE_MAX_LOAD install
 
 WORKDIR /root/build
 
@@ -47,7 +48,7 @@ WORKDIR /root/build/folly
 RUN git checkout tags/v${folly_release} -b v${folly_release}
 
 RUN cmake DBUILD_SHARED_LIBS=OFF -DFOLLY_USE_JEMALLOC=0 -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-march=x86-64" .
-RUN make && make install
+RUN . /root/build/get_make_options.sh && make -j $MAKE_JOBS -l $MAKE_MAX_LOAD && make -j $MAKE_JOBS -l $MAKE_MAX_LOAD install
 
 FROM ubuntu:${os_release}
 COPY --from=builder /usr/local/include/. /usr/local/include/.

--- a/docker/utils/get_make_options.sh
+++ b/docker/utils/get_make_options.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+BYTES_PER_MEGABYTE=1000000
+
+# We need up to 2000 MB (less than 2GB) per thread.
+MAX_THREAD_MEMORY_IN_BYTES=$((2000 * BYTES_PER_MEGABYTE))
+
+# The functionality below calculates the number of bytes of memory available by getting the number
+# Of physical pages available, multiplying it by the page size (in bytes) and dividing that by the
+# number of bytes per thread that we want available to give us the maximum number of threads
+MAX_THREADS=$(($(getconf _PHYS_PAGES) * $(getconf PAGE_SIZE) / MAX_THREAD_MEMORY_IN_BYTES))
+
+# Get the number of possible threads by pulling the online processors
+EFFECTIVE_THREADS=$(getconf _NPROCESSORS_ONLN)
+
+# Use the lesser of the maximum allowed threads by memory or available processors
+export MAKE_JOBS=$((MAX_THREADS < EFFECTIVE_THREADS ? MAX_THREADS : EFFECTIVE_THREADS))
+
+# Set the maximum load average on the CPU as 9/10ths of the available cores
+# This ensures that we don't saturate the CPU with processes that are greater
+# than the cores available
+export MAKE_MAX_LOAD=$((EFFECTIVE_THREADS * 9 / 10))


### PR DESCRIPTION
Summary:
# Context
This change is intended to help speed up the builds for FBPCF and all the dependent images. Right now we are using a C4.4xlarge instance for building the images, but we never use anywhere near the CPU or Memory limits for an instance that large. This change allows us to take more advantage of that instance size and improve our build times. Some examples when building with the FBPCS machine are that we were only using about 6% CPU for a build and this change increased it to ~25% and reduced the build time from ~40 minutes to ~19 minutes.
https://pxl.cl/2qpD2 (https://github.com/facebookresearch/fbpcf/commit/7566956549c53453c504db141be371b74d6b1165)
https://pxl.cl/2qpD1

# This Diff
This diff updates the FBPCF builds to take advantage of the same build features. Right now builds are taking ~ 55 mintues. After the change, they are taking less than 30 minutes.

## Before the change:
```
build binaries completed successfully

  0.04s user 0.05s system 0% cpu 56:40.53 total
```
Logs: https://www.internalfb.com/intern/paste/P603909791/

##After the change:
```
build binaries completed successfully

  0.01s user 0.04s system 0% cpu 29:26.80 total
```
Logs: https://www.internalfb.com/intern/paste/P603946390/

Differential Revision: D42626641

