### PR TITLE
Add column for serializing a packed bit field.

### DIFF
--- a/fbpcf/mpc_std_lib/unified_data_process/serialization/FixedSizeArrayColumn.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/serialization/FixedSizeArrayColumn.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <memory>
+#include "fbpcf/mpc_std_lib/unified_data_process/serialization/IColumnDefinition.h"
+
+namespace fbpcf::mpc_std_lib::unified_data_process::serialization {
+
+template <int schedulerId, typename InnerType>
+class FixedSizeArrayColumn : public IColumnDefinition<schedulerId> {
+ public:
+  FixedSizeArrayColumn(
+      std::string columnName,
+      std::unique_ptr<IColumnDefinition<schedulerId>> innerType,
+      size_t length)
+      : columnName_{columnName},
+        innerType_{std::move(innerType)},
+        length_{length} {}
+
+  std::string getColumnName() const override {
+    return columnName_;
+  }
+
+  size_t getColumnSizeBytes() const override {
+    return length_ * innerType_->getColumnSizeBytes();
+  }
+
+  size_t getLength() const {
+    return length_;
+  }
+
+  void serializeColumnAsPlaintextBytes(
+      const void* inputData,
+      unsigned char* buf) const override {
+    size_t innerTypeSize = innerType_->getColumnSizeBytes();
+    for (int i = 0; i < length_; i++) {
+      size_t offset = innerTypeSize * i;
+      innerType_->serializeColumnAsPlaintextBytes(
+          (const void*)(((const unsigned char*)inputData) + offset),
+          buf + offset);
+    }
+  }
+
+  typename IColumnDefinition<schedulerId>::DeserializeType
+  deserializeSharesToMPCType(
+      const std::vector<std::vector<unsigned char>>& serializedSecretShares,
+      size_t byteOffset) const override {
+    auto rst = std::vector<InnerType>(0);
+
+    size_t innerTypeSize = innerType_->getColumnSizeBytes();
+
+    for (int i = 0; i < length_; i++) {
+      size_t offset = byteOffset + innerTypeSize * i;
+      typename IColumnDefinition<schedulerId>::DeserializeType innerVal =
+          innerType_->deserializeSharesToMPCType(
+              serializedSecretShares, offset);
+      rst.push_back(std::get<InnerType>(innerVal));
+    }
+
+    return rst;
+  }
+
+ private:
+  std::string columnName_;
+  std::unique_ptr<IColumnDefinition<schedulerId>> innerType_;
+  size_t length_;
+};
+
+} // namespace fbpcf::mpc_std_lib::unified_data_process::serialization

--- a/fbpcf/mpc_std_lib/unified_data_process/serialization/IColumnDefinition.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/serialization/IColumnDefinition.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <variant>
+#include "fbpcf/frontend/BitString.h"
+#include "fbpcf/frontend/MPCTypes.h"
+
+namespace fbpcf::mpc_std_lib::unified_data_process::serialization {
+
+template <int schedulerId>
+class IColumnDefinition {
+  using MPCTypes = frontend::MPCTypes<schedulerId, true /* usingBatch */>;
+
+ public:
+  /* Possible return types for deserialization following UDP run */
+  using DeserializeType = std::variant<
+      typename MPCTypes::SecBool,
+      typename MPCTypes::SecUnsigned32Int,
+      typename MPCTypes::Sec32Int,
+      typename MPCTypes::Sec64Int,
+      std::vector<typename MPCTypes::SecBool>,
+      std::vector<typename MPCTypes::SecUnsigned32Int>,
+      std::vector<typename MPCTypes::Sec32Int>,
+      std::vector<typename MPCTypes::Sec64Int>>;
+
+  virtual ~IColumnDefinition() = default;
+
+  virtual std::string getColumnName() const = 0;
+
+  virtual size_t getColumnSizeBytes() const = 0;
+
+  /* Pass in a single value of the column to be serialized, sequentially write
+   * the bytes starting at the beginning of buf */
+  virtual void serializeColumnAsPlaintextBytes(
+      const void* inputData,
+      unsigned char* buf) const = 0;
+
+  /* Given the secret shared output of bytes following the UDP stage,
+   * load the values into the MPC type correponding to this column.
+   * Data starts loading at the offset passed in, and will read the next
+   * getColumnSizeBytes() from each row. Caller is responsible for unpacking
+   * the variant for the column type.
+   */
+  virtual DeserializeType deserializeSharesToMPCType(
+      const std::vector<std::vector<unsigned char>>& serializedSecretShares,
+      size_t offset) const = 0;
+};
+
+} // namespace fbpcf::mpc_std_lib::unified_data_process::serialization

