### PR TITLE
fix key reuse issue in SIV generation

### DIFF
--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpUtil.cpp
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpUtil.cpp
@@ -37,9 +37,10 @@ UdpUtil::localEncryption(
 
   __m128i s2vRes;
   {
+    __m128i sivKey = fbpcf::engine::util::getRandomM128iFromSystemNoise();
     const primitive::mac::S2vFactory s2vFactory;
     std::vector<unsigned char> keyByte(kBlockSize);
-    _mm_storeu_si128((__m128i*)keyByte.data(), prgKey);
+    _mm_storeu_si128((__m128i*)keyByte.data(), sivKey);
     const auto s2v = s2vFactory.create(keyByte);
 
     std::vector<unsigned char> plaintextCombined;


### PR DESCRIPTION
Summary: As title. We generate a new random key for SIV generation. This is for resolving the key resue issue in AES encryption and SIV generation.

Reviewed By: xyguo

Differential Revision: D43195438

