### PR TITLE
Add column type enum for dynamic mapping

### DIFF
--- a/fbpcf/mpc_std_lib/unified_data_process/serialization/FixedSizeArrayColumn.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/serialization/FixedSizeArrayColumn.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <memory>
+#include <stdexcept>
 #include "fbpcf/mpc_std_lib/unified_data_process/serialization/IColumnDefinition.h"
 
 namespace fbpcf::mpc_std_lib::unified_data_process::serialization {
@@ -29,6 +30,23 @@ class FixedSizeArrayColumn : public IColumnDefinition<schedulerId> {
 
   size_t getColumnSizeBytes() const override {
     return length_ * innerType_->getColumnSizeBytes();
+  }
+
+  typename IColumnDefinition<schedulerId>::SupportedColumnTypes getColumnType()
+      const override {
+    auto innerColumnType = innerType_->getColumnType();
+
+    switch (innerColumnType) {
+      case IColumnDefinition<schedulerId>::SupportedColumnTypes::UInt32:
+        return IColumnDefinition<schedulerId>::SupportedColumnTypes::UInt32Vec;
+      case IColumnDefinition<schedulerId>::SupportedColumnTypes::Int32:
+        return IColumnDefinition<schedulerId>::SupportedColumnTypes::Int32Vec;
+      case IColumnDefinition<schedulerId>::SupportedColumnTypes::Int64:
+        return IColumnDefinition<schedulerId>::SupportedColumnTypes::Int64Vec;
+      default:
+        throw std::runtime_error(
+            "This code should be unreachable. Tried to get invalid Array Column");
+    }
   }
 
   size_t getLength() const {

--- a/fbpcf/mpc_std_lib/unified_data_process/serialization/IColumnDefinition.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/serialization/IColumnDefinition.h
@@ -21,6 +21,17 @@ class IColumnDefinition {
   using MPCTypes = frontend::MPCTypes<schedulerId, true /* usingBatch */>;
 
  public:
+  enum SupportedColumnTypes {
+    Bit = 0,
+    PackedBitField = 1,
+    UInt32 = 2,
+    Int32 = 3,
+    Int64 = 4,
+    UInt32Vec = 5,
+    Int32Vec = 6,
+    Int64Vec = 7,
+  };
+
   /* Possible return types for deserialization following UDP run */
   using DeserializeType = std::variant<
       typename MPCTypes::SecBool,
@@ -37,6 +48,8 @@ class IColumnDefinition {
   virtual std::string getColumnName() const = 0;
 
   virtual size_t getColumnSizeBytes() const = 0;
+
+  virtual SupportedColumnTypes getColumnType() const = 0;
 
   /* Pass in a single value of the column to be serialized, sequentially write
    * the bytes starting at the beginning of buf */

--- a/fbpcf/mpc_std_lib/unified_data_process/serialization/PackedBitFieldColumn.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/serialization/PackedBitFieldColumn.h
@@ -42,6 +42,11 @@ class PackedBitFieldColumn : public IColumnDefinition<schedulerId> {
     return 1;
   }
 
+  typename IColumnDefinition<schedulerId>::SupportedColumnTypes getColumnType()
+      const override {
+    return IColumnDefinition<schedulerId>::SupportedColumnTypes::PackedBitField;
+  }
+
   // input to this function is a pointer to a bool vector since memory layout
   // is not guaranteed by compiler (i.e. can not get a bool* from a
   // vector<bool>.data())

--- a/fbpcf/mpc_std_lib/unified_data_process/serialization/test/SerializationTest.cpp
+++ b/fbpcf/mpc_std_lib/unified_data_process/serialization/test/SerializationTest.cpp
@@ -299,4 +299,39 @@ TEST(SerializationTest, PackedBitFieldColumnTest) {
     testVectorEq(vals[j], rst[j]);
   }
 }
+
+TEST(erializationTest, ColumnTypeTest) {
+  using ColType = IColumnDefinition<0>::SupportedColumnTypes;
+  std::unique_ptr<IColumnDefinition<0>> col0 =
+      std::make_unique<IntegerColumn<0, true, 32>>("col0");
+  EXPECT_EQ(col0->getColumnType(), ColType::Int32);
+
+  std::unique_ptr<IColumnDefinition<0>> col1 =
+      std::make_unique<IntegerColumn<0, true, 64>>("col1");
+  EXPECT_EQ(col1->getColumnType(), ColType::Int64);
+
+  std::unique_ptr<IColumnDefinition<0>> col2 =
+      std::make_unique<IntegerColumn<0, false, 32>>("col2");
+  EXPECT_EQ(col2->getColumnType(), ColType::UInt32);
+
+  std::vector<std::string> names{"bool1", "bool2"};
+  std::unique_ptr<IColumnDefinition<0>> col3 =
+      std::make_unique<PackedBitFieldColumn<0>>("col3", names);
+  EXPECT_EQ(col3->getColumnType(), ColType::PackedBitField);
+
+  std::unique_ptr<IColumnDefinition<0>> col4 = std::make_unique<
+      FixedSizeArrayColumn<0, frontend::MPCTypes<0>::Sec32Int>>(
+      "col4", std::make_unique<IntegerColumn<0, true, 32>>("test"), 4);
+  EXPECT_EQ(col4->getColumnType(), ColType::Int32Vec);
+
+  std::unique_ptr<IColumnDefinition<0>> col5 = std::make_unique<
+      FixedSizeArrayColumn<0, frontend::MPCTypes<0>::Sec64Int>>(
+      "col4", std::make_unique<IntegerColumn<0, true, 64>>("test"), 4);
+  EXPECT_EQ(col5->getColumnType(), ColType::Int64Vec);
+
+  std::unique_ptr<IColumnDefinition<0>> col6 = std::make_unique<
+      FixedSizeArrayColumn<0, frontend::MPCTypes<0>::SecUnsigned32Int>>(
+      "col4", std::make_unique<IntegerColumn<0, false, 32>>("test"), 4);
+  EXPECT_EQ(col6->getColumnType(), ColType::UInt32Vec);
+}
 } // namespace fbpcf::mpc_std_lib::unified_data_process::serialization


### PR DESCRIPTION
Summary:
# Background:

Currently in order to successfully use UDP, you must write some carefully crafted code that will take all the rows of metadata for one side and package it into a collection of bytes. Afterwards the caller will get a `SecString` object back which is a bit representation of all the bytes they passed in, minus the filtered out rows. The user must then extract the corresponding bits for each column into separate MPC Types.  This is a cumbersome process which is error prone, as you must make sure to carefully match up the two steps and any changes can cause a bug.

# This Diff

In order to be able to dynamically create column types at runtime, we need some simple global mapping to all the valid template types we want to support. The idea is that each class will have a unique enum value that we can then use to instantiate it at runtime through a command line structure mapping column names to their types.

Differential Revision: D43341286