--- a/fbpcf/mpc_std_lib/unified_data_process/serialization/IntegerColumn.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/serialization/IntegerColumn.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "fbpcf/frontend/Int.h"
+#include "fbpcf/mpc_std_lib/unified_data_process/serialization/IColumnDefinition.h"
+
+#include <string>
+namespace fbpcf::mpc_std_lib::unified_data_process::serialization {
+
+template <int schedulerId, bool isSigned, int8_t width>
+class IntegerColumn : public IColumnDefinition<schedulerId> {
+  static_assert(
+      width == 8 || width == 16 || width == 32 || width == 64,
+      "Can only serialize on standard integer types");
+
+  template <
+      typename T8,
+      typename T16,
+      typename T32,
+      typename T64,
+      int8_t intWidth>
+  using typeSelector = typename std::conditional<
+      intWidth <= 16,
+      typename std::conditional<intWidth <= 8, T8, T16>::type,
+      typename std::conditional<intWidth <= 32, T32, T64>::type>::type;
+
+ public:
+  using NativeType = typename std::conditional<
+      isSigned,
+      typeSelector<int8_t, int16_t, int32_t, int64_t, width>,
+      typeSelector<uint8_t, uint16_t, uint32_t, uint64_t, width>>::type;
+
+  using ShareType =
+      typename std::conditional<isSigned, int64_t, uint64_t>::type;
+
+  using MPCNativeType = frontend::Int<isSigned, width, true, schedulerId, true>;
+
+  explicit IntegerColumn(std::string columnName) : columnName_{columnName} {}
+
+  std::string getColumnName() const override {
+    return columnName_;
+  }
+
+  size_t getColumnSizeBytes() const override {
+    return width / 8;
+  }
+
+  void serializeColumnAsPlaintextBytes(
+      const void* inputData,
+      unsigned char* buf) const override {
+    const NativeType value = *((NativeType*)inputData);
+    for (size_t i = 0; i < sizeof(NativeType); ++i) {
+      buf[i] = extractByte(value, i);
+    }
+  }
+
+  typename IColumnDefinition<schedulerId>::DeserializeType
+  deserializeSharesToMPCType(
+      const std::vector<std::vector<unsigned char>>& serializedSecretShares,
+      size_t byteOffset) const override {
+    std::vector<ShareType> reconstructedShares(serializedSecretShares.size());
+
+    for (int i = 0; i < serializedSecretShares.size(); i++) {
+      reconstructedShares[i] = reconstructFromBytes<NativeType>(
+          serializedSecretShares[i].data() + byteOffset);
+    }
+
+    typename IColumnDefinition<schedulerId>::DeserializeType rst =
+        MPCNativeType(
+            typename MPCNativeType::ExtractedInt(reconstructedShares));
+
+    return typename IColumnDefinition<schedulerId>::DeserializeType(
+        std::move(rst));
+  }
+
+ private:
+  template <typename T>
+  static unsigned char extractByte(T val, size_t byte) {
+    if (byte < 0 || byte >= sizeof(T)) {
+      throw std::invalid_argument("Not enough bytes in type");
+    }
+
+    return (uint8_t)(val >> 8 * byte);
+  }
+
+  template <typename T>
+  static T reconstructFromBytes(const unsigned char* data) {
+    T val = 0;
+    for (size_t i = 0; i < sizeof(T); i++) {
+      val |= ((T) * (data + i)) << (i * 8);
+    }
+    return val;
+  }
+
+  std::string columnName_;
+};
+
+} // namespace fbpcf::mpc_std_lib::unified_data_process::serialization

