### PR TITLE
fix an unintended variable reuse in UdpEncryption object

### DIFF
--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpEncryption.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpEncryption.h
@@ -80,7 +80,8 @@ class UdpEncryption {
   std::unique_ptr<fbpcf::engine::communication::IPartyCommunicationAgent>
       agent_;
 
-  uint64_t indexOffset_;
+  uint64_t myDataIndexOffset_;
+  uint64_t peerDataIndexOffset_;
 
   size_t myDataWidth_;
   __m128i prgKey_;


### PR DESCRIPTION
Summary: `indexOffset_` is meant to record how much data has been processed. And my data and peer's data should be recorded separately. However the original implementation mistakenly used the same variable and the unit test failed to catch that. This diff fixes the bug and adds necessary tests.

Reviewed By: haochenuw

Differential Revision: D43746711

