### PR TITLE
ORAM encoder API definition

### DIFF
--- a/fbpcf/mpc_std_lib/oram/encoder/IOramEncoder.h
+++ b/fbpcf/mpc_std_lib/oram/encoder/IOramEncoder.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace fbpcf::mpc_std_lib::oram {
+/*
+ * An ORAM encoder is responsible for taking tuples of aggregation indexes
+ * and mapping them to a unique single ID that can be consumed by an
+ * ORAM implementation
+ */
+class IOramEncoder {
+ public:
+  class OramMappingConfig {};
+
+  virtual ~IOramEncoder() = default;
+
+  /*
+   * Given the list of all breakdown column values, assign a unique ORAM index
+   * to each permutation and return the mapping information that can be used to
+   * retrieve the results. Can be called multiple times in batch mode and
+   * preserve the ordering.
+   */
+  virtual std::vector<uint32_t> generateORAMIndexes(
+      const std::vector<std::vector<uint32_t>>& tuples) = 0;
+
+  /*
+   * Retrieve the current mapping for all permutations of the group by columns.
+   * Should only be called once after finishing calling generateORAMIndexes()
+   */
+  virtual std::unique_ptr<OramMappingConfig> exportMappingConfig() const = 0;
+
+ private:
+};
+
+} // namespace fbpcf::mpc_std_lib::oram

--- a/fbpcf/mpc_std_lib/oram/encoder/OramEncoder.cpp
+++ b/fbpcf/mpc_std_lib/oram/encoder/OramEncoder.cpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "fbpcf/mpc_std_lib/oram/encoder/OramEncoder.h"
+#include <stdexcept>
+
+namespace fbpcf::mpc_std_lib::oram {
+
+std::vector<uint32_t> OramEncoder::generateORAMIndexes(
+    const std::vector<std::vector<uint32_t>>& /* tuples */) {
+  throw std::runtime_error("Unimplemented");
+}
+
+std::unique_ptr<IOramEncoder::OramMappingConfig>
+OramEncoder::exportMappingConfig() const {
+  throw std::runtime_error("Unimplemented");
+}
+
+} // namespace fbpcf::mpc_std_lib::oram

--- a/fbpcf/mpc_std_lib/oram/encoder/OramEncoder.h
+++ b/fbpcf/mpc_std_lib/oram/encoder/OramEncoder.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <stdexcept>
+#include "fbpcf/mpc_std_lib/oram/encoder/IOramEncoder.h"
+
+namespace fbpcf::mpc_std_lib::oram {
+
+class OramEncoder : public IOramEncoder {
+ public:
+  explicit OramEncoder() {}
+
+  std::vector<uint32_t> generateORAMIndexes(
+      const std::vector<std::vector<uint32_t>>& /* tuples */) override;
+
+  std::unique_ptr<OramMappingConfig> exportMappingConfig() const override;
+
+ private:
+};
+
+} // namespace fbpcf::mpc_std_lib::oram


### PR DESCRIPTION
Summary:
# Context
The ORAM encoder / decoder library is a simple component that will be utilized to generate unique group by keys for ORAM aggregation logic. It supports the following flow
1. Collect all the rows of data being grouped (assuming the plaintext values are known to a single party).
2. Collect Filters to apply to this data.
3. Map each row to a single index in the ORAM step
4. Perform ORAM aggregation.
5. Map the buckets back to their original values. Any values that have been filtered out will decode to an empty vector.

# This diff

Adds the base API for an ORAM encoder. Some of the specific signatures will change a little in future diffs but this is the general idea.

#Facebook Execution plan: https://docs.google.com/document/d/13QPQ1TEvy9-4TgFVCa8fzdjHQtH5Sf8wE6FTMR01Sv8/edit#

Differential Revision: D44040849

