### PR TITLE
Add Integer Column Definition

### DIFF
--- a/fbpcf/mpc_std_lib/unified_data_process/serialization/IColumnDefinition.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/serialization/IColumnDefinition.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <variant>
+#include "fbpcf/frontend/BitString.h"
+#include "fbpcf/frontend/MPCTypes.h"
+
+namespace fbpcf::mpc_std_lib::unified_data_process::serialization {
+
+template <int schedulerId>
+class IColumnDefinition {
+  using MPCTypes = frontend::MPCTypes<schedulerId, true /* usingBatch */>;
+
+ public:
+  /* Possible return types for deserialization following UDP run */
+  using DeserializeType = std::variant<
+      typename MPCTypes::SecBool,
+      typename MPCTypes::SecUnsigned32Int,
+      typename MPCTypes::Sec32Int,
+      typename MPCTypes::Sec64Int,
+      std::vector<typename MPCTypes::SecBool>,
+      std::vector<typename MPCTypes::SecUnsigned32Int>,
+      std::vector<typename MPCTypes::Sec32Int>,
+      std::vector<typename MPCTypes::Sec64Int>>;
+
+  virtual ~IColumnDefinition() = default;
+
+  virtual std::string getColumnName() const = 0;
+
+  virtual size_t getColumnSizeBytes() const = 0;
+
+  /* Pass in a single value of the column to be serialized, sequentially write
+   * the bytes starting at the beginning of buf */
+  virtual void serializeColumnAsPlaintextBytes(
+      const void* inputData,
+      unsigned char* buf) const = 0;
+
+  /* Given the secret shared output of bytes following the UDP stage,
+   * load the values into the MPC type correponding to this column.
+   * Data starts loading at the offset passed in, and will read the next
+   * getColumnSizeBytes() from each row. Caller is responsible for unpacking
+   * the variant for the column type.
+   */
+  virtual DeserializeType deserializeSharesToMPCType(
+      const std::vector<std::vector<unsigned char>>& serializedSecretShares,
+      size_t offset) const = 0;
+};
+
+} // namespace fbpcf::mpc_std_lib::unified_data_process::serialization

--- a/fbpcf/mpc_std_lib/unified_data_process/serialization/IntegerColumn.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/serialization/IntegerColumn.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "fbpcf/frontend/Int.h"
+#include "fbpcf/mpc_std_lib/unified_data_process/serialization/IColumnDefinition.h"
+
+#include <string>
+namespace fbpcf::mpc_std_lib::unified_data_process::serialization {
+
+template <int schedulerId, bool isSigned, int8_t width>
+class IntegerColumn : public IColumnDefinition<schedulerId> {
+  static_assert(
+      width == 8 || width == 16 || width == 32 || width == 64,
+      "Can only serialize on standard integer types");
+
+  template <
+      typename T8,
+      typename T16,
+      typename T32,
+      typename T64,
+      int8_t intWidth>
+  using typeSelector = typename std::conditional<
+      intWidth <= 16,
+      typename std::conditional<intWidth <= 8, T8, T16>::type,
+      typename std::conditional<intWidth <= 32, T32, T64>::type>::type;
+
+ public:
+  using NativeType = typename std::conditional<
+      isSigned,
+      typeSelector<int8_t, int16_t, int32_t, int64_t, width>,
+      typeSelector<uint8_t, uint16_t, uint32_t, uint64_t, width>>::type;
+
+  using ShareType =
+      typename std::conditional<isSigned, int64_t, uint64_t>::type;
+
+  using MPCNativeType = frontend::Int<isSigned, width, true, schedulerId, true>;
+
+  explicit IntegerColumn(std::string columnName) : columnName_{columnName} {}
+
+  std::string getColumnName() const override {
+    return columnName_;
+  }
+
+  size_t getColumnSizeBytes() const override {
+    return width / 8;
+  }
+
+  void serializeColumnAsPlaintextBytes(
+      const void* inputData,
+      unsigned char* buf) const override {
+    const NativeType value = *((NativeType*)inputData);
+    for (size_t i = 0; i < sizeof(NativeType); ++i) {
+      buf[i] = extractByte(value, i);
+    }
+  }
+
+  typename IColumnDefinition<schedulerId>::DeserializeType
+  deserializeSharesToMPCType(
+      const std::vector<std::vector<unsigned char>>& serializedSecretShares,
+      size_t byteOffset) const override {
+    std::vector<ShareType> reconstructedShares(serializedSecretShares.size());
+
+    for (int i = 0; i < serializedSecretShares.size(); i++) {
+      reconstructedShares[i] = reconstructFromBytes<NativeType>(
+          serializedSecretShares[i].data() + byteOffset);
+    }
+
+    typename IColumnDefinition<schedulerId>::DeserializeType rst =
+        MPCNativeType(
+            typename MPCNativeType::ExtractedInt(reconstructedShares));
+
+    return typename IColumnDefinition<schedulerId>::DeserializeType(
+        std::move(rst));
+  }
+
+ private:
+  template <typename T>
+  static unsigned char extractByte(T val, size_t byte) {
+    if (byte < 0 || byte >= sizeof(T)) {
+      throw std::invalid_argument("Not enough bytes in type");
+    }
+
+    return (uint8_t)(val >> 8 * byte);
+  }
+
+  template <typename T>
+  static T reconstructFromBytes(const unsigned char* data) {
+    T val = 0;
+    for (size_t i = 0; i < sizeof(T); i++) {
+      val |= ((T) * (data + i)) << (i * 8);
+    }
+    return val;
+  }
+
+  std::string columnName_;
+};
+
+} // namespace fbpcf::mpc_std_lib::unified_data_process::serialization