--- a/fbpcf/mpc_std_lib/unified_data_process/serialization/PackedBitFieldColumn.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/serialization/PackedBitFieldColumn.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "fbpcf/frontend/MPCTypes.h"
+#include "fbpcf/mpc_std_lib/unified_data_process/serialization/IColumnDefinition.h"
+
+#include <string>
+namespace fbpcf::mpc_std_lib::unified_data_process::serialization {
+
+template <int schedulerId>
+class PackedBitFieldColumn : public IColumnDefinition<schedulerId> {
+  using NativeType = std::vector<bool>;
+  using MPCTypes = frontend::MPCTypes<schedulerId, true>;
+
+ public:
+  PackedBitFieldColumn(
+      std::string columnName,
+      std::vector<std::string> subColumnNames)
+      : columnName_{columnName}, subColumnNames_{subColumnNames} {
+    if (subColumnNames.size() > 8) {
+      throw std::runtime_error(
+          "Can only pack 8 bits into a byte. Please create another PackedBitField"
+          " if you would like to store additional boolean values");
+    }
+  }
+
+  std::string getColumnName() const override {
+    return columnName_;
+  }
+
+  const std::vector<std::string>& getSubColumnNames() const {
+    return subColumnNames_;
+  }
+
+  size_t getColumnSizeBytes() const override {
+    return 1;
+  }
+
+  // input to this function is a pointer to a bool vector since memory layout
+  // is not guaranteed by compiler (i.e. can not get a bool* from a
+  // vector<bool>.data())
+  void serializeColumnAsPlaintextBytes(
+      const void* inputData,
+      unsigned char* buf) const override {
+    const NativeType value = *((NativeType*)inputData);
+    if (value.size() != subColumnNames_.size()) {
+      throw std::runtime_error(
+          "Size mismatch between expected number of packed bits and actual data");
+    }
+
+    unsigned char toWrite = 0;
+    for (size_t i = 0; i < value.size(); ++i) {
+      toWrite |= (value[i] << i);
+    }
+    buf[0] = toWrite;
+  }
+
+  typename IColumnDefinition<schedulerId>::DeserializeType
+  deserializeSharesToMPCType(
+      const std::vector<std::vector<unsigned char>>& serializedSecretShares,
+      size_t offset) const override {
+    std::vector<std::vector<bool>> reconstructedShares(
+        subColumnNames_.size(),
+        std::vector<bool>(serializedSecretShares.size()));
+
+    for (int i = 0; i < serializedSecretShares.size(); i++) {
+      unsigned char packedValues = serializedSecretShares[i][offset];
+      for (int j = 0; j < subColumnNames_.size(); j++) {
+        reconstructedShares[j][i] = (packedValues >> j) & 1;
+      }
+    }
+
+    std::vector<typename MPCTypes::SecBool> rst(reconstructedShares.size());
+    for (int i = 0; i < reconstructedShares.size(); i++) {
+      rst[i] = typename MPCTypes::SecBool(
+          typename MPCTypes::SecBool::ExtractedBit(reconstructedShares[i]));
+    }
+
+    return rst;
+  }
+
+ private:
+  std::string columnName_;
+  std::vector<std::string> subColumnNames_;
+};
+
+} // namespace fbpcf::mpc_std_lib::unified_data_process::serialization

--- a/fbpcf/mpc_std_lib/unified_data_process/serialization/test/SerializationTest.cpp
+++ b/fbpcf/mpc_std_lib/unified_data_process/serialization/test/SerializationTest.cpp
@@ -46,6 +46,35 @@ static std::vector<int32_t> deserializeAndRevealInt32(
   return rst;
 }
 
