### PR TITLE
Add a subclass for UDP encryption to allow process sharded inputs.

### DIFF
--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/DataProcessor.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/DataProcessor.h
@@ -12,6 +12,7 @@
 #include "fbpcf/engine/util/util.h"
 #include "fbpcf/mpc_std_lib/aes_circuit/IAesCircuitCtr.h"
 #include "fbpcf/mpc_std_lib/unified_data_process/data_processor/IDataProcessor.h"
+#include "fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpEncryption.h"
 #include "fbpcf/primitive/mac/S2v.h"
 #include "fbpcf/primitive/mac/S2vFactory.h"
 
@@ -34,7 +35,7 @@ class DataProcessor final : public IDataProcessor<schedulerId> {
       std::unique_ptr<AesCtr> aesCircuitCtr)
       : myId_(myId),
         partnerId_(partnerId),
-        agent_(std::move(agent)),
+        encrypter_(std::move(agent)),
         aesCircuitCtr_(std::move(aesCircuitCtr)) {}
 
   /**
@@ -55,8 +56,7 @@ class DataProcessor final : public IDataProcessor<schedulerId> {
  private:
   int32_t myId_;
   int32_t partnerId_;
-  std::unique_ptr<fbpcf::engine::communication::IPartyCommunicationAgent>
-      agent_;
+  UdpEncryption encrypter_;
   std::unique_ptr<AesCtr> aesCircuitCtr_;
 };
 

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/DataProcessor.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/DataProcessor.h
@@ -58,38 +58,6 @@ class DataProcessor final : public IDataProcessor<schedulerId> {
   std::unique_ptr<fbpcf::engine::communication::IPartyCommunicationAgent>
       agent_;
   std::unique_ptr<AesCtr> aesCircuitCtr_;
-
- protected:
-  // locally encrypt the plaintext, output expanded keys and ciphertext
-  std::tuple<
-      std::array<__m128i, 11>,
-      std::vector<std::vector<uint8_t>>,
-      std::vector<uint8_t>>
-  localEncryption(const std::vector<std::vector<unsigned char>>& plaintextData);
-
-  // privately share the input byte stream from party inputPartyID into vector
-  // of batched Bit. Also padding the Bit vector to make its size be mulitple
-  // of 128
-  std::vector<typename IDataProcessor<schedulerId>::SecBit>
-  privatelyShareByteStream(
-      const std::vector<std::vector<unsigned char>>& localData,
-      int inputPartyID);
-
-  // privately share a 2d vector of __m128i from party inputPartyID into vector
-  // of batched Bit.
-  std::vector<typename IDataProcessor<schedulerId>::SecBit>
-  privatelyShareM128iStream(
-      const std::vector<std::vector<__m128i>>& localDataM128i,
-      int inputPartyID);
-
-  // privately share the expanded key from party inputPartyID into vector
-  // of batched Bit. Each bit from the expanded key will be convert into a
-  // batched Bit with a specified bathcSize
-  std::vector<typename IDataProcessor<schedulerId>::SecBit>
-  privatelyShareExpandedKey(
-      const std::vector<__m128i>& localKeyM128i,
-      size_t batchSize,
-      int inputPartyID);
 };
 
 } // namespace fbpcf::mpc_std_lib::unified_data_process::data_processor

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpEncryption.cpp
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpEncryption.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpEncryption.h"
+#include <stdexcept>
+#include <string>
+#include "fbpcf/primitive/mac/S2v.h"
+#include "fbpcf/primitive/mac/S2vFactory.h"
+
+namespace fbpcf::mpc_std_lib::unified_data_process::data_processor {
+
+UdpEncryption::UdpEncryption(
+
+    std::unique_ptr<fbpcf::engine::communication::IPartyCommunicationAgent>
+        agent)
+    : agent_(std::move(agent)),
+      statusOfProcessingMyData_(Status::idle),
+      statusOfProcessingPeerData_(Status::idle) {}
+
+void UdpEncryption::prepareToProcessMyData(size_t myDataWidth) {
+  if (statusOfProcessingMyData_ != Status::idle) {
+    throw std::runtime_error("Can't call prepare when processing my data!");
+  }
+  statusOfProcessingMyData_ = Status::inProgress;
+  myDataWidth_ = myDataWidth;
+  prgKey_ = fbpcf::engine::util::getRandomM128iFromSystemNoise();
+  indexOffset_ = 0;
+}
+
+void UdpEncryption::processMyData(
+    const std::vector<std::vector<unsigned char>>& plaintextData) {
+  if (statusOfProcessingMyData_ != Status::inProgress) {
+    throw std::runtime_error("Can't call procesMyData before preparation!");
+  }
+  if (plaintextData.size() == 0) {
+    throw std::invalid_argument("can't use empty inputs");
+  }
+  if (plaintextData.at(0).size() != myDataWidth_) {
+    throw std::invalid_argument(
+        "Inconsistent data width, expecting " + std::to_string(myDataWidth_) +
+        " but get " + std::to_string(plaintextData.at(0).size()));
+  }
+  auto [ciphertext, nonce] =
+      UdpUtil::localEncryption(plaintextData, prgKey_, indexOffset_);
+  agent_->send(nonce);
+  for (size_t i = 0; i < ciphertext.size(); i++) {
+    agent_->send(ciphertext.at(i));
+  }
+  indexOffset_ += plaintextData.size();
+}
+
+void UdpEncryption::prepareToProcessPeerData(
+    size_t peerDataWidth,
+    const std::vector<int32_t>& indexes) {
+  if (statusOfProcessingPeerData_ != Status::idle) {
+    throw std::runtime_error(
+        "Can't call prepare when already processing peer data!");
+  }
+  statusOfProcessingPeerData_ = Status::inProgress;
+
+  for (size_t i = 0; i < indexes.size(); i++) {
+    indexToOrderMap_.emplace(indexes.at(i), i);
+  }
+
+  peerDataWidth_ = peerDataWidth;
+  indexOffset_ = 0;
+
+  cherryPickedEncryption_ =
+      std::vector<std::vector<unsigned char>>(indexes.size());
+  cherryPickedNonce_ = std::vector<__m128i>(indexes.size());
+  cherryPickedIndex_ = std::vector<int32_t>(indexes.size());
+}
+
+void UdpEncryption::processPeerData(size_t dataSize) {
+  if (statusOfProcessingPeerData_ != Status::inProgress) {
+    throw std::runtime_error("Can't call procesPeerData before preparation!");
+  }
+  __m128i nonce;
+  {
+    auto nonceData = agent_->receive(kBlockSize);
+    nonce = _mm_lddqu_si128((__m128i*)nonceData.data());
+  }
+
+  for (size_t i = 0; i < dataSize; i++) {
+    auto ciphertext = agent_->receive(peerDataWidth_);
+    auto pos = indexToOrderMap_.find(i + indexOffset_);
+    if (pos != indexToOrderMap_.end()) {
+      // this ciphertext should be picked up
+      cherryPickedEncryption_.at(pos->second) = std::move(ciphertext);
+      cherryPickedNonce_.at(pos->second) = nonce;
+      cherryPickedIndex_.at(pos->second) = i + indexOffset_;
+      indexToOrderMap_.erase(pos);
+      // TODO: this can be further optimized by not copying duplicated nonce.
+    }
+  }
+  indexOffset_ += dataSize;
+}
+
+} // namespace fbpcf::mpc_std_lib::unified_data_process::data_processor

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpEncryption.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpEncryption.h
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <emmintrin.h>
+#include "fbpcf/engine/communication/IPartyCommunicationAgent.h"
+#include "fbpcf/engine/util/util.h"
+#include "fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpUtil.h"
+
+namespace fbpcf::mpc_std_lib::unified_data_process::data_processor {
+
+template <int schedulerId>
+class DataProcessor;
+
+/**
+ * This class handles the encryption step of UDP at scale. The raw data can
+ *be passed into this object in batches. This object is not thread-safe but
+ *it will spin up multiple threads internally.
+ **/
+class UdpEncryption {
+  template <int schedulerId>
+  friend class DataProcessor;
+
+ public:
+  explicit UdpEncryption(
+      std::unique_ptr<fbpcf::engine::communication::IPartyCommunicationAgent>
+          agent);
+
+  void prepareToProcessMyData(size_t myDataWidth);
+
+  // process my data via UDP encryption. This API should be called in coordinate
+  // with "ProcessPeerData" on peer's side. If this API is ever called, calling
+  // "getExpandedKey" to retrive the expanded key for decryption later.
+  void processMyData(
+      const std::vector<std::vector<unsigned char>>& plaintextData);
+
+  std::vector<__m128i> getExpandedKey() {
+    if (statusOfProcessingMyData_ != Status::inProgress) {
+      throw std::runtime_error(
+          "Can't call get ExapndedKey before preparation!");
+    }
+    statusOfProcessingMyData_ = Status::idle;
+
+    auto expandedKey = engine::util::Aes::expandEncryptionKey(prgKey_);
+    return std::vector<__m128i>(expandedKey.begin(), expandedKey.end());
+  }
+
+  void prepareToProcessPeerData(
+      size_t peerDataWidth,
+      const std::vector<int32_t>& indexes);
+
+  // process peer data via UDP encryption. This API should be called in
+  // coordinate with "ProcessMyData" on peer's side. This API is ever called,
+  // calling "getProcessedData" to retrive the cherry-picked encryption later.
+  void processPeerData(size_t dataSize);
+
+  // returning the ciphertext, nonce, and index of cherry-picked rows
+  std::tuple<
+      std::vector<std::vector<unsigned char>>,
+      std::vector<__m128i>,
+      std::vector<int32_t>>
+  getProcessedData() {
+    if (statusOfProcessingPeerData_ != Status::inProgress) {
+      throw std::runtime_error(
+          "Can't call getProcessedData before preparation!");
+    }
+    statusOfProcessingPeerData_ = Status::idle;
+    return {
+        std::move(cherryPickedEncryption_),
+        std::move(cherryPickedNonce_),
+        std::move(cherryPickedIndex_)};
+  }
+
+ private:
+  std::unique_ptr<fbpcf::engine::communication::IPartyCommunicationAgent>
+      agent_;
+
+  uint64_t indexOffset_;
+
+  size_t myDataWidth_;
+  __m128i prgKey_;
+
+  size_t peerDataWidth_;
+  // this map records the index-to-order map, the i-th row in peer's input
+  // should be indexToOrderMap_.at(i)-th in the encryption result, if i is in
+  // this map.
+  std::map<int32_t, int32_t> indexToOrderMap_;
+
+  // the vector of cherry-picked data of matched user, the three vectors
+  // consists of ciphertext, nonce, and index, respectively. We need to save the
+  // nonce because different nonces would be used in different "batches".
+
+  std::vector<std::vector<unsigned char>> cherryPickedEncryption_;
+  std::vector<__m128i> cherryPickedNonce_;
+  std::vector<int32_t> cherryPickedIndex_;
+
+  static const size_t kBlockSize = 16;
+
+  // record the status of this object of processing data
+  enum Status {
+    idle, // need to call setup first before any other APIs
+    inProgress, // allowed to call "processXXData" and getters. Calling getters
+                // will reset this object to idle status.
+  };
+  enum Status statusOfProcessingMyData_;
+  enum Status statusOfProcessingPeerData_;
+};
+
+} // namespace fbpcf::mpc_std_lib::unified_data_process::data_processor

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpUtil.cpp
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpUtil.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpUtil.h"
+#include <cstdint>
+#include <cstring>
+
+namespace fbpcf::mpc_std_lib::unified_data_process::data_processor {
+
+std::vector<__m128i> UdpUtil::generateCounterBlocks(
+    __m128i nonce,
+    uint64_t startingIndex,
+    size_t size) {
+  std::vector<__m128i> rst(size);
+  for (size_t i = 0; i < size; i++) {
+    rst.at(i) = _mm_add_epi64(nonce, _mm_set_epi64x(0, i + startingIndex));
+  }
+  return rst;
+}
+
+std::pair<std::vector<std::vector<uint8_t>>, std::vector<uint8_t>>
+UdpUtil::localEncryption(
+    const std::vector<std::vector<unsigned char>>& plaintextData,
+    __m128i prgKey,
+    uint64_t indexOffset) {
+  size_t rowCounts = plaintextData.size();
+  size_t rowSize = plaintextData.at(0).size();
+  size_t rowBlocks = (rowSize + kBlockSize - 1) / kBlockSize;
+
+  fbpcf::engine::util::Aes localAes(prgKey);
+
+  // generate counters for each block
+
+  __m128i s2vRes;
+  {
+    const primitive::mac::S2vFactory s2vFactory;
+    std::vector<unsigned char> keyByte(kBlockSize);
+    _mm_storeu_si128((__m128i*)keyByte.data(), prgKey);
+    const auto s2v = s2vFactory.create(keyByte);
+
+    std::vector<unsigned char> plaintextCombined;
+    plaintextCombined.reserve(rowSize * rowCounts);
+    std::for_each(
+        plaintextData.begin(),
+        plaintextData.end(),
+        [&plaintextCombined](const auto& v) {
+          std::copy(v.begin(), v.end(), std::back_inserter(plaintextCombined));
+        });
+    s2vRes = s2v->getMacM128i(plaintextCombined);
+  }
+
+  std::vector<std::vector<__m128i>> counterM128i(rowCounts);
+
+  for (uint64_t i = 0; i < counterM128i.size(); ++i) {
+    counterM128i.at(i) =
+        generateCounterBlocks(s2vRes, (indexOffset + i) * rowBlocks, rowBlocks);
+    // encrypt counters
+    localAes.encryptInPlace(counterM128i.at(i));
+  }
+
+  std::vector<std::vector<uint8_t>> ciphertextByte(
+      rowCounts, std::vector<uint8_t>(rowSize));
+
+  for (size_t i = 0; i < rowCounts; ++i) {
+    std::vector<uint8_t> mask(rowBlocks * kBlockSize);
+    memcpy(mask.data(), counterM128i.at(i).data(), rowBlocks * kBlockSize);
+    for (size_t j = 0; j < rowSize; ++j) {
+      ciphertextByte.at(i).at(j) = mask.at(j) ^ plaintextData.at(i).at(j);
+    }
+  }
+
+  std::vector<unsigned char> s2vVec(kBlockSize);
+  _mm_storeu_si128((__m128i*)s2vVec.data(), s2vRes);
+  return {ciphertextByte, s2vVec};
+}
+
+} // namespace fbpcf::mpc_std_lib::unified_data_process::data_processor

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpUtil.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpUtil.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <emmintrin.h>
+#include <sys/types.h>
+#include "fbpcf/frontend/BitString.h"
+#include "fbpcf/primitive/mac/S2v.h"
+#include "fbpcf/primitive/mac/S2vFactory.h"
+
+namespace fbpcf::mpc_std_lib::unified_data_process::data_processor {
+
+class UdpUtil {
+  template <int schedulerId>
+  using SecBit = frontend::Bit<true, schedulerId, true>;
+
+  static const size_t kBlockSize = 16;
+
+ public:
+  static std::pair<std::vector<std::vector<uint8_t>>, std::vector<uint8_t>>
+  localEncryption(
+      const std::vector<std::vector<unsigned char>>& plaintextData,
+      __m128i prgKey,
+      uint64_t indexOffset = 0);
+
+  static std::vector<__m128i>
+  generateCounterBlocks(__m128i nonce, uint64_t startingIndex, size_t size);
+
+  template <int schedulerId>
+  static std::vector<SecBit<schedulerId>> privatelyShareByteStream(
+      const std::vector<std::vector<unsigned char>>& localData,
+      int inputPartyID);
+
+  template <int schedulerId>
+  static std::vector<SecBit<schedulerId>> privatelyShareM128iStream(
+      const std::vector<std::vector<__m128i>>& localDataM128i,
+      int inputPartyID);
+
+  template <int schedulerId>
+  static std::vector<SecBit<schedulerId>> privatelyShareExpandedKey(
+      const std::vector<__m128i>& localKeyM128i,
+      size_t batchSize,
+      int inputPartyID);
+};
+
+} // namespace fbpcf::mpc_std_lib::unified_data_process::data_processor
+
+#include "fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpUtil_impl.h"

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpUtil_impl.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpUtil_impl.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace fbpcf::mpc_std_lib::unified_data_process::data_processor {
+
+template <int schedulerId>
+std::vector<UdpUtil::SecBit<schedulerId>> UdpUtil::privatelyShareByteStream(
+    const std::vector<std::vector<unsigned char>>& localData,
+    int inputPartyID) {
+  size_t unitSize = sizeof(unsigned char) * 8;
+  size_t localDataWidth = localData.at(0).size() * unitSize;
+  size_t stringWidth = localDataWidth % 128 == 0
+      ? localDataWidth
+      : localDataWidth + 128 - localDataWidth % 128;
+  size_t inputSize = localData.size();
+  std::vector<SecBit<schedulerId>> sharedData(stringWidth);
+  for (size_t i = 0; i < localDataWidth; i++) {
+    std::vector<bool> sharedBit(inputSize);
+    for (size_t j = 0; j < inputSize; j++) {
+      sharedBit.at(j) =
+          ((localData.at(j).at(i / unitSize) >> (unitSize - 1 - i % unitSize)) &
+           1);
+    }
+    sharedData.at(i) = SecBit<schedulerId>(sharedBit, inputPartyID);
+  }
+  // padding
+  for (size_t i = localDataWidth; i < stringWidth; ++i) {
+    std::vector<bool> sharedBit(inputSize);
+    sharedData.at(i) = SecBit<schedulerId>(sharedBit, inputPartyID);
+  }
+  return sharedData;
+}
+
+template <int schedulerId>
+std::vector<UdpUtil::SecBit<schedulerId>> UdpUtil::privatelyShareM128iStream(
+    const std::vector<std::vector<__m128i>>& localDataM128i,
+    int inputPartyID) {
+  size_t unitSize = 128;
+  size_t batchSize = localDataM128i.size();
+  size_t rowSize = localDataM128i.at(0).size();
+  std::vector<std::vector<bool>> localDataBool(
+      batchSize * rowSize, std::vector<bool>(unitSize));
+  for (size_t i = 0; i < batchSize; ++i) {
+    for (size_t j = 0; j < rowSize; ++j) {
+      // The bits extracted from extractLnbToVector() is the following order:
+      // All bytes are in a order that from most significant byte to least
+      // significant bytes. The bits in each byte is in a order that from lsb
+      // to msb.
+      fbpcf::engine::util::extractLnbToVector(
+          localDataM128i.at(i).at(j), localDataBool.at(i * rowSize + j));
+    }
+  }
+  std::vector<SecBit<schedulerId>> sharedDataBit(rowSize * 128);
+  for (size_t i = 0; i < rowSize * 128; ++i) {
+    std::vector<bool> sharedBit(batchSize);
+    for (size_t j = 0; j < batchSize; ++j) {
+      sharedBit.at(j) = localDataBool.at(j * rowSize + i / 128)
+                            .at(i % 128 / 8 * 8 + (7 - i % 8));
+    }
+    sharedDataBit.at(i) = SecBit<schedulerId>(sharedBit, inputPartyID);
+  }
+  return sharedDataBit;
+}
+
+template <int schedulerId>
+std::vector<UdpUtil::SecBit<schedulerId>> UdpUtil::privatelyShareExpandedKey(
+    const std::vector<__m128i>& localKeyM128i,
+    size_t batchSize,
+    int inputPartyID) {
+  size_t unitSize = 128;
+  size_t blockNo = localKeyM128i.size(); // should be 11
+  std::vector<std::vector<bool>> localDataBool(
+      blockNo, std::vector<bool>(unitSize));
+  for (size_t i = 0; i < blockNo; ++i) {
+    // The bits extracted from extractLnbToVector() is the following order:
+    // All bytes are in a order that from most significant byte to least
+    // significant bytes. The bits in each byte is in a order that from lsb to
+    // msb.
+    fbpcf::engine::util::extractLnbToVector(
+        localKeyM128i.at(i), localDataBool.at(i));
+  }
+  std::vector<SecBit<schedulerId>> sharedKeyBit(blockNo * unitSize);
+  for (size_t i = 0; i < blockNo * unitSize; ++i) {
+    std::vector<bool> sharedBit(
+        batchSize,
+        localDataBool.at(i / unitSize).at(i % unitSize / 8 * 8 + (7 - i % 8)));
+    sharedKeyBit.at(i) = SecBit<schedulerId>(sharedBit, inputPartyID);
+  }
+  return sharedKeyBit;
+}
+
+} // namespace fbpcf::mpc_std_lib::unified_data_process::data_processor


### PR DESCRIPTION
Summary:
As title. We modularize the UDP encryption logic into a separate stateful object such that it could input data distributed among multiple shards.
This diff is to ensure the change won't affect existing code. The test for "multiple shards" will be in a following diff.

Reviewed By: haochenuw

Differential Revision: D42913416

