### PR TITLE
Split the test cases to avoid timeout errors

### DIFF
--- a/fbpcf/engine/tuple_generator/oblivious_transfer/test/BidirectionObliviousTransferTest.cpp
+++ b/fbpcf/engine/tuple_generator/oblivious_transfer/test/BidirectionObliviousTransferTest.cpp
@@ -330,6 +330,10 @@ TEST(
           1024,
           128,
           8));
+}
+TEST(
+    RcotBasedBidirectionObliviousTransferTest,
+    testBiDirectionOTIntegerWithExtenderBasedRcotPoweredByFerretExtenderPoweredByDummyMpcotAnd10LocalLinearMatrixMultipler) {
   testRcotBasedBidirectionObliviousTransferForIntegers(
       std::make_unique<ExtenderBasedRandomCorrelatedObliviousTransferFactory>(
           std::make_unique<
@@ -352,7 +356,6 @@ TEST(
           128,
           8));
 }
-
 TEST(
     RcotBasedBidirectionObliviousTransferTest,
     testBiDirectionOTWithExtenderBasedRcotPoweredByFerretExtenderPoweredByMpcotWithDummySpcotAnd10LocalLinearMatrixMultipler) {
@@ -432,6 +435,10 @@ TEST(
           ferret::kExtendedSize,
           ferret::kBaseSize,
           ferret::kWeight));
+}
+TEST(
+    RcotBasedBidirectionObliviousTransferTest,
+    testBiDirectionOTIntegerWithExtenderBasedRcotPoweredByFerretExtenderPoweredByMpcotWithRealSpcotAnd10LocalLinearMatrixMultipler) {
   testRcotBasedBidirectionObliviousTransferForIntegers(
       std::make_unique<ExtenderBasedRandomCorrelatedObliviousTransferFactory>(
           std::make_unique<
@@ -483,6 +490,10 @@ TEST(
           ferret::kExtendedSize,
           ferret::kBaseSize,
           ferret::kWeight));
+}
+TEST(
+    RcotBasedBidirectionObliviousTransferTest,
+    testBiDirectionOTIntegerWithBootstrappedExtenderBasedRcotPoweredByFerretExtenderPoweredByMpcotWithRealSpcotAnd10LocalLinearMatrixMultipler) {
   testRcotBasedBidirectionObliviousTransferForIntegers(
       std::make_unique<ExtenderBasedRandomCorrelatedObliviousTransferFactory>(
           std::make_unique<tuple_generator::oblivious_transfer::


### PR DESCRIPTION
Summary:
We have seen a task T145020747 that some tests are flaky because they exceed the 600s limit. This diff splits the test cases to reduce the time needed to execute each test case.

Thanks adshastri for suggesting this fix. We will keep monitoring if this helps reduce flakiness and we will gradually apply it to other test cases

Reviewed By: adshastri

Differential Revision: D43200388

