### PR TITLE
Update the FBPCF Dependency Docker Images to be build with the Haswell architecture

### DIFF
--- a/.github/workflows/aws-s3-publish.yml
+++ b/.github/workflows/aws-s3-publish.yml
@@ -3,9 +3,10 @@ name: Build and publish aws s3 dependency
 on:
   workflow_dispatch:
     inputs:
-      name:
-        description: "Build and publish an fbpcf/aws-s3-core image for a particular version"
-        default: "Run"
+      image_tag:
+        description: "The tag to apply to the AWS SDK image. Previously this was the AWS SDK release version (e.g. 1.8.177)"
+        required: true
+        type: string
       aws_release:
         description: "The aws s3 version to build and publish (e.g. 1.8.177)"
         required: true
@@ -44,16 +45,16 @@ jobs:
       - name: Build image
         run: |
           docker build \
-          --build-arg os_release=${{ github.event.inputs.os_release }} \
-          --build-arg aws_release=${{ github.event.inputs.aws_release }} \
-          -t "fbpcf/${{ github.event.inputs.os }}-aws-s3-core:${{ github.event.inputs.aws_release }}" \
-          -f "docker/aws-s3-core/Dockerfile.${{ github.event.inputs.os }}" .
+          --build-arg os_release=${{ inputs.os_release }} \
+          --build-arg aws_release=${{ inputs.aws_release }} \
+          -t "fbpcf/${{ inputs.os }}-aws-s3-core:${{ inputs.image_tag }}" \
+          -f "docker/aws-s3-core/Dockerfile.${{ inputs.os }}" .
 
       - name: Tag image
         run: |
-          docker tag fbpcf/${{ github.event.inputs.os }}-aws-s3-core:${{ github.event.inputs.aws_release }} \
-          ${{ env.REGISTRY }}/${{ github.repository }}/${{ github.event.inputs.os }}-aws-s3-core:${{ github.event.inputs.aws_release }}
+          docker tag fbpcf/${{ inputs.os }}-aws-s3-core:${{ inputs.image_tag }} \
+          ${{ env.REGISTRY }}/${{ github.repository }}/${{ inputs.os }}-aws-s3-core:${{ inputs.image_tag }}
 
       - name: Publish image
         run: |
-          docker push --all-tags ${{ env.REGISTRY }}/${{ github.repository }}/${{ github.event.inputs.os }}-aws-s3-core
+          docker push --all-tags ${{ env.REGISTRY }}/${{ github.repository }}/${{ inputs.os }}-aws-s3-core

--- a/.github/workflows/emp-publish.yml
+++ b/.github/workflows/emp-publish.yml
@@ -3,9 +3,10 @@ name: Build and publish emp dependency
 on:
   workflow_dispatch:
     inputs:
-      name:
-        description: "Build and publish an fbpcf/emp image for a particular version"
-        default: "Run"
+      image_tag:
+        description: "The tag to apply to the emp image. Previously this was the emp tool release version (e.g. 0.2.3)"
+        required: true
+        type: string
       emp_release:
         description: "The emp version to build and publish (e.g. 0.2.2)"
         required: true
@@ -48,17 +49,17 @@ jobs:
       - name: Build image
         run: |
           docker build \
-          --build-arg os_release=${{ github.event.inputs.os_release }} \
-          --build-arg emp_tool_release=${{ github.event.inputs.emp_tool_release }} \
-          --build-arg emp_release=${{ github.event.inputs.emp_release }} \
-          -t "fbpcf/${{ github.event.inputs.os }}-emp:${{ github.event.inputs.emp_tool_release }}" \
-          -f "docker/emp/Dockerfile.${{ github.event.inputs.os }}" .
+          --build-arg os_release=${{ inputs.os_release }} \
+          --build-arg emp_tool_release=${{ inputs.emp_tool_release }} \
+          --build-arg emp_release=${{ inputs.emp_release }} \
+          -t "fbpcf/${{ inputs.os }}-emp:${{ inputs.image_tag }}" \
+          -f "docker/emp/Dockerfile.${{ inputs.os }}" .
 
       - name: Tag image
         run: |
-          docker tag fbpcf/${{ github.event.inputs.os }}-emp:${{ github.event.inputs.emp_tool_release }} \
-          ${{ env.REGISTRY }}/${{ github.repository }}/${{ github.event.inputs.os }}-emp:${{ github.event.inputs.emp_tool_release }}
+          docker tag fbpcf/${{ inputs.os }}-emp:${{ inputs.image_tag }} \
+          ${{ env.REGISTRY }}/${{ github.repository }}/${{ inputs.os }}-emp:${{ inputs.image_tag }}
 
       - name: Publish image
         run: |
