### PR TITLE
Update PCF binaries to be built using the haswell archetecture

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -9,10 +9,13 @@ set -e
 UBUNTU_RELEASE="20.04"
 EMP_TOOL_RELEASE="0.2.3"
 EMP_RELEASE="0.2.2"
+EMP_IMAGE_TAG="0.2.3-haswell"
 AWS_RELEASE="1.8.177"
+AWS_IMAGE_TAG="1.8.177-haswell"
 GCP_RELEASE="v1.32.1"
 FMT_RELEASE="7.1.3"
 FOLLY_RELEASE="2021.06.28.00"
+FOLLY_IMAGE_TAG="2021.06.28.00-haswell"
 GITHUB_PACKAGES="ghcr.io/facebookresearch"
 
 PROG_NAME=$0
@@ -74,11 +77,11 @@ build_dep_image() {
   RETURN="${IMAGE}"
 }
 
-EMP_IMAGE="fbpcf/${IMAGE_PREFIX}-emp:${EMP_TOOL_RELEASE}"
+EMP_IMAGE="fbpcf/${IMAGE_PREFIX}-emp:${EMP_IMAGE_TAG}"
 build_dep_image "${EMP_IMAGE}" "emp" "--build-arg os_release=${OS_RELEASE} --build-arg emp_tool_release=${EMP_TOOL_RELEASE} --build-arg emp_release=${EMP_RELEASE}"
 EMP_IMAGE="${RETURN}"
 
-AWS_IMAGE="fbpcf/${IMAGE_PREFIX}-aws-s3-core:${AWS_RELEASE}"
+AWS_IMAGE="fbpcf/${IMAGE_PREFIX}-aws-s3-core:${AWS_IMAGE_TAG}"
 build_dep_image "${AWS_IMAGE}" "aws-s3-core" "--build-arg os_release=${OS_RELEASE} --build-arg aws_release=${AWS_RELEASE}"
 AWS_IMAGE="${RETURN}"
 
@@ -86,7 +89,7 @@ GCP_IMAGE="fbpcf/${IMAGE_PREFIX}-google-cloud-cpp:${GCP_RELEASE}"
 build_dep_image "${GCP_IMAGE}" "google-cloud-cpp" "--build-arg os_release=${OS_RELEASE} --build-arg gcp_cpp_release=${GCP_RELEASE}"
 GCP_IMAGE="${RETURN}"
 
-FOLLY_IMAGE="fbpcf/${IMAGE_PREFIX}-folly:${FOLLY_RELEASE}"
+FOLLY_IMAGE="fbpcf/${IMAGE_PREFIX}-folly:${FOLLY_IMAGE_TAG}"
 build_dep_image "${FOLLY_IMAGE}" "folly" "--build-arg os_release=${OS_RELEASE} --build-arg folly_release=${FOLLY_RELEASE} --build-arg fmt_release=${FMT_RELEASE}"
 FOLLY_IMAGE="${RETURN}"
 

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -59,7 +59,7 @@ COPY docker/utils/get_make_options.sh .
 # Link all libraries post-install
 RUN ldconfig
 
-RUN cmake . -DTHREADING=ON -DEMP_USE_RANDOM_DEVICE=ON
+RUN cmake . -DTHREADING=ON -DEMP_USE_RANDOM_DEVICE=ON -DCMAKE_CXX_FLAGS="-march=haswell" -DCMAKE_C_FLAGS="-march=haswell"
 RUN . /root/build/fbpcf/get_make_options.sh && make -j $MAKE_JOBS -l $MAKE_MAX_LOAD && make -j $MAKE_JOBS -l $MAKE_MAX_LOAD install
 
 CMD ["/bin/bash"]

--- a/docker/cmake/fbpcf.cmake
+++ b/docker/cmake/fbpcf.cmake
@@ -37,3 +37,4 @@ find_library(re2 libre2.so)
 # since emp-tool is compiled with cc++11 and our games needs c++17 overwrite the
 # compile option to c++17
 add_compile_options(-std=c++17)
+add_compile_options(-march=haswell)


### PR DESCRIPTION
Summary:
## Context
After attempting to build the images with the "x86-64" architecture for a while, I determined that we wouldn't be able to make it work as the EMP library used an instruction that wasing included in the "x86-64" architecture (specifically ). This meant that I needed to explore other options. My next choice was to find the architecture of the current build machines that we use (c4.4xlarge) and go with that since we know that we were building it previously natively for those machines. The c4.4xlarge uses an Intel Xeon E5-2666 based on the cpu info from the machine:
```
ubuntu@ip-172-31-15-42:~$ lscpu
Architecture:                    x86_64
CPU op-mode(s):                  32-bit, 64-bit
...
Model name:                      Intel(R) Xeon(R) CPU E5-2666 v3 @ 2.90GHz
...
```

According to the Intel website, this processor uses the Haswell architecture: https://www.intel.com/content/www/us/en/products/sku/81706/intel-xeon-processor-e52660-v3-25m-cache-2-60-ghz/specifications.html

With that information, I decided to rebuild everything for the haswell architecture since it should match our current build system and allow us all the symbols necessary to run the computation.

## This Diff
This diff updates the FBPCF binaries to use the new "haswell" image versions and specifies the haswell architecture for the FBPCF binaries also.

Differential Revision: D42627125