+template <int schedulerId>
+static std::vector<std::vector<int32_t>> deserializeAndRevealInt32Vector(
+    fbpcf::scheduler::ISchedulerFactory<true>& schedulerFactory,
+    const std::vector<std::vector<unsigned char>>& serializedSecretShares,
+    IColumnDefinition<schedulerId>& serializer) {
+  auto scheduler = schedulerFactory.create();
+
+  fbpcf::scheduler::SchedulerKeeper<schedulerId>::setScheduler(
+      std::move(scheduler));
+
+  typename IColumnDefinition<schedulerId>::DeserializeType mpcValue =
+      serializer.deserializeSharesToMPCType(serializedSecretShares, 0);
+  std::vector<typename frontend::MPCTypes<schedulerId>::Sec32Int> visitedVal =
+      std::get<std::vector<typename frontend::MPCTypes<schedulerId>::Sec32Int>>(
+          mpcValue);
+
+  std::vector<std::vector<int32_t>> rst(
+      visitedVal.size(), std::vector<int32_t>(visitedVal[0].getBatchSize()));
+
+  for (int i = 0; i < visitedVal.size(); i++) {
+    std::vector<int64_t> rst64 = visitedVal[i].openToParty(0).getValue();
+    std::transform(rst64.begin(), rst64.end(), rst[i].begin(), [](int64_t val) {
+      return val;
+    });
+  }
+
+  return rst;
+}
+
 TEST(SerializationTest, IntegerColumnTest) {
   auto factories = fbpcf::engine::communication::getInMemoryAgentFactory(2);
 
@@ -101,6 +130,81 @@ TEST(SerializationTest, IntegerColumnTest) {
   auto rst = future0.get();
   future1.get();
   testVectorEq(vals, rst);
+}
+
+TEST(SerializationTest, ArrayColumnTest) {
+  auto factories = fbpcf::engine::communication::getInMemoryAgentFactory(2);
+
+  auto schedulerFactory0 =
+      fbpcf::scheduler::NetworkPlaintextSchedulerFactory<true>(
+          0, *factories[0]);
+
+  auto schedulerFactory1 =
+      fbpcf::scheduler::NetworkPlaintextSchedulerFactory<true>(
+          1, *factories[1]);
+
+  const size_t batchSize = 100;
+  const size_t paddingSize = 4;
+
+  std::random_device rd;
+  std::mt19937_64 e(rd());
+  std::uniform_int_distribution<int32_t> dist(
+      std::numeric_limits<int32_t>().min(),
+      std::numeric_limits<int32_t>().max());
+
+  FixedSizeArrayColumn<0, frontend::MPCTypes<0>::Sec32Int> serializer0(
+      "testColumnName",
+      std::make_unique<IntegerColumn<0, true, 32>>("testColumnName"),
+      paddingSize);
+  FixedSizeArrayColumn<1, frontend::MPCTypes<1>::Sec32Int> serializer1(
+      "testColumnName",
+      std::make_unique<IntegerColumn<1, true, 32>>("testColumnName"),
+      paddingSize);
+  EXPECT_EQ(serializer0.getColumnSizeBytes(), paddingSize * 4);
+
+  std::vector<std::vector<uint8_t>> bufs(
+      batchSize, std::vector<uint8_t>(serializer0.getColumnSizeBytes()));
+
+  std::vector<std::vector<int32_t>> vals(
+      paddingSize, std::vector<int32_t>(batchSize));
+
+  for (int i = 0; i < batchSize; i++) {
+    std::vector<int32_t> val(paddingSize);
+    for (int j = 0; j < paddingSize; j++) {
+      val[j] = dist(e);
+      vals[j][i] = val[j];
+    }
+
+    serializer0.serializeColumnAsPlaintextBytes(val.data(), bufs[i].data());
+
+    for (int j = 0; j < paddingSize; j++) {
+      EXPECT_EQ(bufs[i][0 + j * sizeof(int32_t)], val[j] & 255);
+      EXPECT_EQ(bufs[i][1 + j * sizeof(int32_t)], (val[j] >> 8) & 255);
+      EXPECT_EQ(bufs[i][2 + j * sizeof(int32_t)], (val[j] >> 16) & 255);
+      EXPECT_EQ(bufs[i][3 + j * sizeof(int32_t)], (val[j] >> 24) & 255);
+    }
+  }
+
+  auto future0 = std::async([&schedulerFactory0, &bufs, &serializer0]() {
+    return deserializeAndRevealInt32Vector<0>(
+        schedulerFactory0, bufs, serializer0);
+  });
+
+  auto future1 = std::async([&schedulerFactory1, &serializer1]() {
+    return deserializeAndRevealInt32Vector<1>(
+        schedulerFactory1,
+        std::vector<std::vector<uint8_t>>(
+            batchSize, std::vector<uint8_t>(serializer1.getColumnSizeBytes())),
+        serializer1);
+  });
+
+  auto rst = future0.get();
+  future1.get();
+
+  EXPECT_EQ(rst.size(), paddingSize);
+  for (int j = 0; j < paddingSize; j++) {
+    testVectorEq(vals[j], rst[j]);
+  }
 }
 
 } // namespace fbpcf::mpc_std_lib::unified_data_process::serialization

