### PR TITLE
Add RowDefinition implementation with integer column support

### DIFF
--- a/fbpcf/mpc_std_lib/unified_data_process/serialization/FixedSizeArrayColumn.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/serialization/FixedSizeArrayColumn.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <memory>
+#include <stdexcept>
 #include "fbpcf/mpc_std_lib/unified_data_process/serialization/IColumnDefinition.h"
 
 namespace fbpcf::mpc_std_lib::unified_data_process::serialization {
@@ -29,6 +30,23 @@ class FixedSizeArrayColumn : public IColumnDefinition<schedulerId> {
 
   size_t getColumnSizeBytes() const override {
     return length_ * innerType_->getColumnSizeBytes();
+  }
+
+  typename IColumnDefinition<schedulerId>::SupportedColumnTypes getColumnType()
+      const override {
+    auto innerColumnType = innerType_->getColumnType();
+
+    switch (innerColumnType) {
+      case IColumnDefinition<schedulerId>::SupportedColumnTypes::UInt32:
+        return IColumnDefinition<schedulerId>::SupportedColumnTypes::UInt32Vec;
+      case IColumnDefinition<schedulerId>::SupportedColumnTypes::Int32:
+        return IColumnDefinition<schedulerId>::SupportedColumnTypes::Int32Vec;
+      case IColumnDefinition<schedulerId>::SupportedColumnTypes::Int64:
+        return IColumnDefinition<schedulerId>::SupportedColumnTypes::Int64Vec;
+      default:
+        throw std::runtime_error(
+            "This code should be unreachable. Tried to get invalid Array Column");
+    }
   }
 
   size_t getLength() const {

--- a/fbpcf/mpc_std_lib/unified_data_process/serialization/IColumnDefinition.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/serialization/IColumnDefinition.h
@@ -21,6 +21,17 @@ class IColumnDefinition {
   using MPCTypes = frontend::MPCTypes<schedulerId, true /* usingBatch */>;
 
  public:
+  enum SupportedColumnTypes {
+    Bit = 0,
+    PackedBitField = 1,
+    UInt32 = 2,
+    Int32 = 3,
+    Int64 = 4,
+    UInt32Vec = 5,
+    Int32Vec = 6,
+    Int64Vec = 7,
+  };
+
   /* Possible return types for deserialization following UDP run */
   using DeserializeType = std::variant<
       typename MPCTypes::SecBool,
@@ -37,6 +48,8 @@ class IColumnDefinition {
   virtual std::string getColumnName() const = 0;
 
   virtual size_t getColumnSizeBytes() const = 0;
+
+  virtual SupportedColumnTypes getColumnType() const = 0;
 
   /* Pass in a single value of the column to be serialized, sequentially write
    * the bytes starting at the beginning of buf */

--- a/fbpcf/mpc_std_lib/unified_data_process/serialization/IRowStructureDefinition.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/serialization/IRowStructureDefinition.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <unordered_map>
+#include <vector>
+#include "IColumnDefinition.h"
+#include "fbpcf/frontend/BitString.h"
+
+namespace fbpcf::mpc_std_lib::unified_data_process::serialization {
+
+template <int schedulerId>
+class IRowStructureDefinition {
+ public:
+  using SecString = frontend::BitString<true, schedulerId, true>;
+
+  using InputColumnDataType = std::variant<
+      std::vector<bool>,
+      std::vector<uint32_t>,
+      std::vector<int32_t>,
+      std::vector<int64_t>,
+      std::vector<std::vector<bool>>,
+      std::vector<std::vector<uint32_t>>,
+      std::vector<std::vector<int32_t>>,
+      std::vector<std::vector<int64_t>>>;
+
+  virtual ~IRowStructureDefinition() = default;
+
+  /* Returns the number of bytes to serialize a single row */
+  virtual size_t getRowSizeBytes() const = 0;
+
+  // Serialize each column's worth of data according to the structure
+  // definition. Each key must match the name of a column in the definition and
+  // the value contains the data for that column
+  virtual std::vector<std::vector<unsigned char>> serializeDataAsBytesForUDP(
+      const std::unordered_map<std::string, InputColumnDataType>& data,
+      int numRows) const = 0;
+
+  // Following a run of the UDP protocol, deserialize the batched BitString
+  // containing encrypted columns into private MPC types.
+  virtual std::unordered_map<
+      std::string,
+      typename IColumnDefinition<schedulerId>::DeserializeType>
+  deserializeUDPOutputIntoMPCTypes(const SecString& secretSharedData) const = 0;
+};
+
+} // namespace fbpcf::mpc_std_lib::unified_data_process::serialization

--- a/fbpcf/mpc_std_lib/unified_data_process/serialization/PackedBitFieldColumn.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/serialization/PackedBitFieldColumn.h
@@ -42,6 +42,11 @@ class PackedBitFieldColumn : public IColumnDefinition<schedulerId> {
     return 1;
   }
 
+  typename IColumnDefinition<schedulerId>::SupportedColumnTypes getColumnType()
+      const override {
+    return IColumnDefinition<schedulerId>::SupportedColumnTypes::PackedBitField;
+  }
+
   // input to this function is a pointer to a bool vector since memory layout
   // is not guaranteed by compiler (i.e. can not get a bool* from a
   // vector<bool>.data())

--- a/fbpcf/mpc_std_lib/unified_data_process/serialization/RowStructureDefinition.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/serialization/RowStructureDefinition.h
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <stdexcept>
+#include <unordered_map>
+#include <vector>
+
+#include "fbpcf/mpc_std_lib/unified_data_process/serialization/FixedSizeArrayColumn.h"
+#include "fbpcf/mpc_std_lib/unified_data_process/serialization/IRowStructureDefinition.h"
+#include "fbpcf/mpc_std_lib/unified_data_process/serialization/IntegerColumn.h"
+#include "fbpcf/mpc_std_lib/unified_data_process/serialization/PackedBitFieldColumn.h"
+
+#include "folly/Format.h"
+
+namespace fbpcf::mpc_std_lib::unified_data_process::serialization {
+
+template <int schedulerId>
+class RowStructureDefinition : public IRowStructureDefinition<schedulerId> {
+ public:
+  using SecString = frontend::BitString<true, schedulerId, true>;
+  using SecBit = frontend::Bit<true, schedulerId, true>;
+
+  explicit RowStructureDefinition(
+      std::unique_ptr<
+          std::vector<std::unique_ptr<IColumnDefinition<schedulerId>>>>
+          columnDefinitions)
+      : columnDefinitions_(std::move(columnDefinitions)) {}
+
+  /* Returns the number of bytes to serialize a single row */
+  size_t getRowSizeBytes() const override {
+    size_t rst = 0;
+    for (const auto& columnType : *columnDefinitions_.get()) {
+      rst += columnType->getColumnSizeBytes();
+    }
+
+    return rst;
+  }
+
+  std::vector<std::vector<unsigned char>> serializeDataAsBytesForUDP(
+      const std::unordered_map<
+          std::string,
+          typename IRowStructureDefinition<schedulerId>::InputColumnDataType>&
+          data,
+      int numRows) const override {
+    // validate number of columns matches what is expected
+    size_t expectedColumns = 0;
+    for (const std::unique_ptr<IColumnDefinition<schedulerId>>&
+             columnDefinition : *columnDefinitions_.get()) {
+      const PackedBitFieldColumn<schedulerId>* packedBitCol =
+          dynamic_cast<const PackedBitFieldColumn<schedulerId>*>(
+              columnDefinition.get());
+
+      if (packedBitCol == nullptr) {
+        expectedColumns++;
+      } else {
+        expectedColumns += packedBitCol->getSubColumnNames().size();
+      }
+    }
+    if (data.size() != expectedColumns) {
+      throw std::runtime_error(
+          "Mismatch between number of columns defined by row structure and what was passed in.");
+    }
+
+    size_t byteOffset = 0;
+
+    std::vector<std::vector<unsigned char>> writeBuffers(
+        numRows, std::vector<unsigned char>(getRowSizeBytes()));
+
+    for (const std::unique_ptr<IColumnDefinition<schedulerId>>&
+             columnDefinition : *columnDefinitions_.get()) {
+      const IColumnDefinition<schedulerId>* columnPointer =
+          columnDefinition.get();
+      auto columnType = columnDefinition->getColumnType();
+
+      switch (columnType) {
+        case IColumnDefinition<schedulerId>::SupportedColumnTypes::UInt32:
+          serializeIntegerColumn<false, 32>(
+              columnPointer, data, writeBuffers, numRows, byteOffset);
+          break;
+        case IColumnDefinition<schedulerId>::SupportedColumnTypes::Int32:
+          serializeIntegerColumn<true, 32>(
+              columnPointer, data, writeBuffers, numRows, byteOffset);
+          break;
+        case IColumnDefinition<schedulerId>::SupportedColumnTypes::Int64:
+          serializeIntegerColumn<true, 64>(
+              columnPointer, data, writeBuffers, numRows, byteOffset);
+          break;
+        default:
+          throw std::runtime_error(
+              "Unknown column type while serializing data.");
+      }
+
+      byteOffset += columnPointer->getColumnSizeBytes();
+    }
+
+    return writeBuffers;
+  }
+
+  // Following a run of the UDP protocol, deserialize the array into pointers
+  // to MPC types. Data is represented in column order format
+  virtual std::unordered_map<
+      std::string,
+      typename IColumnDefinition<schedulerId>::DeserializeType>
+  deserializeUDPOutputIntoMPCTypes(
+      const SecString& secretSharedData) const override {
+    std::vector<std::vector<bool>> secretSharedBits =
+        secretSharedData.extractStringShare().getValue();
+    secretSharedBits = transpose(secretSharedBits);
+    std::vector<std::vector<unsigned char>> secretSharedBytes(0);
+    secretSharedBytes.reserve(secretSharedBits.size());
+    for (int i = 0; i < secretSharedBits.size(); i++) {
+      secretSharedBytes.push_back(convertFromBits(secretSharedBits[i]));
+    }
+
+    std::unordered_map<
+        std::string,
+        typename IColumnDefinition<schedulerId>::DeserializeType>
+        rst;
+    size_t byteOffset = 0;
+    for (const std::unique_ptr<IColumnDefinition<schedulerId>>&
+             columnDefinition : *columnDefinitions_.get()) {
+      rst.emplace(
+          columnDefinition->getColumnName(),
+          columnDefinition->deserializeSharesToMPCType(
+              secretSharedBytes, byteOffset));
+      byteOffset += columnDefinition->getColumnSizeBytes();
+    }
+
+    return rst;
+  }
+
+ private:
+  // use an ordered map for consistency between both parties
+  std::unique_ptr<std::vector<std::unique_ptr<IColumnDefinition<schedulerId>>>>
+      columnDefinitions_;
+
+  std::vector<unsigned char> convertFromBits(
+      const std::vector<bool>& data) const {
+    std::vector<unsigned char> rst;
+    rst.reserve(data.size() / 8);
+
+    size_t i = 0;
+
+    while (i < data.size()) {
+      unsigned char val = 0;
+      size_t bitsLeft = data.size() - i > 8 ? 8 : data.size() - i;
+      for (auto j = 0; j < bitsLeft; j++) {
+        val |= (data[i] << j);
+        ++i;
+      }
+      rst.push_back(val);
+    }
+
+    return rst;
+  }
+
+  template <typename T>
+  std::vector<std::vector<T>> transpose(
+      const std::vector<std::vector<T>>& data) const {
+    std::vector<std::vector<T>> result;
+    if (data.size() == 0) {
+      return result;
+    }
+
+    result.reserve(data[0].size());
+    for (size_t column = 0; column < data[0].size(); column++) {
+      std::vector<T> innerArray(data.size());
+      result.push_back(std::vector<T>(data.size()));
+      for (size_t row = 0; row < data.size(); row++) {
+        result[column][row] = data[row][column];
+      }
+    }
+    return result;
+  }
+
+  template <bool isSigned, int8_t width>
+  void serializeIntegerColumn(
+      const IColumnDefinition<schedulerId>* columnPointer,
+      const std::unordered_map<
+          std::string,
+          typename IRowStructureDefinition<schedulerId>::InputColumnDataType>&
+          inputData,
+      std::vector<std::vector<unsigned char>>& writeBuffers,
+      int numRows,
+      size_t byteOffset) const {
+    std::string colName = columnPointer->getColumnName();
+
+    if (!inputData.contains(colName)) {
+      throw std::runtime_error(folly::sformat(
+          "Column {} which was defined in the structure was not included"
+          " in the input data map.",
+          colName));
+    }
+
+    using IntType =
+        typename IntegerColumn<schedulerId, isSigned, width>::NativeType;
+
+    const std::vector<IntType> intVals =
+        std::get<std::vector<IntType>>(inputData.at(colName));
+
+    if (intVals.size() != numRows) {
+      std::string err = folly::sformat(
+          "Invalid number of values for column {}. Got {} values but number of rows should be {} ",
+          colName,
+          intVals.size(),
+          numRows);
+      throw std::runtime_error(err);
+    }
+
+    for (int i = 0; i < numRows; i++) {
+      columnPointer->serializeColumnAsPlaintextBytes(
+          &intVals[i], writeBuffers[i].data() + byteOffset);
+    }
+  }
+};
+
+} // namespace fbpcf::mpc_std_lib::unified_data_process::serialization

--- a/fbpcf/mpc_std_lib/unified_data_process/serialization/test/ColumnSerializationTest.cpp
+++ b/fbpcf/mpc_std_lib/unified_data_process/serialization/test/ColumnSerializationTest.cpp
@@ -103,7 +103,7 @@ static std::vector<std::vector<bool>> deserializeAndRevealPackedBits(
   return rst;
 }
 
-TEST(SerializationTest, IntegerColumnTest) {
+TEST(ColumnSerializationTest, IntegerColumnTest) {
   auto factories = fbpcf::engine::communication::getInMemoryAgentFactory(2);
 
   auto schedulerFactory0 =
@@ -160,7 +160,7 @@ TEST(SerializationTest, IntegerColumnTest) {
   testVectorEq(vals, rst);
 }
 
-TEST(SerializationTest, ArrayColumnTest) {
+TEST(ColumnSerializationTest, ArrayColumnTest) {
   auto factories = fbpcf::engine::communication::getInMemoryAgentFactory(2);
 
   auto schedulerFactory0 =
@@ -235,7 +235,7 @@ TEST(SerializationTest, ArrayColumnTest) {
   }
 }
 
-TEST(SerializationTest, PackedBitFieldColumnTest) {
+TEST(ColumnSerializationTest, PackedBitFieldColumnTest) {
   auto factories = fbpcf::engine::communication::getInMemoryAgentFactory(2);
 
   auto schedulerFactory0 =
@@ -334,4 +334,5 @@ TEST(erializationTest, ColumnTypeTest) {
       "col4", std::make_unique<IntegerColumn<0, false, 32>>("test"), 4);
   EXPECT_EQ(col6->getColumnType(), ColType::UInt32Vec);
 }
+
 } // namespace fbpcf::mpc_std_lib::unified_data_process::serialization

--- a/fbpcf/mpc_std_lib/unified_data_process/serialization/test/RowSerializationTest.cpp
+++ b/fbpcf/mpc_std_lib/unified_data_process/serialization/test/RowSerializationTest.cpp
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include <algorithm>
+
+#include "fbpcf/engine/communication/test/AgentFactoryCreationHelper.h"
+#include "fbpcf/frontend/MPCTypes.h"
+#include "fbpcf/scheduler/ISchedulerFactory.h"
+#include "fbpcf/scheduler/SchedulerHelper.h"
+#include "fbpcf/test/TestHelper.h"
+
+#include "fbpcf/mpc_std_lib/unified_data_process/serialization/IRowStructureDefinition.h"
+#include "fbpcf/mpc_std_lib/unified_data_process/serialization/IntegerColumn.h"
+#include "fbpcf/mpc_std_lib/unified_data_process/serialization/RowStructureDefinition.h"
+
+namespace fbpcf::mpc_std_lib::unified_data_process::serialization {
+
+template <int schedulerId>
+std::unique_ptr<IRowStructureDefinition<schedulerId>> createRowDefinition() {
+  auto columnDefs = std::make_unique<
+      std::vector<typename std::unique_ptr<IColumnDefinition<schedulerId>>>>(0);
+
+  columnDefs->push_back(
+      std::make_unique<IntegerColumn<schedulerId, true, 32>>("int32Column"));
+  columnDefs->push_back(
+      std::make_unique<IntegerColumn<schedulerId, true, 64>>("int64Column"));
+  columnDefs->push_back(
+      std::make_unique<IntegerColumn<schedulerId, false, 32>>("uint32Column"));
+  auto serializer = std::make_unique<RowStructureDefinition<schedulerId>>(
+      std::move(columnDefs));
+  return std::move(serializer);
+}
+
+template <int schedulerId>
+std::unordered_map<
+    std::string,
+    typename IRowStructureDefinition<schedulerId>::InputColumnDataType>
+deserializeAndRevealAllColumns(
+    fbpcf::scheduler::ISchedulerFactory<true>& schedulerFactory,
+    const std::vector<std::vector<unsigned char>>& serializedSecretShares,
+    const std::unique_ptr<IRowStructureDefinition<schedulerId>>&
+        rowDefinition) {
+  auto scheduler = schedulerFactory.create();
+
+  fbpcf::scheduler::SchedulerKeeper<schedulerId>::setScheduler(
+      std::move(scheduler));
+
+  // The vector of vector of bytes would be passed into UDP, and the SecString
+  // output will have less number of rows based on the intersection. We are
+  // pretending there is no data filtered out and party 0 creates the SecString
+  // as a private input.
+  std::vector<std::vector<bool>> bitSharesTranspose(
+      serializedSecretShares[0].size() * 8,
+      std::vector<bool>(serializedSecretShares.size()));
+
+  for (int i = 0; i < serializedSecretShares.size(); i++) {
+    for (int j = 0; j < serializedSecretShares[i].size(); j++) {
+      for (int k = 0; k < 8; k++) {
+        bitSharesTranspose[j * 8 + k][i] =
+            serializedSecretShares[i][j] >> k & 1;
+      }
+    }
+  }
+
+  frontend::BitString<true, schedulerId, true> udpOutput(bitSharesTranspose, 0);
+
+  auto deserialization =
+      rowDefinition.get()->deserializeUDPOutputIntoMPCTypes(udpOutput);
+
+  std::unordered_map<
+      std::string,
+      typename IRowStructureDefinition<schedulerId>::InputColumnDataType>
+      rst;
+
+  std::vector<int64_t> int32Opened =
+      std::get<typename frontend::MPCTypes<schedulerId>::Sec32Int>(
+          deserialization.at("int32Column"))
+          .openToParty(0)
+          .getValue();
+  std::vector<int32_t> int32Data(int32Opened.size());
+  std::transform(
+      int32Opened.begin(),
+      int32Opened.end(),
+      int32Data.begin(),
+      [](int64_t data) { return data; });
+  rst.emplace("int32Column", int32Data);
+
+  std::vector<int64_t> int64Data =
+      std::get<typename frontend::MPCTypes<schedulerId>::Sec64Int>(
+          deserialization.at("int64Column"))
+          .openToParty(0)
+          .getValue();
+
+  rst.emplace("int64Column", int64Data);
+
+  std::vector<uint64_t> uint32Opened =
+      std::get<typename frontend::MPCTypes<schedulerId>::SecUnsigned32Int>(
+          deserialization.at("uint32Column"))
+          .openToParty(0)
+          .getValue();
+
+  std::vector<uint32_t> uint32Data(uint32Opened.size());
+  std::transform(
+      uint32Opened.begin(),
+      uint32Opened.end(),
+      uint32Data.begin(),
+      [](uint64_t data) { return data; });
+  rst.emplace("uint32Column", uint32Data);
+
+  return rst;
+}
+
+TEST(RowSerializationTest, RowWithMultipleColumnsTest) {
+  auto factories = fbpcf::engine::communication::getInMemoryAgentFactory(2);
+
+  auto schedulerFactory0 =
+      fbpcf::scheduler::NetworkPlaintextSchedulerFactory<true>(
+          0, *factories[0]);
+
+  auto schedulerFactory1 =
+      fbpcf::scheduler::NetworkPlaintextSchedulerFactory<true>(
+          1, *factories[1]);
+
+  const size_t batchSize = 100;
+
+  std::random_device rd;
+  std::mt19937_64 e(rd());
+  std::uniform_int_distribution<int64_t> uint32Dist(
+      std::numeric_limits<uint32_t>().min(),
+      std::numeric_limits<uint32_t>().max());
+  std::uniform_int_distribution<int32_t> int32Dist(
+      std::numeric_limits<int32_t>().min(),
+      std::numeric_limits<int32_t>().max());
+  std::uniform_int_distribution<int64_t> int64Dist(
+      std::numeric_limits<int64_t>().min(),
+      std::numeric_limits<int64_t>().max());
+
+  std::unique_ptr<IRowStructureDefinition<0>> serializer0 =
+      createRowDefinition<0>();
+  std::unique_ptr<IRowStructureDefinition<1>> serializer1 =
+      createRowDefinition<1>();
+
+  EXPECT_EQ(serializer0->getRowSizeBytes(), 16);
+  EXPECT_EQ(serializer1->getRowSizeBytes(), 16);
+
+  std::vector<int32_t> int32Data(0);
+  std::vector<int64_t> int64Data(0);
+  std::vector<uint32_t> uint32Data(0);
+
+  for (int i = 0; i < batchSize; i++) {
+    int32Data.push_back(int32Dist(e));
+    int64Data.push_back(int64Dist(e));
+    uint32Data.push_back(uint32Dist(e));
+  }
+
+  std::unordered_map<
+      std::string,
+      IRowStructureDefinition<0>::InputColumnDataType>
+      inputData{
+          {"int32Column", int32Data},
+          {"int64Column", int64Data},
+          {"uint32Column", uint32Data}};
+
+  auto serializedBytes =
+      serializer0->serializeDataAsBytesForUDP(inputData, batchSize);
+
+  auto future0 =
+      std::async([&schedulerFactory0, &serializedBytes, &serializer0]() {
+        return deserializeAndRevealAllColumns<0>(
+            schedulerFactory0, serializedBytes, serializer0);
+      });
+
+  auto future1 = std::async([&schedulerFactory1, &serializer1]() {
+    return deserializeAndRevealAllColumns<1>(
+        schedulerFactory1,
+        std::vector<std::vector<unsigned char>>(
+            batchSize, std::vector<uint8_t>(serializer1->getRowSizeBytes())),
+        serializer1);
+  });
+
+  auto rst = future0.get();
+  future1.get();
+
+  auto int32Rst = std::get<std::vector<int32_t>>(rst.at("int32Column"));
+  auto int64Rst = std::get<std::vector<int64_t>>(rst.at("int64Column"));
+  auto uint32Rst = std::get<std::vector<uint32_t>>(rst.at("uint32Column"));
+
+  testVectorEq(int32Data, int32Rst);
+  testVectorEq(int64Data, int64Rst);
+  testVectorEq(uint32Data, uint32Rst);
+}
+} // namespace fbpcf::mpc_std_lib::unified_data_process::serialization

--- a/fbpcf/mpc_std_lib/unified_data_process/serialization/test/SerializationTest.cpp
+++ b/fbpcf/mpc_std_lib/unified_data_process/serialization/test/SerializationTest.cpp
@@ -299,4 +299,39 @@ TEST(SerializationTest, PackedBitFieldColumnTest) {
     testVectorEq(vals[j], rst[j]);
   }
 }
+
+TEST(erializationTest, ColumnTypeTest) {
+  using ColType = IColumnDefinition<0>::SupportedColumnTypes;
+  std::unique_ptr<IColumnDefinition<0>> col0 =
+      std::make_unique<IntegerColumn<0, true, 32>>("col0");
+  EXPECT_EQ(col0->getColumnType(), ColType::Int32);
+
+  std::unique_ptr<IColumnDefinition<0>> col1 =
+      std::make_unique<IntegerColumn<0, true, 64>>("col1");
+  EXPECT_EQ(col1->getColumnType(), ColType::Int64);
+
+  std::unique_ptr<IColumnDefinition<0>> col2 =
+      std::make_unique<IntegerColumn<0, false, 32>>("col2");
+  EXPECT_EQ(col2->getColumnType(), ColType::UInt32);
+
+  std::vector<std::string> names{"bool1", "bool2"};
+  std::unique_ptr<IColumnDefinition<0>> col3 =
+      std::make_unique<PackedBitFieldColumn<0>>("col3", names);
+  EXPECT_EQ(col3->getColumnType(), ColType::PackedBitField);
+
+  std::unique_ptr<IColumnDefinition<0>> col4 = std::make_unique<
+      FixedSizeArrayColumn<0, frontend::MPCTypes<0>::Sec32Int>>(
+      "col4", std::make_unique<IntegerColumn<0, true, 32>>("test"), 4);
+  EXPECT_EQ(col4->getColumnType(), ColType::Int32Vec);
+
+  std::unique_ptr<IColumnDefinition<0>> col5 = std::make_unique<
+      FixedSizeArrayColumn<0, frontend::MPCTypes<0>::Sec64Int>>(
+      "col4", std::make_unique<IntegerColumn<0, true, 64>>("test"), 4);
+  EXPECT_EQ(col5->getColumnType(), ColType::Int64Vec);
+
+  std::unique_ptr<IColumnDefinition<0>> col6 = std::make_unique<
+      FixedSizeArrayColumn<0, frontend::MPCTypes<0>::SecUnsigned32Int>>(
+      "col4", std::make_unique<IntegerColumn<0, false, 32>>("test"), 4);
+  EXPECT_EQ(col6->getColumnType(), ColType::UInt32Vec);
+}
 } // namespace fbpcf::mpc_std_lib::unified_data_process::serialization


### PR DESCRIPTION
Summary:
# Background:

Currently in order to successfully use UDP, you must write some carefully crafted code that will take all the rows of metadata for one side and package it into a collection of bytes. Afterwards the caller will get a `SecString` object back which is a bit representation of all the bytes they passed in, minus the filtered out rows. The user must then extract the corresponding bits for each column into separate MPC Types.  This is a cumbersome process which is error prone, as you must make sure to carefully match up the two steps and any changes can cause a bug.

# This Diff

Creates the implementation for the RowDefinition. As a start we only support integer columns, more types to come in later diff.

Differential Revision: D43208067

