### PR TITLE
Add concurrent download in Shard Aggregator

### DIFF
--- a/fbpcf/io/api/BufferedReader.cpp
+++ b/fbpcf/io/api/BufferedReader.cpp
@@ -76,12 +76,16 @@ std::string BufferedReader::readLine() {
     throw std::runtime_error("There are no more lines in this file.");
   }
 
+  std::string output = "";
   if (currentPosition_ == lastPosition_) {
     loadNextChunk();
+
+    if (lastPosition_ == 0) {
+      return output;
+    }
   }
 
   auto c = buffer_.at(currentPosition_++);
-  std::string output = "";
   while (c != '\n') {
     output += c;
 

--- a/fbpcf/io/api/test/BufferedReaderTest.cpp
+++ b/fbpcf/io/api/test/BufferedReaderTest.cpp
@@ -148,6 +148,19 @@ TEST(BufferedReaderTest, testBufferedReaderWithReadAndReadLineNoChunkSize) {
   runBufferedReaderTestForReadAndReadLine(std::move(bufferedReader));
 }
 
+TEST(BufferedReaderTest, testBufferedReaderEmptyFile) {
+  auto fileReader = std::make_unique<fbpcf::io::FileReader>(
+      IOTestHelper::getBaseDirFromPath(__FILE__) +
+      "data/buffered_reader_empty_file.txt");
+  auto bufferedReader =
+      std::make_unique<fbpcf::io::BufferedReader>(std::move(fileReader));
+
+  auto firstLine = bufferedReader->readLine();
+  EXPECT_TRUE(firstLine.empty());
+  EXPECT_TRUE(bufferedReader->eof());
+  bufferedReader->close();
+}
+
 INSTANTIATE_TEST_SUITE_P(
     BufferedReaderTest,
     BufferedReaderTest,


### PR DESCRIPTION
Summary:
1. Currently, the sequential download takes a long time (~4h in an Amazon run) - add concurrent download support
2. Fix an issue where buffered Reader throws for empty files.

Differential Revision: D43166367