--- a/fbpcf/mpc_std_lib/unified_data_process/serialization/test/SerializationTest.cpp
+++ b/fbpcf/mpc_std_lib/unified_data_process/serialization/test/SerializationTest.cpp
@@ -20,7 +20,9 @@
 #include "fbpcf/scheduler/SchedulerHelper.h"
 #include "fbpcf/test/TestHelper.h"
 
+#include "fbpcf/mpc_std_lib/unified_data_process/serialization/FixedSizeArrayColumn.h"
 #include "fbpcf/mpc_std_lib/unified_data_process/serialization/IntegerColumn.h"
+#include "fbpcf/mpc_std_lib/unified_data_process/serialization/PackedBitFieldColumn.h"
 
 namespace fbpcf::mpc_std_lib::unified_data_process::serialization {
 
@@ -70,6 +72,32 @@ static std::vector<std::vector<int32_t>> deserializeAndRevealInt32Vector(
     std::transform(rst64.begin(), rst64.end(), rst[i].begin(), [](int64_t val) {
       return val;
     });
+  }
+
+  return rst;
+}
+
+template <int schedulerId>
+static std::vector<std::vector<bool>> deserializeAndRevealPackedBits(
+    fbpcf::scheduler::ISchedulerFactory<true>& schedulerFactory,
+    const std::vector<std::vector<unsigned char>>& serializedSecretShares,
+    IColumnDefinition<schedulerId>& serializer) {
+  auto scheduler = schedulerFactory.create();
+
+  fbpcf::scheduler::SchedulerKeeper<schedulerId>::setScheduler(
+      std::move(scheduler));
+
+  typename IColumnDefinition<schedulerId>::DeserializeType mpcValue =
+      serializer.deserializeSharesToMPCType(serializedSecretShares, 0);
+  std::vector<typename frontend::MPCTypes<schedulerId>::SecBool> visitedVal =
+      std::get<std::vector<typename frontend::MPCTypes<schedulerId>::SecBool>>(
+          mpcValue);
+
+  std::vector<std::vector<bool>> rst(
+      visitedVal.size(), std::vector<bool>(visitedVal[0].getBatchSize()));
+
+  for (int i = 0; i < visitedVal.size(); i++) {
+    rst[i] = visitedVal[i].openToParty(0).getValue();
   }
 
   return rst;
@@ -207,4 +235,68 @@ TEST(SerializationTest, ArrayColumnTest) {
   }
 }
 
