### PR TITLE
Implement ORAM encoding without filters

### DIFF
--- a/fbpcf/mpc_std_lib/oram/encoder/IOramEncoder.h
+++ b/fbpcf/mpc_std_lib/oram/encoder/IOramEncoder.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace fbpcf::mpc_std_lib::oram {
+/*
+ * An ORAM encoder is responsible for taking tuples of aggregation indexes
+ * and mapping them to a unique single ID that can be consumed by an
+ * ORAM implementation
+ */
+class IOramEncoder {
+ public:
+  class OramMappingConfig {};
+
+  virtual ~IOramEncoder() = default;
+
+  /*
+   * Given the list of all breakdown column values, assign a unique ORAM index
+   * to each permutation and return the mapping information that can be used to
+   * retrieve the results. Can be called multiple times in batch mode and
+   * preserve the ordering.
+   */
+  virtual std::vector<uint32_t> generateORAMIndexes(
+      const std::vector<std::vector<uint32_t>>& tuples) = 0;
+
+  /*
+   * Retrieve the current mapping for all permutations of the group by columns.
+   * Should only be called once after finishing calling generateORAMIndexes()
+   */
+  virtual std::unique_ptr<OramMappingConfig> exportMappingConfig() const = 0;
+
+ private:
+};
+
+} // namespace fbpcf::mpc_std_lib::oram