-          docker push --all-tags ${{ env.REGISTRY }}/${{ github.repository }}/${{ github.event.inputs.os }}-emp
+          docker push --all-tags ${{ env.REGISTRY }}/${{ github.repository }}/${{ inputs.os }}-emp

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -54,10 +54,12 @@ COPY docker/CMakeLists.txt .
 COPY docker/cmake/ ./cmake
 COPY fbpcf/ ./fbpcf
 COPY example/ ./example
+COPY docker/utils/get_make_options.sh .
+
 # Link all libraries post-install
 RUN ldconfig
 
 RUN cmake . -DTHREADING=ON -DEMP_USE_RANDOM_DEVICE=ON
-RUN make && make install
+RUN . /root/build/fbpcf/get_make_options.sh && make -j $MAKE_JOBS -l $MAKE_MAX_LOAD && make -j $MAKE_JOBS -l $MAKE_MAX_LOAD install
 
 CMD ["/bin/bash"]

--- a/docker/aws-s3-core/Dockerfile.ubuntu
+++ b/docker/aws-s3-core/Dockerfile.ubuntu
@@ -26,7 +26,7 @@ WORKDIR /root/build/aws-sdk-cpp
 RUN git checkout tags/${aws_release} -b ${aws_release}
 # -DCUSTOM_MEMORY_MANAGEMENT=0 is added to avoid Aws::String and std::string issue
 # -DENABLE_TESTING=OFF for a weird failing test HttpClientTest.TestRandomURLWithProxyAndOtherDeclaredAsNonProxyHost
-RUN cmake . -DBUILD_ONLY="s3;core" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_SHARED_LIBS=OFF -DCUSTOM_MEMORY_MANAGEMENT=0 -DENABLE_TESTING=OFF
+RUN cmake . -DBUILD_ONLY="s3;core" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_SHARED_LIBS=OFF -DCUSTOM_MEMORY_MANAGEMENT=0 -DENABLE_TESTING=OFF -DCMAKE_CXX_FLAGS="-march=haswell"
 RUN . /root/build/get_make_options.sh && make -j $MAKE_JOBS -l $MAKE_MAX_LOAD && make install -j $MAKE_JOBS -l $MAKE_MAX_LOAD
 
 FROM ubuntu:${os_release}

--- a/docker/aws-s3-core/Dockerfile.ubuntu
+++ b/docker/aws-s3-core/Dockerfile.ubuntu
@@ -18,6 +18,8 @@ RUN apt-get -y update && apt-get install --no-install-recommends -y \
 RUN mkdir /root/build
 WORKDIR /root/build
 
+COPY docker/utils/get_make_options.sh .
+
 # aws s3/core build and install
 RUN git clone https://github.com/aws/aws-sdk-cpp.git
 WORKDIR /root/build/aws-sdk-cpp
@@ -25,7 +27,7 @@ RUN git checkout tags/${aws_release} -b ${aws_release}
 # -DCUSTOM_MEMORY_MANAGEMENT=0 is added to avoid Aws::String and std::string issue
 # -DENABLE_TESTING=OFF for a weird failing test HttpClientTest.TestRandomURLWithProxyAndOtherDeclaredAsNonProxyHost
 RUN cmake . -DBUILD_ONLY="s3;core" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_SHARED_LIBS=OFF -DCUSTOM_MEMORY_MANAGEMENT=0 -DENABLE_TESTING=OFF
-RUN make && make install
+RUN . /root/build/get_make_options.sh && make -j $MAKE_JOBS -l $MAKE_MAX_LOAD && make install -j $MAKE_JOBS -l $MAKE_MAX_LOAD
 
 FROM ubuntu:${os_release}
 COPY --from=builder /usr/local/include/. /usr/local/include/.

--- a/docker/emp/Dockerfile.ubuntu
+++ b/docker/emp/Dockerfile.ubuntu
@@ -33,21 +33,21 @@ RUN git clone -b${emp_tool_release} https://github.com/emp-toolkit/emp-tool.git
 WORKDIR /root/build/emp-tool
 RUN sed -i "s/SHARED/STATIC/" CMakeLists.txt
 RUN cmake -DBUILD_SHARED_LIBS=OFF -DTHREADING=ON .