+TEST(SerializationTest, PackedBitFieldColumnTest) {
+  auto factories = fbpcf::engine::communication::getInMemoryAgentFactory(2);
+
+  auto schedulerFactory0 =
+      fbpcf::scheduler::NetworkPlaintextSchedulerFactory<true>(
+          0, *factories[0]);
+
+  auto schedulerFactory1 =
+      fbpcf::scheduler::NetworkPlaintextSchedulerFactory<true>(
+          1, *factories[1]);
+
+  const size_t batchSize = 100;
+  const size_t numBits = 7;
+
+  std::random_device rd;
+  std::mt19937_64 e(rd());
+  std::uniform_int_distribution<> dist(0, 1);
+
+  PackedBitFieldColumn<0> serializer0(
+      "testColumnName", std::vector<std::string>(7, "testColumnName"));
+  PackedBitFieldColumn<1> serializer1(
+      "testColumnName", std::vector<std::string>(7, "testColumnName"));
+  EXPECT_EQ(serializer0.getColumnSizeBytes(), 1);
+
+  std::vector<std::vector<uint8_t>> bufs(
+      batchSize, std::vector<uint8_t>(serializer0.getColumnSizeBytes()));
+
+  std::vector<std::vector<bool>> vals(numBits, std::vector<bool>(batchSize));
+
+  for (int i = 0; i < batchSize; i++) {
+    std::vector<bool> val(numBits);
+    for (int j = 0; j < numBits; j++) {
+      val[j] = dist(e);
+      vals[j][i] = val[j];
+    }
+
+    serializer0.serializeColumnAsPlaintextBytes(&val, bufs[i].data());
+
+    for (int j = 0; j < numBits; j++) {
+      EXPECT_EQ((bufs[i][0] >> j) & 1, val[j]);
+    }
+  }
+
+  auto future0 = std::async([&schedulerFactory0, &bufs, &serializer0]() {
+    return deserializeAndRevealPackedBits<0>(
+        schedulerFactory0, bufs, serializer0);
+  });
+
+  auto future1 = std::async([&schedulerFactory1, &serializer1]() {
+    return deserializeAndRevealPackedBits<1>(
+        schedulerFactory1,
+        std::vector<std::vector<uint8_t>>(
+            batchSize, std::vector<uint8_t>(serializer1.getColumnSizeBytes())),
+        serializer1);
+  });
+
+  auto rst = future0.get();
+  future1.get();
+
+  EXPECT_EQ(rst.size(), numBits);
+  for (int j = 0; j < numBits; j++) {
+    testVectorEq(vals[j], rst[j]);
+  }
+}
 } // namespace fbpcf::mpc_std_lib::unified_data_process::serialization