--- a/fbpcf/mpc_std_lib/oram/encoder/IOramEncoder.h
+++ b/fbpcf/mpc_std_lib/oram/encoder/IOramEncoder.h
@@ -20,7 +20,20 @@ namespace fbpcf::mpc_std_lib::oram {
  */
 class IOramEncoder {
  public:
-  class OramMappingConfig {};
+  class OramMappingConfig {
+   public:
+    OramMappingConfig() {}
+
+    std::string toString() {
+      return "";
+    }
+
+    static OramMappingConfig fromString() {
+      return OramMappingConfig();
+    }
+
+   private:
+  };
 
   virtual ~IOramEncoder() = default;
 
@@ -28,7 +41,7 @@ class IOramEncoder {
    * Given the list of all breakdown column values, assign a unique ORAM index
    * to each permutation and return the mapping information that can be used to
    * retrieve the results. Can be called multiple times in batch mode and
-   * preserve the ordering.
+   * preserve the ordering. A value of 0 indicates the tuple is filtered out.
    */
   virtual std::vector<uint32_t> generateORAMIndexes(
       const std::vector<std::vector<uint32_t>>& tuples) = 0;

--- a/fbpcf/mpc_std_lib/oram/encoder/OramEncoder.cpp
+++ b/fbpcf/mpc_std_lib/oram/encoder/OramEncoder.cpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "fbpcf/mpc_std_lib/oram/encoder/OramEncoder.h"
+#include <stdexcept>
+
+namespace fbpcf::mpc_std_lib::oram {
+
+std::vector<uint32_t> OramEncoder::generateORAMIndexes(
+    const std::vector<std::vector<uint32_t>>& /* tuples */) {
+  throw std::runtime_error("Unimplemented");
+}
+
+std::unique_ptr<IOramEncoder::OramMappingConfig>
+OramEncoder::exportMappingConfig() const {
+  throw std::runtime_error("Unimplemented");
+}
+
+} // namespace fbpcf::mpc_std_lib::oram

--- a/fbpcf/mpc_std_lib/oram/encoder/OramEncoder.cpp
+++ b/fbpcf/mpc_std_lib/oram/encoder/OramEncoder.cpp
@@ -11,8 +11,22 @@
 namespace fbpcf::mpc_std_lib::oram {
 
 std::vector<uint32_t> OramEncoder::generateORAMIndexes(
-    const std::vector<std::vector<uint32_t>>& /* tuples */) {
-  throw std::runtime_error("Unimplemented");
+    const std::vector<std::vector<uint32_t>>& tuples) {
+  std::vector<uint32_t> rst(0);
+  rst.reserve(tuples.size());
+  for (const auto& tuple : tuples) {
+    std::string breakdownKey = convertBreakdownsToKey(tuple);
+
+    if (breakdownMapping_.find(breakdownKey) != breakdownMapping_.end()) {
+      rst.push_back(breakdownMapping_[breakdownKey]);
+    } else {
+      breakdownMapping_.emplace(breakdownKey, currentIndex_);
+      rst.push_back(currentIndex_);
+      currentIndex_++;
+    }
+  }
+
+  return rst;
 }
 
 std::unique_ptr<IOramEncoder::OramMappingConfig>

--- a/fbpcf/mpc_std_lib/oram/encoder/OramEncoder.h
+++ b/fbpcf/mpc_std_lib/oram/encoder/OramEncoder.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <stdexcept>
+#include "fbpcf/mpc_std_lib/oram/encoder/IOramEncoder.h"
+
+namespace fbpcf::mpc_std_lib::oram {
+
+class OramEncoder : public IOramEncoder {
+ public:
+  explicit OramEncoder() {}
+
+  std::vector<uint32_t> generateORAMIndexes(
+      const std::vector<std::vector<uint32_t>>& /* tuples */) override;
+
+  std::unique_ptr<OramMappingConfig> exportMappingConfig() const override;
+
+ private:
+};
+
+} // namespace fbpcf::mpc_std_lib::oram

--- a/fbpcf/mpc_std_lib/oram/encoder/OramEncoder.h
+++ b/fbpcf/mpc_std_lib/oram/encoder/OramEncoder.h
@@ -8,20 +8,30 @@
 #pragma once
 
 #include <stdexcept>
+#include <unordered_map>
+#include "folly/String.h"
+
 #include "fbpcf/mpc_std_lib/oram/encoder/IOramEncoder.h"
 
 namespace fbpcf::mpc_std_lib::oram {
 
 class OramEncoder : public IOramEncoder {
  public:
-  explicit OramEncoder() {}
+  explicit OramEncoder() : currentIndex_(1), breakdownMapping_() {}
 
   std::vector<uint32_t> generateORAMIndexes(
-      const std::vector<std::vector<uint32_t>>& /* tuples */) override;
+      const std::vector<std::vector<uint32_t>>& tuples) override;
 
   std::unique_ptr<OramMappingConfig> exportMappingConfig() const override;
 
  private:
+  uint32_t currentIndex_;
+  std::unordered_map<std::string, uint32_t> breakdownMapping_;
+
+  std::string convertBreakdownsToKey(
+      const std::vector<uint32_t>& breakdownValues) const {
+    return folly::join(",", breakdownValues);
+  }
 };
 
 } // namespace fbpcf::mpc_std_lib::oram

--- a/fbpcf/mpc_std_lib/oram/encoder/test/OramEncoderTest.cpp
+++ b/fbpcf/mpc_std_lib/oram/encoder/test/OramEncoderTest.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include <memory>
+#include <random>
+
+#include "fbpcf/mpc_std_lib/oram/encoder/IOramEncoder.h"
+#include "fbpcf/mpc_std_lib/oram/encoder/OramEncoder.h"
+
+namespace fbpcf::mpc_std_lib::oram {
+
+TEST(OramEncoderTest, testEncoderNoFilters) {
+  std::unique_ptr<IOramEncoder> encoder = std::make_unique<OramEncoder>();
+
+  /*
+   * Total breakdown groups: 4
+   * B1: [0 - 1]
+   * B2: [0 - 2]
+   * B3: [0 - 1]
+   * B4: [0 - 3]
+   * Total possible Breakdowns: 1 + 2 * 3 * 2 * 4 = 49
+   * i = b1 * 24 + b2 * 8 + b3 * 4 + b4 + 1
+   */
+
+  std::vector<std::vector<uint32_t>> breakdownTuples(0);
+  for (uint32_t i = 0; i < 48; i++) {
+    std::vector<uint32_t> breakdownValues{
+        i / 24, (i / 8) % 3, (i / 4) % 2, i % 4};
+    breakdownTuples.push_back(breakdownValues);
+  }
+
+  auto mapping = encoder->generateORAMIndexes(breakdownTuples);
+
+  for (int i = 0; i < 48; i++) {
+    EXPECT_EQ(mapping[i], i + 1);
+  }
+
+  breakdownTuples.clear();
+
+  std::random_device rd;
+  std::mt19937_64 e(rd());
+  std::uniform_int_distribution<uint32_t> randomB1AndB3(0, 1);
+  std::uniform_int_distribution<uint32_t> randomB2(0, 2);
+  std::uniform_int_distribution<uint32_t> randomB4(0, 3);
+
+  for (int i = 0; i < 100; i++) {
+    std::vector<uint32_t> breakdownValues{
+        randomB1AndB3(e), randomB2(e), randomB1AndB3(e), randomB4(e)};
+    breakdownTuples.push_back(breakdownValues);
+  }
+
+  mapping = encoder->generateORAMIndexes(breakdownTuples);
+
+  for (int i = 0; i < 100; i++) {
+    EXPECT_EQ(
+        mapping[i],
+        1 + breakdownTuples[i][0] * 24 + breakdownTuples[i][1] * 8 +
+            breakdownTuples[i][2] * 4 + breakdownTuples[i][3]);
+  }
+}
+} // namespace fbpcf::mpc_std_lib::oram


### PR DESCRIPTION
Summary:
# Context
The ORAM encoder / decoder library is a simple component that will be utilized to generate unique group by keys for ORAM aggregation logic. It supports the following flow
1. Collect all the rows of data being grouped (assuming the plaintext values are known to a single party).
2. Collect Filters to apply to this data.
3. Map each row to a single index in the ORAM step
4. Perform ORAM aggregation.
5. Map the buckets back to their original values. Any values that have been filtered out will decode to an empty vector.

# This diff

Implementation of the ORAM encoding functionality. We serialize the inputs into a comma separated string and perform a lookup in the existing map. If there is no match then increment the current index and store the value before returning it.

Differential Revision: D44040848

