### PR TITLE
Handle empty file read error in BufferedReader

### DIFF
--- a/fbpcf/io/api/LocalFileReader.cpp
+++ b/fbpcf/io/api/LocalFileReader.cpp
@@ -9,6 +9,7 @@
 #include <folly/logging/xlog.h>
 #include <cerrno>
 #include <cstddef>
+#include <cstdio>
 #include <fstream>
 #include <vector>
 
@@ -51,7 +52,9 @@ size_t LocalFileReader::read(std::vector<char>& buf) {
 }
 
 bool LocalFileReader::eof() {
-  return inputStream_->eof();
+  // eof() returns true only if we have already attempted to read past the end
+  // of the file
+  return inputStream_->eof() || inputStream_->peek() == EOF;
 }
 
 LocalFileReader::~LocalFileReader() {

--- a/fbpcf/io/api/test/BufferedReaderTest.cpp
+++ b/fbpcf/io/api/test/BufferedReaderTest.cpp
@@ -7,6 +7,7 @@
 
 #include <gtest/gtest.h>
 #include <memory>
+#include <stdexcept>
 
 #include "fbpcf/io/api/BufferedReader.h"
 #include "fbpcf/io/api/FileReader.h"
@@ -146,6 +147,17 @@ TEST(BufferedReaderTest, testBufferedReaderWithReadAndReadLineNoChunkSize) {
       std::make_unique<fbpcf::io::BufferedReader>(std::move(fileReader));
 
   runBufferedReaderTestForReadAndReadLine(std::move(bufferedReader));
+}
+
+TEST(BufferedReaderTest, testBufferedReaderEmptyFile) {
+  auto fileReader = std::make_unique<fbpcf::io::FileReader>(
+      IOTestHelper::getBaseDirFromPath(__FILE__) +
+      "data/buffered_reader_empty_file.txt");
+  auto bufferedReader =
+      std::make_unique<fbpcf::io::BufferedReader>(std::move(fileReader));
+
+  EXPECT_THROW(bufferedReader->readLine(), std::runtime_error);
+  bufferedReader->close();
 }
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
Summary: Currently, BufferedReader.readLine() throws when reading empty files. Add a check to handle that.

Differential Revision: D43255041

