### PR TITLE
Fix major serialization bug

### DIFF
--- a/fbpcf/mpc_std_lib/unified_data_process/serialization/RowStructureDefinition.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/serialization/RowStructureDefinition.h
@@ -324,10 +324,8 @@ class RowStructureDefinition : public IRowStructureDefinition<schedulerId> {
       }
     }
 
-    for (int i = 0; i < writeBuffers.size(); i++) {
-      packedBitCol->serializeColumnAsPlaintextBytes(
-          bitPack, writeBuffers, byteOffset);
-    }
+    packedBitCol->serializeColumnAsPlaintextBytes(
+        bitPack, writeBuffers, byteOffset);
   }
 };
 


### PR DESCRIPTION
Summary: Found this bug while testing PL on Explat. There is an n^2 loop. The column implementation is already writing the values for each row to the byte buffers (https://fburl.com/code/a48hfogh). This effectively means we are processing this column n^2 times. For 1 million rows that is 1 trillion times we are calling this method 🤦‍♀️

Differential Revision: D43954084