--- a/fbpcf/mpc_std_lib/unified_data_process/serialization/test/SerializationTest.cpp
+++ b/fbpcf/mpc_std_lib/unified_data_process/serialization/test/SerializationTest.cpp
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include <algorithm>
+#include <functional>
+#include <future>
+#include <limits>
+#include <memory>
+#include <random>
+#include <variant>
+
+#include "fbpcf/engine/communication/test/AgentFactoryCreationHelper.h"
+#include "fbpcf/frontend/MPCTypes.h"
+#include "fbpcf/scheduler/ISchedulerFactory.h"
+#include "fbpcf/scheduler/SchedulerHelper.h"
+#include "fbpcf/test/TestHelper.h"
+
+#include "fbpcf/mpc_std_lib/unified_data_process/serialization/IntegerColumn.h"
+
+namespace fbpcf::mpc_std_lib::unified_data_process::serialization {
+
+template <int schedulerId>
+static std::vector<int32_t> deserializeAndRevealInt32(
+    fbpcf::scheduler::ISchedulerFactory<true>& schedulerFactory,
+    const std::vector<std::vector<unsigned char>>& serializedSecretShares,
+    IColumnDefinition<schedulerId>& serializer) {
+  auto scheduler = schedulerFactory.create();
+
+  fbpcf::scheduler::SchedulerKeeper<schedulerId>::setScheduler(
+      std::move(scheduler));
+
+  typename IColumnDefinition<schedulerId>::DeserializeType mpcValue =
+      serializer.deserializeSharesToMPCType(serializedSecretShares, 0);
+  typename frontend::MPCTypes<schedulerId>::Sec32Int visitedVal =
+      std::get<typename frontend::MPCTypes<schedulerId>::Sec32Int>(mpcValue);
+
+  std::vector<int64_t> rst64 = visitedVal.openToParty(0).getValue();
+  std::vector<int32_t> rst(rst64.size());
+  std::transform(
+      rst64.begin(), rst64.end(), rst.begin(), [](int64_t val) { return val; });
+  return rst;
+}
+
+TEST(SerializationTest, IntegerColumnTest) {
+  auto factories = fbpcf::engine::communication::getInMemoryAgentFactory(2);
+
+  auto schedulerFactory0 =
+      fbpcf::scheduler::NetworkPlaintextSchedulerFactory<true>(
+          0, *factories[0]);
+
+  auto schedulerFactory1 =
+      fbpcf::scheduler::NetworkPlaintextSchedulerFactory<true>(
+          1, *factories[1]);
+
+  const size_t batchSize = 100;
+
+  std::random_device rd;
+  std::mt19937_64 e(rd());
+  std::uniform_int_distribution<int32_t> dist(
+      std::numeric_limits<int32_t>().min(),
+      std::numeric_limits<int32_t>().max());
+
+  IntegerColumn<0, true, 32> serializer0("testColumnName");
+  IntegerColumn<1, true, 32> serializer1("testColumnName");
+  EXPECT_EQ(serializer0.getColumnSizeBytes(), 4);
+
+  std::vector<std::vector<unsigned char>> bufs(
+      batchSize, std::vector<unsigned char>(serializer0.getColumnSizeBytes()));
+
+  std::vector<int32_t> vals(batchSize);
+
+  for (int i = 0; i < 100; i++) {
+    int32_t v = dist(e);
+
+    vals[i] = v;
+    serializer0.serializeColumnAsPlaintextBytes(&v, bufs[i].data());
+
+    EXPECT_EQ(bufs[i][0], v & 255);
+    EXPECT_EQ(bufs[i][1], (v >> 8) & 255);
+    EXPECT_EQ(bufs[i][2], (v >> 16) & 255);
+    EXPECT_EQ(bufs[i][3], (v >> 24) & 255);
+  }
+
+  auto future0 = std::async([&schedulerFactory0, &bufs, &serializer0]() {
+    return deserializeAndRevealInt32<0>(schedulerFactory0, bufs, serializer0);
+  });
+
+  auto future1 = std::async([&schedulerFactory1, &serializer1]() {
+    return deserializeAndRevealInt32<1>(
+        schedulerFactory1,
+        std::vector<std::vector<uint8_t>>(
+            batchSize, std::vector<uint8_t>(serializer1.getColumnSizeBytes())),
+        serializer1);
+  });
+
+  auto rst = future0.get();
+  future1.get();
+  testVectorEq(vals, rst);
+}
+
+} // namespace fbpcf::mpc_std_lib::unified_data_process::serialization


### PR DESCRIPTION
Summary:
# Background:

Currently in order to successfully use UDP, you must write some carefully crafted code that will take all the rows of metadata for one side and package it into a collection of bytes. Afterwards the caller will get a `SecString` object back which is a bit representation of all the bytes they passed in, minus the filtered out rows. The user must then extract the corresponding bits for each column into separate MPC Types.  This is a cumbersome process which is error prone, as you must make sure to carefully match up the two steps and any changes can cause a bug.

# This Diff

Adds support for a packed bit field column. The current plan is that the user will not directly interface with this column type, but it is internal to the row structure. It will support up to 8 different boolean values to be packed inside of it. The reason for this is that a bool value takes up a whole byte in memory. This means if we naively store these, each bool will actually take 8 bits in the final row structure. This allows us to fit 8 bool columns into one byte!

Differential Revision: D43289316