--- a/fbpcf/mpc_std_lib/unified_data_process/serialization/test/SerializationTest.cpp
+++ b/fbpcf/mpc_std_lib/unified_data_process/serialization/test/SerializationTest.cpp
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include <algorithm>
+#include <functional>
+#include <future>
+#include <limits>
+#include <memory>
+#include <random>
+#include <variant>
+
+#include "fbpcf/engine/communication/test/AgentFactoryCreationHelper.h"
+#include "fbpcf/frontend/MPCTypes.h"
+#include "fbpcf/scheduler/ISchedulerFactory.h"
+#include "fbpcf/scheduler/SchedulerHelper.h"
+#include "fbpcf/test/TestHelper.h"
+
+#include "fbpcf/mpc_std_lib/unified_data_process/serialization/IntegerColumn.h"
+
+namespace fbpcf::mpc_std_lib::unified_data_process::serialization {
+
+template <int schedulerId>
+static std::vector<int32_t> deserializeAndRevealInt32(
+    fbpcf::scheduler::ISchedulerFactory<true>& schedulerFactory,
+    const std::vector<std::vector<unsigned char>>& serializedSecretShares,
+    IColumnDefinition<schedulerId>& serializer) {
+  auto scheduler = schedulerFactory.create();
+
+  fbpcf::scheduler::SchedulerKeeper<schedulerId>::setScheduler(
+      std::move(scheduler));
+
+  typename IColumnDefinition<schedulerId>::DeserializeType mpcValue =
+      serializer.deserializeSharesToMPCType(serializedSecretShares, 0);
+  typename frontend::MPCTypes<schedulerId>::Sec32Int visitedVal =
+      std::get<typename frontend::MPCTypes<schedulerId>::Sec32Int>(mpcValue);
+
+  std::vector<int64_t> rst64 = visitedVal.openToParty(0).getValue();
+  std::vector<int32_t> rst(rst64.size());
+  std::transform(
+      rst64.begin(), rst64.end(), rst.begin(), [](int64_t val) { return val; });
+  return rst;
+}
+
+TEST(SerializationTest, IntegerColumnTest) {
+  auto factories = fbpcf::engine::communication::getInMemoryAgentFactory(2);
+
+  auto schedulerFactory0 =
+      fbpcf::scheduler::NetworkPlaintextSchedulerFactory<true>(
+          0, *factories[0]);
+
+  auto schedulerFactory1 =
+      fbpcf::scheduler::NetworkPlaintextSchedulerFactory<true>(
+          1, *factories[1]);
+
+  const size_t batchSize = 100;
+
+  std::random_device rd;
+  std::mt19937_64 e(rd());
+  std::uniform_int_distribution<int32_t> dist(
+      std::numeric_limits<int32_t>().min(),
+      std::numeric_limits<int32_t>().max());
+
+  IntegerColumn<0, true, 32> serializer0("testColumnName");
+  IntegerColumn<1, true, 32> serializer1("testColumnName");
+  EXPECT_EQ(serializer0.getColumnSizeBytes(), 4);
+
+  std::vector<std::vector<unsigned char>> bufs(
+      batchSize, std::vector<unsigned char>(serializer0.getColumnSizeBytes()));
+
+  std::vector<int32_t> vals(batchSize);
+
+  for (int i = 0; i < 100; i++) {
+    int32_t v = dist(e);
+
+    vals[i] = v;
+    serializer0.serializeColumnAsPlaintextBytes(&v, bufs[i].data());
+
+    EXPECT_EQ(bufs[i][0], v & 255);
+    EXPECT_EQ(bufs[i][1], (v >> 8) & 255);
+    EXPECT_EQ(bufs[i][2], (v >> 16) & 255);
+    EXPECT_EQ(bufs[i][3], (v >> 24) & 255);
+  }
+
+  auto future0 = std::async([&schedulerFactory0, &bufs, &serializer0]() {
+    return deserializeAndRevealInt32<0>(schedulerFactory0, bufs, serializer0);
+  });
+
+  auto future1 = std::async([&schedulerFactory1, &serializer1]() {
+    return deserializeAndRevealInt32<1>(
+        schedulerFactory1,
+        std::vector<std::vector<uint8_t>>(
+            batchSize, std::vector<uint8_t>(serializer1.getColumnSizeBytes())),
+        serializer1);
+  });
+
+  auto rst = future0.get();
+  future1.get();
+  testVectorEq(vals, rst);
+}
+
+} // namespace fbpcf::mpc_std_lib::unified_data_process::serialization


### PR DESCRIPTION
Summary:
# Background:

Currently in order to successfully use UDP, you must write some carefully crafted code that will take all the rows of metadata for one side and package it into a collection of bytes. Afterwards the caller will get a `SecString` object back which is a bit representation of all the bytes they passed in, minus the filtered out rows. The user must then extract the corresponding bits for each column into separate MPC Types.  This is a cumbersome process which is error prone, as you must make sure to carefully match up the two steps and any changes can cause a bug.

# This Diff

Adds support for the first column type in the serializer. This is an IntegerColumn.

Differential Revision: D43366177

