### PR TITLE
Add interface to define a Row based serializer

### DIFF
--- a/fbpcf/mpc_std_lib/unified_data_process/serialization/FixedSizeArrayColumn.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/serialization/FixedSizeArrayColumn.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <memory>
+#include <stdexcept>
 #include "fbpcf/mpc_std_lib/unified_data_process/serialization/IColumnDefinition.h"
 
 namespace fbpcf::mpc_std_lib::unified_data_process::serialization {
@@ -29,6 +30,23 @@ class FixedSizeArrayColumn : public IColumnDefinition<schedulerId> {
 
   size_t getColumnSizeBytes() const override {
     return length_ * innerType_->getColumnSizeBytes();
+  }
+
+  typename IColumnDefinition<schedulerId>::SupportedColumnTypes getColumnType()
+      const override {
+    auto innerColumnType = innerType_->getColumnType();
+
+    switch (innerColumnType) {
+      case IColumnDefinition<schedulerId>::SupportedColumnTypes::UInt32:
+        return IColumnDefinition<schedulerId>::SupportedColumnTypes::UInt32Vec;
+      case IColumnDefinition<schedulerId>::SupportedColumnTypes::Int32:
+        return IColumnDefinition<schedulerId>::SupportedColumnTypes::Int32Vec;
+      case IColumnDefinition<schedulerId>::SupportedColumnTypes::Int64:
+        return IColumnDefinition<schedulerId>::SupportedColumnTypes::Int64Vec;
+      default:
+        throw std::runtime_error(
+            "This code should be unreachable. Tried to get invalid Array Column");
+    }
   }
 
   size_t getLength() const {

--- a/fbpcf/mpc_std_lib/unified_data_process/serialization/IColumnDefinition.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/serialization/IColumnDefinition.h
@@ -21,6 +21,17 @@ class IColumnDefinition {
   using MPCTypes = frontend::MPCTypes<schedulerId, true /* usingBatch */>;
 
  public:
+  enum SupportedColumnTypes {
+    Bit = 0,
+    PackedBitField = 1,
+    UInt32 = 2,
+    Int32 = 3,
+    Int64 = 4,
+    UInt32Vec = 5,
+    Int32Vec = 6,
+    Int64Vec = 7,
+  };
+
   /* Possible return types for deserialization following UDP run */
   using DeserializeType = std::variant<
       typename MPCTypes::SecBool,
@@ -37,6 +48,8 @@ class IColumnDefinition {
   virtual std::string getColumnName() const = 0;
 
   virtual size_t getColumnSizeBytes() const = 0;
+
+  virtual SupportedColumnTypes getColumnType() const = 0;
 
   /* Pass in a single value of the column to be serialized, sequentially write
    * the bytes starting at the beginning of buf */

--- a/fbpcf/mpc_std_lib/unified_data_process/serialization/IRowStructureDefinition.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/serialization/IRowStructureDefinition.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <unordered_map>
+#include <vector>
+#include "IColumnDefinition.h"
+#include "fbpcf/frontend/BitString.h"
+
+namespace fbpcf::mpc_std_lib::unified_data_process::serialization {
+
+template <int schedulerId>
+class IRowStructureDefinition {
+ public:
+  using SecString = frontend::BitString<true, schedulerId, true>;
+
+  using InputColumnDataType = std::variant<
+      std::vector<bool>,
+      std::vector<uint32_t>,
+      std::vector<int32_t>,
+      std::vector<int64_t>,
+      std::vector<std::vector<bool>>,
+      std::vector<std::vector<uint32_t>>,
+      std::vector<std::vector<int32_t>>,
+      std::vector<std::vector<int64_t>>>;
+
+  virtual ~IRowStructureDefinition() = default;
+
+  /* Returns the number of bytes to serialize a single row */
+  virtual size_t getRowSizeBytes() const = 0;
+
+  // Serialize each column's worth of data according to the structure
+  // definition. Each key must match the name of a column in the definition and
+  // the value contains the data for that column
+  virtual std::vector<std::vector<unsigned char>> serializeDataAsBytesForUDP(
+      const std::unordered_map<std::string, InputColumnDataType>& data,
+      int numRows) const = 0;
+
+  // Following a run of the UDP protocol, deserialize the batched BitString
+  // containing encrypted columns into private MPC types.
+  virtual std::unordered_map<
+      std::string,
+      typename IColumnDefinition<schedulerId>::DeserializeType>
+  deserializeUDPOutputIntoMPCTypes(const SecString& secretSharedData) const = 0;
+};
+
+} // namespace fbpcf::mpc_std_lib::unified_data_process::serialization

--- a/fbpcf/mpc_std_lib/unified_data_process/serialization/PackedBitFieldColumn.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/serialization/PackedBitFieldColumn.h
@@ -42,6 +42,11 @@ class PackedBitFieldColumn : public IColumnDefinition<schedulerId> {
     return 1;
   }
 
+  typename IColumnDefinition<schedulerId>::SupportedColumnTypes getColumnType()
+      const override {
+    return IColumnDefinition<schedulerId>::SupportedColumnTypes::PackedBitField;
+  }
+
   // input to this function is a pointer to a bool vector since memory layout
   // is not guaranteed by compiler (i.e. can not get a bool* from a
   // vector<bool>.data())

--- a/fbpcf/mpc_std_lib/unified_data_process/serialization/test/ColumnSerializationTest.cpp
+++ b/fbpcf/mpc_std_lib/unified_data_process/serialization/test/ColumnSerializationTest.cpp
@@ -103,7 +103,7 @@ static std::vector<std::vector<bool>> deserializeAndRevealPackedBits(
   return rst;
 }
 
-TEST(SerializationTest, IntegerColumnTest) {
+TEST(ColumnSerializationTest, IntegerColumnTest) {
   auto factories = fbpcf::engine::communication::getInMemoryAgentFactory(2);
 
   auto schedulerFactory0 =
@@ -160,7 +160,7 @@ TEST(SerializationTest, IntegerColumnTest) {
   testVectorEq(vals, rst);
 }
 
-TEST(SerializationTest, ArrayColumnTest) {
+TEST(ColumnSerializationTest, ArrayColumnTest) {
   auto factories = fbpcf::engine::communication::getInMemoryAgentFactory(2);
 
   auto schedulerFactory0 =
@@ -235,7 +235,7 @@ TEST(SerializationTest, ArrayColumnTest) {
   }
 }
 
-TEST(SerializationTest, PackedBitFieldColumnTest) {
+TEST(ColumnSerializationTest, PackedBitFieldColumnTest) {
   auto factories = fbpcf::engine::communication::getInMemoryAgentFactory(2);
 
   auto schedulerFactory0 =
@@ -334,4 +334,5 @@ TEST(erializationTest, ColumnTypeTest) {
       "col4", std::make_unique<IntegerColumn<0, false, 32>>("test"), 4);
   EXPECT_EQ(col6->getColumnType(), ColType::UInt32Vec);
 }
+
 } // namespace fbpcf::mpc_std_lib::unified_data_process::serialization

--- a/fbpcf/mpc_std_lib/unified_data_process/serialization/test/SerializationTest.cpp
+++ b/fbpcf/mpc_std_lib/unified_data_process/serialization/test/SerializationTest.cpp
@@ -299,4 +299,39 @@ TEST(SerializationTest, PackedBitFieldColumnTest) {
     testVectorEq(vals[j], rst[j]);
   }
 }
+
+TEST(erializationTest, ColumnTypeTest) {
+  using ColType = IColumnDefinition<0>::SupportedColumnTypes;
+  std::unique_ptr<IColumnDefinition<0>> col0 =
+      std::make_unique<IntegerColumn<0, true, 32>>("col0");
+  EXPECT_EQ(col0->getColumnType(), ColType::Int32);
+
+  std::unique_ptr<IColumnDefinition<0>> col1 =
+      std::make_unique<IntegerColumn<0, true, 64>>("col1");
+  EXPECT_EQ(col1->getColumnType(), ColType::Int64);
+
+  std::unique_ptr<IColumnDefinition<0>> col2 =
+      std::make_unique<IntegerColumn<0, false, 32>>("col2");
+  EXPECT_EQ(col2->getColumnType(), ColType::UInt32);
+
+  std::vector<std::string> names{"bool1", "bool2"};
+  std::unique_ptr<IColumnDefinition<0>> col3 =
+      std::make_unique<PackedBitFieldColumn<0>>("col3", names);
+  EXPECT_EQ(col3->getColumnType(), ColType::PackedBitField);
+
+  std::unique_ptr<IColumnDefinition<0>> col4 = std::make_unique<
+      FixedSizeArrayColumn<0, frontend::MPCTypes<0>::Sec32Int>>(
+      "col4", std::make_unique<IntegerColumn<0, true, 32>>("test"), 4);
+  EXPECT_EQ(col4->getColumnType(), ColType::Int32Vec);
+
+  std::unique_ptr<IColumnDefinition<0>> col5 = std::make_unique<
+      FixedSizeArrayColumn<0, frontend::MPCTypes<0>::Sec64Int>>(
+      "col4", std::make_unique<IntegerColumn<0, true, 64>>("test"), 4);
+  EXPECT_EQ(col5->getColumnType(), ColType::Int64Vec);
+
+  std::unique_ptr<IColumnDefinition<0>> col6 = std::make_unique<
+      FixedSizeArrayColumn<0, frontend::MPCTypes<0>::SecUnsigned32Int>>(
+      "col4", std::make_unique<IntegerColumn<0, false, 32>>("test"), 4);
+  EXPECT_EQ(col6->getColumnType(), ColType::UInt32Vec);
+}
 } // namespace fbpcf::mpc_std_lib::unified_data_process::serialization


### PR DESCRIPTION
Summary:
# Background:

Currently in order to successfully use UDP, you must write some carefully crafted code that will take all the rows of metadata for one side and package it into a collection of bytes. Afterwards the caller will get a `SecString` object back which is a bit representation of all the bytes they passed in, minus the filtered out rows. The user must then extract the corresponding bits for each column into separate MPC Types.  This is a cumbersome process which is error prone, as you must make sure to carefully match up the two steps and any changes can cause a bug.

# This Diff

This diff defines the interface that the caller will use to pass in all their data for serialization / deserialization after UDP.

Step 1. Put all the data into an unordered map of column name to type. Note that the variant type of the data must match the expected type based on the column (i.e. a uint32 column expects `std::vector<uint32_t>`, a int64 vec column expects `std::vector<std::vector<int64_t>>`. Call `serializeDataAsBytesForUDP` to get a vector of vector bytes ready for UDP consumption.
Step 2. Pass this data into the UDP protocol data processor portion. Get back a `SecString` with all the filtered out rows and same structure
Step 3. Call `deserializeUDPOutputIntoMPCTypes`. This will return the same unordered map of column names to the private MPC values that were deserialized from the SecString. The caller is in charge of unboxing the variants to the expected types.

Differential Revision: D43366172

