### PR TITLE
Add uint64 support for serialization library

### DIFF
--- a/fbpcf/mpc_std_lib/unified_data_process/serialization/FixedSizeArrayColumn.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/serialization/FixedSizeArrayColumn.h
@@ -9,43 +9,48 @@
 
 #include <memory>
 #include <stdexcept>
+#include <type_traits>
 #include "fbpcf/mpc_std_lib/unified_data_process/serialization/IColumnDefinition.h"
 
+#include "folly/Format.h"
 namespace fbpcf::mpc_std_lib::unified_data_process::serialization {
 
-template <int schedulerId, typename InnerType>
+template <int schedulerId, typename InnerMPCType, typename InnerPlaintextType>
 class FixedSizeArrayColumn : public IColumnDefinition<schedulerId> {
+  static_assert(
+      std::is_same<InnerPlaintextType, uint32_t>::value ||
+          std::is_same<InnerPlaintextType, int32_t>::value ||
+          std::is_same<InnerPlaintextType, int64_t>::value,
+      "Currently only supported types are vec<int32>, vec<uint32_t>, vec<int64>");
+
+  using ShareType = typename std::conditional<
+      std::is_same<InnerPlaintextType, uint32_t>::value,
+      uint64_t,
+      int64_t>::type;
+
  public:
-  FixedSizeArrayColumn(
-      std::string columnName,
-      std::unique_ptr<IColumnDefinition<schedulerId>> innerType,
-      size_t length)
-      : columnName_{columnName},
-        innerType_{std::move(innerType)},
-        length_{length} {}
+  FixedSizeArrayColumn(std::string columnName, size_t length)
+      : columnName_{columnName}, length_{length} {}
 
   std::string getColumnName() const override {
     return columnName_;
   }
 
   size_t getColumnSizeBytes() const override {
-    return length_ * innerType_->getColumnSizeBytes();
+    return length_ * sizeof(InnerPlaintextType);
   }
 
   typename IColumnDefinition<schedulerId>::SupportedColumnTypes getColumnType()
       const override {
-    auto innerColumnType = innerType_->getColumnType();
-
-    switch (innerColumnType) {
-      case IColumnDefinition<schedulerId>::SupportedColumnTypes::UInt32:
-        return IColumnDefinition<schedulerId>::SupportedColumnTypes::UInt32Vec;
-      case IColumnDefinition<schedulerId>::SupportedColumnTypes::Int32:
-        return IColumnDefinition<schedulerId>::SupportedColumnTypes::Int32Vec;
-      case IColumnDefinition<schedulerId>::SupportedColumnTypes::Int64:
-        return IColumnDefinition<schedulerId>::SupportedColumnTypes::Int64Vec;
-      default:
-        throw std::runtime_error(
-            "This code should be unreachable. Tried to get invalid Array Column");
+    if constexpr (std::is_same<InnerPlaintextType, uint32_t>::value) {
+      return IColumnDefinition<schedulerId>::SupportedColumnTypes::UInt32Vec;
+    } else if constexpr (std::is_same<InnerPlaintextType, int32_t>::value) {
+      return IColumnDefinition<schedulerId>::SupportedColumnTypes::Int32Vec;
+    } else if constexpr (std::is_same<InnerPlaintextType, int64_t>::value) {
+      return IColumnDefinition<schedulerId>::SupportedColumnTypes::Int64Vec;
+    } else {
+      throw std::runtime_error(
+          "This code should be unreachable. Tried to get invalid Array Column");
     }
   }
 
@@ -54,14 +59,39 @@ class FixedSizeArrayColumn : public IColumnDefinition<schedulerId> {
   }
 
   void serializeColumnAsPlaintextBytes(
-      const void* inputData,
-      unsigned char* buf) const override {
-    size_t innerTypeSize = innerType_->getColumnSizeBytes();
-    for (int i = 0; i < length_; i++) {
-      size_t offset = innerTypeSize * i;
-      innerType_->serializeColumnAsPlaintextBytes(
-          (const void*)(((const unsigned char*)inputData) + offset),
-          buf + offset);
+      const typename IColumnDefinition<schedulerId>::InputColumnDataType&
+          inputData,
+      std::vector<std::vector<unsigned char>>& writeBuffers,
+      size_t byteOffset) const override {
+    const std::vector<std::vector<InnerPlaintextType>>& vectorVals =
+        std::get<std::reference_wrapper<
+            std::vector<std::vector<InnerPlaintextType>>>>(inputData)
+            .get();
+
+    if (vectorVals.size() != writeBuffers.size()) {
+      std::string err = folly::sformat(
+          "Invalid number of values for column {}. Got {} values but number of rows should be {} ",
+          columnName_,
+          vectorVals.size(),
+          writeBuffers.size());
+      throw std::runtime_error(err);
+    }
+
+    for (size_t i = 0; i < writeBuffers.size(); i++) {
+      if (vectorVals[i].size() != length_) {
+        std::string err = folly::sformat(
+            "Invalid number of values in array at index {}. Got {} values but number of rows should be {}",
+            i,
+            vectorVals[i].size(),
+            length_);
+        throw std::runtime_error(err);
+      }
+      for (size_t j = 0; j < length_; j++) {
+        for (size_t k = 0; k < sizeof(InnerPlaintextType); k++) {
+          writeBuffers[i][byteOffset + j * sizeof(InnerPlaintextType) + +k] =
+              extractByte(vectorVals[i][j], k);
+        }
+      }
     }
   }
 
@@ -69,22 +99,43 @@ class FixedSizeArrayColumn : public IColumnDefinition<schedulerId> {
   deserializeSharesToMPCType(
       const std::vector<std::vector<unsigned char>>& serializedSecretShares,
       size_t byteOffset) const override {
-    auto rst = std::vector<InnerType>(0);
-
-    size_t innerTypeSize = innerType_->getColumnSizeBytes();
+    auto rst = std::vector<InnerMPCType>(0);
 
     for (int i = 0; i < length_; i++) {
-      size_t offset = byteOffset + innerTypeSize * i;
-      typename IColumnDefinition<schedulerId>::DeserializeType innerVal =
-          innerType_->deserializeSharesToMPCType(
-              serializedSecretShares, offset);
-      rst.push_back(std::get<InnerType>(innerVal));
+      std::vector<ShareType> reconstructedShares(serializedSecretShares.size());
+
+      for (int j = 0; j < serializedSecretShares.size(); j++) {
+        reconstructedShares[j] = reconstructFromBytes<InnerPlaintextType>(
+            serializedSecretShares[j].data() + byteOffset +
+            sizeof(InnerPlaintextType) * i);
+      }
+
+      rst.push_back(InnerMPCType(
+          typename InnerMPCType::ExtractedInt(reconstructedShares)));
     }
 
     return rst;
   }
 
  private:
+  template <typename T>
+  unsigned char extractByte(T val, size_t byte) const {
+    if (byte < 0 || byte >= sizeof(T)) {
+      throw std::invalid_argument("Not enough bytes in type");
+    }
+
+    return (uint8_t)(val >> 8 * byte);
+  }
+
+  template <typename T>
+  T reconstructFromBytes(const unsigned char* data) const {
+    T val = 0;
+    for (size_t i = 0; i < sizeof(T); i++) {
+      val |= ((T) * (data + i)) << (i * 8);
+    }
+    return val;
+  }
+
   std::string columnName_;
   std::unique_ptr<IColumnDefinition<schedulerId>> innerType_;
   size_t length_;

--- a/fbpcf/mpc_std_lib/unified_data_process/serialization/FixedSizeArrayColumn.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/serialization/FixedSizeArrayColumn.h
@@ -19,12 +19,14 @@ template <int schedulerId, typename InnerMPCType, typename InnerPlaintextType>
 class FixedSizeArrayColumn : public IColumnDefinition<schedulerId> {
   static_assert(
       std::is_same<InnerPlaintextType, uint32_t>::value ||
+          std::is_same<InnerPlaintextType, uint64_t>::value ||
           std::is_same<InnerPlaintextType, int32_t>::value ||
           std::is_same<InnerPlaintextType, int64_t>::value,
       "Currently only supported types are vec<int32>, vec<uint32_t>, vec<int64>");
 
   using ShareType = typename std::conditional<
-      std::is_same<InnerPlaintextType, uint32_t>::value,
+      std::is_same<InnerPlaintextType, uint32_t>::value ||
+          std::is_same<InnerPlaintextType, uint64_t>::value,
       uint64_t,
       int64_t>::type;
 
@@ -44,6 +46,8 @@ class FixedSizeArrayColumn : public IColumnDefinition<schedulerId> {
       const override {
     if constexpr (std::is_same<InnerPlaintextType, uint32_t>::value) {
       return IColumnDefinition<schedulerId>::SupportedColumnTypes::UInt32Vec;
+    } else if constexpr (std::is_same<InnerPlaintextType, uint64_t>::value) {
+      return IColumnDefinition<schedulerId>::SupportedColumnTypes::UInt64Vec;
     } else if constexpr (std::is_same<InnerPlaintextType, int32_t>::value) {
       return IColumnDefinition<schedulerId>::SupportedColumnTypes::Int32Vec;
     } else if constexpr (std::is_same<InnerPlaintextType, int64_t>::value) {

--- a/fbpcf/mpc_std_lib/unified_data_process/serialization/IColumnDefinition.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/serialization/IColumnDefinition.h
@@ -32,6 +32,17 @@ class IColumnDefinition {
     Int64Vec = 7,
   };
 
+  /* Possible input types for this column. Must match the column definition */
+  using InputColumnDataType = std::variant<
+      std::reference_wrapper<std::vector<bool>>,
+      std::reference_wrapper<std::vector<uint32_t>>,
+      std::reference_wrapper<std::vector<int32_t>>,
+      std::reference_wrapper<std::vector<int64_t>>,
+      std::reference_wrapper<std::vector<std::vector<bool>>>,
+      std::reference_wrapper<std::vector<std::vector<uint32_t>>>,
+      std::reference_wrapper<std::vector<std::vector<int32_t>>>,
+      std::reference_wrapper<std::vector<std::vector<int64_t>>>>;
+
   /* Possible return types for deserialization following UDP run */
   using DeserializeType = std::variant<
       typename MPCTypes::SecBool,
@@ -51,11 +62,12 @@ class IColumnDefinition {
 
   virtual SupportedColumnTypes getColumnType() const = 0;
 
-  /* Pass in a single value of the column to be serialized, sequentially write
-   * the bytes starting at the beginning of buf */
+  /* Pass in all values of the column to be serialized, sequentially write
+   * the bytes for each row starting at the offset provided. */
   virtual void serializeColumnAsPlaintextBytes(
-      const void* inputData,
-      unsigned char* buf) const = 0;
+      const InputColumnDataType& inputData,
+      std::vector<std::vector<unsigned char>>& writeBuffers,
+      size_t byteOffset) const = 0;
 
   /* Given the secret shared output of bytes following the UDP stage,
    * load the values into the MPC type correponding to this column.

--- a/fbpcf/mpc_std_lib/unified_data_process/serialization/IColumnDefinition.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/serialization/IColumnDefinition.h
@@ -25,21 +25,26 @@ class IColumnDefinition {
     Bit = 0,
     PackedBitField = 1,
     UInt32 = 2,
-    Int32 = 3,
-    Int64 = 4,
-    UInt32Vec = 5,
-    Int32Vec = 6,
-    Int64Vec = 7,
+    UInt64 = 3,
+    Int32 = 4,
+    Int64 = 5,
+    UInt32Vec = 6,
+    UInt64Vec = 7,
+    Int32Vec = 8,
+    Int64Vec = 9,
+
   };
 
   /* Possible input types for this column. Must match the column definition */
   using InputColumnDataType = std::variant<
       std::reference_wrapper<std::vector<bool>>,
       std::reference_wrapper<std::vector<uint32_t>>,
+      std::reference_wrapper<std::vector<uint64_t>>,
       std::reference_wrapper<std::vector<int32_t>>,
       std::reference_wrapper<std::vector<int64_t>>,
       std::reference_wrapper<std::vector<std::vector<bool>>>,
       std::reference_wrapper<std::vector<std::vector<uint32_t>>>,
+      std::reference_wrapper<std::vector<std::vector<uint64_t>>>,
       std::reference_wrapper<std::vector<std::vector<int32_t>>>,
       std::reference_wrapper<std::vector<std::vector<int64_t>>>>;
 
@@ -47,10 +52,12 @@ class IColumnDefinition {
   using DeserializeType = std::variant<
       typename MPCTypes::SecBool,
       typename MPCTypes::SecUnsigned32Int,
+      typename MPCTypes::SecUnsigned64Int,
       typename MPCTypes::Sec32Int,
       typename MPCTypes::Sec64Int,
       std::vector<typename MPCTypes::SecBool>,
       std::vector<typename MPCTypes::SecUnsigned32Int>,
+      std::vector<typename MPCTypes::SecUnsigned64Int>,
       std::vector<typename MPCTypes::Sec32Int>,
       std::vector<typename MPCTypes::Sec64Int>>;
 

--- a/fbpcf/mpc_std_lib/unified_data_process/serialization/IRowStructureDefinition.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/serialization/IRowStructureDefinition.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <cstddef>
+#include <functional>
 #include <unordered_map>
 #include <vector>
 #include "IColumnDefinition.h"
@@ -20,16 +21,6 @@ class IRowStructureDefinition {
  public:
   using SecString = frontend::BitString<true, schedulerId, true>;
 
-  using InputColumnDataType = std::variant<
-      std::vector<bool>,
-      std::vector<uint32_t>,
-      std::vector<int32_t>,
-      std::vector<int64_t>,
-      std::vector<std::vector<bool>>,
-      std::vector<std::vector<uint32_t>>,
-      std::vector<std::vector<int32_t>>,
-      std::vector<std::vector<int64_t>>>;
-
   virtual ~IRowStructureDefinition() = default;
 
   /* Returns the number of bytes to serialize a single row */
@@ -39,7 +30,9 @@ class IRowStructureDefinition {
   // definition. Each key must match the name of a column in the definition and
   // the value contains the data for that column
   virtual std::vector<std::vector<unsigned char>> serializeDataAsBytesForUDP(
-      const std::unordered_map<std::string, InputColumnDataType>& data,
+      const std::unordered_map<
+          std::string,
+          typename IColumnDefinition<schedulerId>::InputColumnDataType>& data,
       int numRows) const = 0;
 
   // Following a run of the UDP protocol, deserialize the batched BitString

--- a/fbpcf/mpc_std_lib/unified_data_process/serialization/IntegerColumn.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/serialization/IntegerColumn.h
@@ -58,8 +58,7 @@ class IntegerColumn : public IColumnDefinition<schedulerId> {
   typename IColumnDefinition<schedulerId>::SupportedColumnTypes getColumnType()
       const override {
     static_assert(
-        (isSigned && (width == 32 || width == 64)) || width == 32,
-        "For now only support int32, int64, uint64");
+        width == 32 || width == 64, "For now only support 32 and 64 bit types");
     if constexpr (isSigned) {
       if constexpr (width == 32) {
         return IColumnDefinition<schedulerId>::SupportedColumnTypes::Int32;
@@ -68,6 +67,8 @@ class IntegerColumn : public IColumnDefinition<schedulerId> {
       }
     } else if constexpr (width == 32) {
       return IColumnDefinition<schedulerId>::SupportedColumnTypes::UInt32;
+    } else if constexpr (width == 64) {
+      return IColumnDefinition<schedulerId>::SupportedColumnTypes::UInt64;
     }
     throw std::runtime_error(folly::sformat(
         "This code should be unreachable. {}int{}_t column type is not supported",

--- a/fbpcf/mpc_std_lib/unified_data_process/serialization/RowStructureDefinition.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/serialization/RowStructureDefinition.h
@@ -58,6 +58,11 @@ class RowStructureDefinition : public IRowStructureDefinition<schedulerId> {
               std::make_unique<IntegerColumn<schedulerId, false, 32>>(
                   columnNameToType.first));
           break;
+        case IColumnDefinition<schedulerId>::SupportedColumnTypes::UInt64:
+          columnDefinitions_->push_back(
+              std::make_unique<IntegerColumn<schedulerId, false, 64>>(
+                  columnNameToType.first));
+          break;
         case IColumnDefinition<schedulerId>::SupportedColumnTypes::Int32:
           columnDefinitions_->push_back(
               std::make_unique<IntegerColumn<schedulerId, true, 32>>(
@@ -74,6 +79,13 @@ class RowStructureDefinition : public IRowStructureDefinition<schedulerId> {
                   schedulerId,
                   typename frontend::MPCTypes<schedulerId>::SecUnsigned32Int,
                   uint32_t>>(columnNameToType.first, paddingSize));
+          break;
+        case IColumnDefinition<schedulerId>::SupportedColumnTypes::UInt64Vec:
+          columnDefinitions_->push_back(
+              std::make_unique<FixedSizeArrayColumn<
+                  schedulerId,
+                  typename frontend::MPCTypes<schedulerId>::SecUnsigned64Int,
+                  uint64_t>>(columnNameToType.first, paddingSize));
 
           break;
         case IColumnDefinition<schedulerId>::SupportedColumnTypes::Int32Vec:


### PR DESCRIPTION
Summary:
# Background:

Currently in order to successfully use UDP, you must write some carefully crafted code that will take all the rows of metadata for one side and package it into a collection of bytes. Afterwards the caller will get a `SecString` object back which is a bit representation of all the bytes they passed in, minus the filtered out rows. The user must then extract the corresponding bits for each column into separate MPC Types.  This is a cumbersome process which is error prone, as you must make sure to carefully match up the two steps and any changes can cause a bug.

# This Diff

Adds support for `uint64_t` and `vec<uint64_t>` column types in serialization engine.

Differential Revision: D43521296