-RUN . /root/build/get_make_options.sh && make -j $MAKE_JOBS -l $MAKE_MAX_LOAD && make -j $MAKE_JOBS -l $MAKE_MAX_LOAD install
+RUN . /root/build/get_make_options.sh && make -j $MAKE_JOBS -l $MAKE_MAX_LOAD CFLAGS="-march=haswell" CXXFLAGS="-march=haswell" && make -j $MAKE_JOBS -l $MAKE_MAX_LOAD install
 
 # emp-ot build and install
 WORKDIR /root/build
 RUN git clone -b${emp_release} https://github.com/emp-toolkit/emp-ot.git
 WORKDIR /root/build/emp-ot
 RUN cmake -DBUILD_SHARED_LIBS=OFF -DTHREADING=ON .
-RUN . /root/build/get_make_options.sh && make -j $MAKE_JOBS -l $MAKE_MAX_LOAD && make -j $MAKE_JOBS -l $MAKE_MAX_LOAD install
+RUN . /root/build/get_make_options.sh && make -j $MAKE_JOBS -l $MAKE_MAX_LOAD CFLAGS="-march=haswell" CXXFLAGS="-march=haswell" && make -j $MAKE_JOBS -l $MAKE_MAX_LOAD install
 
 # emp-sh2pc build and install
 WORKDIR /root/build
 RUN git clone -b${emp_release} https://github.com/emp-toolkit/emp-sh2pc.git
 WORKDIR /root/build/emp-sh2pc
 RUN cmake -DBUILD_SHARED_LIBS=OFF -DTHREADING=ON .
-RUN . /root/build/get_make_options.sh && make -j $MAKE_JOBS -l $MAKE_MAX_LOAD && make -j $MAKE_JOBS -l $MAKE_MAX_LOAD install
+RUN . /root/build/get_make_options.sh && make -j $MAKE_JOBS -l $MAKE_MAX_LOAD CFLAGS="-march=haswell" CXXFLAGS="-march=haswell" && make -j $MAKE_JOBS -l $MAKE_MAX_LOAD install
 
 FROM ubuntu:${os_release}
 RUN mkdir /usr/local/cmake

--- a/docker/emp/Dockerfile.ubuntu
+++ b/docker/emp/Dockerfile.ubuntu
@@ -19,6 +19,7 @@ WORKDIR /root/build
 
 # Build and install emp packages
 FROM dev-environment AS emp-builder
+COPY docker/utils/get_make_options.sh .
 ARG emp_tool_release="0.2.3"
 ARG emp_release="0.2.2"
 ARG DEBIAN_FRONTEND=noninteractive
@@ -32,21 +33,21 @@ RUN git clone -b${emp_tool_release} https://github.com/emp-toolkit/emp-tool.git
 WORKDIR /root/build/emp-tool
 RUN sed -i "s/SHARED/STATIC/" CMakeLists.txt
 RUN cmake -DBUILD_SHARED_LIBS=OFF -DTHREADING=ON .
-RUN make && make install
+RUN . /root/build/get_make_options.sh && make -j $MAKE_JOBS -l $MAKE_MAX_LOAD && make -j $MAKE_JOBS -l $MAKE_MAX_LOAD install
 
 # emp-ot build and install
 WORKDIR /root/build
 RUN git clone -b${emp_release} https://github.com/emp-toolkit/emp-ot.git
 WORKDIR /root/build/emp-ot
 RUN cmake -DBUILD_SHARED_LIBS=OFF -DTHREADING=ON .
-RUN make && make install
+RUN . /root/build/get_make_options.sh && make -j $MAKE_JOBS -l $MAKE_MAX_LOAD && make -j $MAKE_JOBS -l $MAKE_MAX_LOAD install
 
 # emp-sh2pc build and install
 WORKDIR /root/build
 RUN git clone -b${emp_release} https://github.com/emp-toolkit/emp-sh2pc.git
 WORKDIR /root/build/emp-sh2pc
 RUN cmake -DBUILD_SHARED_LIBS=OFF -DTHREADING=ON .
-RUN make && make install
+RUN . /root/build/get_make_options.sh && make -j $MAKE_JOBS -l $MAKE_MAX_LOAD && make -j $MAKE_JOBS -l $MAKE_MAX_LOAD install
 
 FROM ubuntu:${os_release}
 RUN mkdir /usr/local/cmake

--- a/docker/folly/Dockerfile.ubuntu
+++ b/docker/folly/Dockerfile.ubuntu
@@ -47,7 +47,8 @@ RUN git clone https://github.com/facebook/folly.git
 WORKDIR /root/build/folly
 RUN git checkout tags/v${folly_release} -b v${folly_release}
 
-RUN cmake DBUILD_SHARED_LIBS=OFF -DFOLLY_USE_JEMALLOC=0 -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-march=x86-64" .
+RUN cmake DBUILD_SHARED_LIBS=OFF -DFOLLY_USE_JEMALLOC=0 -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-march=haswell" .
+
 RUN . /root/build/get_make_options.sh && make -j $MAKE_JOBS -l $MAKE_MAX_LOAD && make -j $MAKE_JOBS -l $MAKE_MAX_LOAD install
 
 FROM ubuntu:${os_release}

--- a/docker/folly/Dockerfile.ubuntu
+++ b/docker/folly/Dockerfile.ubuntu
@@ -18,13 +18,14 @@ RUN apt-get -y update && apt-get install --no-install-recommends -y \
 RUN mkdir /root/build
 WORKDIR /root/build
 
+COPY docker/utils/get_make_options.sh .
+
 # fmt build and install
 RUN git clone https://github.com/fmtlib/fmt.git
 WORKDIR /root/build/fmt
 RUN git checkout tags/${fmt_release} -b ${fmt_release}
 RUN cmake .
-RUN make
-RUN make install
+RUN . /root/build/get_make_options.sh && make -j $MAKE_JOBS -l $MAKE_MAX_LOAD && make -j $MAKE_JOBS -l $MAKE_MAX_LOAD install
 
 WORKDIR /root/build
 
@@ -47,7 +48,7 @@ WORKDIR /root/build/folly
 RUN git checkout tags/v${folly_release} -b v${folly_release}
 
 RUN cmake DBUILD_SHARED_LIBS=OFF -DFOLLY_USE_JEMALLOC=0 -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-march=x86-64" .
-RUN make && make install
+RUN . /root/build/get_make_options.sh && make -j $MAKE_JOBS -l $MAKE_MAX_LOAD && make -j $MAKE_JOBS -l $MAKE_MAX_LOAD install
 
 FROM ubuntu:${os_release}
 COPY --from=builder /usr/local/include/. /usr/local/include/.

--- a/docker/utils/get_make_options.sh
+++ b/docker/utils/get_make_options.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+BYTES_PER_MEGABYTE=1000000
+
+# We need up to 2000 MB (less than 2GB) per thread.
+MAX_THREAD_MEMORY_IN_BYTES=$((2000 * BYTES_PER_MEGABYTE))
+
+# The functionality below calculates the number of bytes of memory available by getting the number
+# Of physical pages available, multiplying it by the page size (in bytes) and dividing that by the
+# number of bytes per thread that we want available to give us the maximum number of threads
+MAX_THREADS=$(($(getconf _PHYS_PAGES) * $(getconf PAGE_SIZE) / MAX_THREAD_MEMORY_IN_BYTES))
+
+# Get the number of possible threads by pulling the online processors
+EFFECTIVE_THREADS=$(getconf _NPROCESSORS_ONLN)
+
+# Use the lesser of the maximum allowed threads by memory or available processors
+export MAKE_JOBS=$((MAX_THREADS < EFFECTIVE_THREADS ? MAX_THREADS : EFFECTIVE_THREADS))
+
+# Set the maximum load average on the CPU as 9/10ths of the available cores
+# This ensures that we don't saturate the CPU with processes that are greater
+# than the cores available
+export MAKE_MAX_LOAD=$((EFFECTIVE_THREADS * 9 / 10))


### PR DESCRIPTION
Summary:
## Context
After attempting to build the images with the "x86-64" architecture for a while, I determined that we wouldn't be able to make it work as the EMP library used an instruction that wasing included in the "x86-64" architecture (specifically ). This meant that I needed to explore other options. My next choice was to find the architecture of the current build machines that we use (c4.4xlarge) and go with that since we know that we were building it previously natively for those machines. The c4.4xlarge uses an Intel Xeon E5-2666 based on the cpu info from the machine:
```
ubuntu@ip-172-31-15-42:~$ lscpu
Architecture:                    x86_64
CPU op-mode(s):                  32-bit, 64-bit
...
Model name:                      Intel(R) Xeon(R) CPU E5-2666 v3 @ 2.90GHz
...
```

According to the Intel website, this processor uses the Haswell architecture: https://www.intel.com/content/www/us/en/products/sku/81706/intel-xeon-processor-e52660-v3-25m-cache-2-60-ghz/specifications.html

With that information, I decided to rebuild everything for the haswell architecture since it should match our current build system and allow us all the symbols necessary to run the computation.

## This Diff
This diff updates all of the dependent FBPCF images (AWS, EMP, and Folly) to be built with the haswell architechture specified. After this has been done and confirmed to work. I will produce new haswell images and update the main FBPCF build in the next diff.

Differential Revision: D42588188

