### PR TITLE
Add filter support

### DIFF
--- a/fbpcf/mpc_std_lib/oram/encoder/IFilter.h
+++ b/fbpcf/mpc_std_lib/oram/encoder/IFilter.h
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace fbpcf::mpc_std_lib::oram {
+
+class IFilter {
+ public:
+  enum FilterType { GT, LT, GTE, LTE, EQ, NEQ, SUBSET_OF, NOT_SUBSET_OF };
+
+  virtual ~IFilter() = default;
+
+  // Returns true if the filter condition passes
+  virtual bool apply(const std::vector<uint32_t>& breakdownValues) const = 0;
+};
+
+class SingleValueFilter : public IFilter {
+ public:
+  explicit SingleValueFilter(
+      FilterType type,
+      size_t columnIndex,
+      uint32_t filterValue)
+      : type_{type}, columnIndex_{columnIndex}, filterValue_{filterValue} {
+    switch (type_) {
+      case GT:
+      case LT:
+      case GTE:
+      case LTE:
+      case EQ:
+      case NEQ:
+        break;
+      case SUBSET_OF:
+      case NOT_SUBSET_OF:
+        throw std::invalid_argument(
+            "SingleValueFilter must be of type (GT, LT, GTE, LTE, EQ, NEQ");
+    }
+  }
+
+  bool apply(const std::vector<uint32_t>& breakdownValues) const override {
+    if (breakdownValues.size() < columnIndex_ + 1) {
+      throw std::invalid_argument(
+          "Column index of filter exceeds number of breakdown values. Expected at least " +
+          std::to_string(columnIndex_ + 1) + " values but got " +
+          std::to_string(breakdownValues.size()));
+    }
+
+    switch (type_) {
+      case GT:
+        return breakdownValues[columnIndex_] > filterValue_;
+      case LT:
+        return breakdownValues[columnIndex_] < filterValue_;
+      case GTE:
+        return breakdownValues[columnIndex_] >= filterValue_;
+      case LTE:
+        return breakdownValues[columnIndex_] <= filterValue_;
+      case EQ:
+        return breakdownValues[columnIndex_] == filterValue_;
+      case NEQ:
+        return breakdownValues[columnIndex_] != filterValue_;
+      case SUBSET_OF:
+      case NOT_SUBSET_OF:
+        throw std::invalid_argument(
+            "SingleValueFilter must be of type (GT, LT, GTE, LTE, EQ, NEQ");
+    }
+  }
+
+  // Filter condition operator
+  FilterType type_;
+  // The column index the filter applies to
+  size_t columnIndex_;
+  // The comparison value for the filter
+  uint32_t filterValue_;
+};
+
+class VectorValueFilter : public IFilter {
+ public:
+  explicit VectorValueFilter(
+      FilterType type,
+      size_t columnIndex,
+      std::vector<uint32_t> filterValues)
+      : type_{type},
+        columnIndex_{columnIndex},
+        filterValues_{filterValues.begin(), filterValues.end()} {
+    switch (type) {
+      case GT:
+      case LT:
+      case GTE:
+      case LTE:
+      case EQ:
+      case NEQ:
+        throw std::invalid_argument(
+            "VectorValueFilter must be of type (SUBSET_OF, NOT_SUBSET_OF)");
+      case SUBSET_OF:
+      case NOT_SUBSET_OF:
+        break;
+    }
+  }
+
+  bool apply(const std::vector<uint32_t>& breakdownValues) const override {
+    if (breakdownValues.size() < columnIndex_ + 1) {
+      throw std::invalid_argument(
+          "Column index of filter exceeds number of breakdown values. Expected at least " +
+          std::to_string(columnIndex_ + 1) + " values but got " +
+          std::to_string(breakdownValues.size()));
+    }
+
+    switch (type_) {
+      case GT:
+      case LT:
+      case GTE:
+      case LTE:
+      case EQ:
+      case NEQ:
+        throw std::invalid_argument(
+            "VectorValueFilter must be of type (SUBSET_OF NOT_SUBSET_OF)");
+      case SUBSET_OF:
+        return filterValues_.find(breakdownValues[columnIndex_]) !=
+            filterValues_.end();
+      case NOT_SUBSET_OF:
+        return filterValues_.find(breakdownValues[columnIndex_]) ==
+            filterValues_.end();
+    }
+  }
+
+  // Type of multi value filter
+  FilterType type_;
+  // The column index the filter applies to
+  size_t columnIndex_;
+  // List of values for the multi value filter
+  std::set<uint32_t> filterValues_;
+};
+
+} // namespace fbpcf::mpc_std_lib::oram

--- a/fbpcf/mpc_std_lib/oram/encoder/IOramEncoder.h
+++ b/fbpcf/mpc_std_lib/oram/encoder/IOramEncoder.h
@@ -41,7 +41,8 @@ class IOramEncoder {
    * Given the list of all breakdown column values, assign a unique ORAM index
    * to each permutation and return the mapping information that can be used to
    * retrieve the results. Can be called multiple times in batch mode and
-   * preserve the ordering. A value of 0 indicates the tuple is filtered out.
+   * preserve the ordering. The first value to fail the filters will re-use the
+   * same bucket for all future non-passing tuples.
    */
   virtual std::vector<uint32_t> generateORAMIndexes(
       const std::vector<std::vector<uint32_t>>& tuples) = 0;

--- a/fbpcf/mpc_std_lib/oram/encoder/IOramEncoder.h
+++ b/fbpcf/mpc_std_lib/oram/encoder/IOramEncoder.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace fbpcf::mpc_std_lib::oram {
+/*
+ * An ORAM encoder is responsible for taking tuples of aggregation indexes
+ * and mapping them to a unique single ID that can be consumed by an
+ * ORAM implementation
+ */
+class IOramEncoder {
+ public:
+  class OramMappingConfig {};
+
+  virtual ~IOramEncoder() = default;
+
+  /*
+   * Given the list of all breakdown column values, assign a unique ORAM index
+   * to each permutation and return the mapping information that can be used to
+   * retrieve the results. Can be called multiple times in batch mode and
+   * preserve the ordering.
+   */
+  virtual std::vector<uint32_t> generateORAMIndexes(
+      const std::vector<std::vector<uint32_t>>& tuples) = 0;
+
+  /*
+   * Retrieve the current mapping for all permutations of the group by columns.
+   * Should only be called once after finishing calling generateORAMIndexes()
+   */
+  virtual std::unique_ptr<OramMappingConfig> exportMappingConfig() const = 0;
+
+ private:
+};
+
+} // namespace fbpcf::mpc_std_lib::oram

--- a/fbpcf/mpc_std_lib/oram/encoder/IOramEncoder.h
+++ b/fbpcf/mpc_std_lib/oram/encoder/IOramEncoder.h
@@ -20,7 +20,20 @@ namespace fbpcf::mpc_std_lib::oram {
  */
 class IOramEncoder {
  public:
-  class OramMappingConfig {};
+  class OramMappingConfig {
+   public:
+    OramMappingConfig() {}
+
+    std::string toString() {
+      return "";
+    }
+
+    static OramMappingConfig fromString() {
+      return OramMappingConfig();
+    }
+
+   private:
+  };
 
   virtual ~IOramEncoder() = default;
 
@@ -28,7 +41,7 @@ class IOramEncoder {
    * Given the list of all breakdown column values, assign a unique ORAM index
    * to each permutation and return the mapping information that can be used to
    * retrieve the results. Can be called multiple times in batch mode and
-   * preserve the ordering.
+   * preserve the ordering. A value of 0 indicates the tuple is filtered out.
    */
   virtual std::vector<uint32_t> generateORAMIndexes(
       const std::vector<std::vector<uint32_t>>& tuples) = 0;

--- a/fbpcf/mpc_std_lib/oram/encoder/OramEncoder.cpp
+++ b/fbpcf/mpc_std_lib/oram/encoder/OramEncoder.cpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "fbpcf/mpc_std_lib/oram/encoder/OramEncoder.h"
+#include <stdexcept>
+
+namespace fbpcf::mpc_std_lib::oram {
+
+std::vector<uint32_t> OramEncoder::generateORAMIndexes(
+    const std::vector<std::vector<uint32_t>>& /* tuples */) {
+  throw std::runtime_error("Unimplemented");
+}
+
+std::unique_ptr<IOramEncoder::OramMappingConfig>
+OramEncoder::exportMappingConfig() const {
+  throw std::runtime_error("Unimplemented");
+}
+
+} // namespace fbpcf::mpc_std_lib::oram

--- a/fbpcf/mpc_std_lib/oram/encoder/OramEncoder.cpp
+++ b/fbpcf/mpc_std_lib/oram/encoder/OramEncoder.cpp
@@ -11,8 +11,22 @@
 namespace fbpcf::mpc_std_lib::oram {
 
 std::vector<uint32_t> OramEncoder::generateORAMIndexes(
-    const std::vector<std::vector<uint32_t>>& /* tuples */) {
-  throw std::runtime_error("Unimplemented");
+    const std::vector<std::vector<uint32_t>>& tuples) {
+  std::vector<uint32_t> rst(0);
+  rst.reserve(tuples.size());
+  for (const auto& tuple : tuples) {
+    std::string breakdownKey = convertBreakdownsToKey(tuple);
+
+    if (breakdownMapping_.find(breakdownKey) != breakdownMapping_.end()) {
+      rst.push_back(breakdownMapping_[breakdownKey]);
+    } else {
+      breakdownMapping_.emplace(breakdownKey, currentIndex_);
+      rst.push_back(currentIndex_);
+      currentIndex_++;
+    }
+  }
+
+  return rst;
 }
 
 std::unique_ptr<IOramEncoder::OramMappingConfig>

--- a/fbpcf/mpc_std_lib/oram/encoder/OramEncoder.cpp
+++ b/fbpcf/mpc_std_lib/oram/encoder/OramEncoder.cpp
@@ -15,6 +15,24 @@ std::vector<uint32_t> OramEncoder::generateORAMIndexes(
   std::vector<uint32_t> rst(0);
   rst.reserve(tuples.size());
   for (const auto& tuple : tuples) {
+    bool hasThisRowBeenFiltered = false;
+    for (const auto& filter : *filters_) {
+      if (!filter->apply(tuple)) {
+        if (!wasAnyRowFiltered_) {
+          wasAnyRowFiltered_ = true;
+          filteredValuesIndex_ = currentIndex_;
+          currentIndex_++;
+        }
+        rst.push_back(filteredValuesIndex_);
+        hasThisRowBeenFiltered = true;
+        break;
+      }
+    }
+
+    if (hasThisRowBeenFiltered) {
+      continue;
+    }
+
     std::string breakdownKey = convertBreakdownsToKey(tuple);
 
     if (breakdownMapping_.find(breakdownKey) != breakdownMapping_.end()) {

--- a/fbpcf/mpc_std_lib/oram/encoder/OramEncoder.h
+++ b/fbpcf/mpc_std_lib/oram/encoder/OramEncoder.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <stdexcept>
+#include "fbpcf/mpc_std_lib/oram/encoder/IOramEncoder.h"
+
+namespace fbpcf::mpc_std_lib::oram {
+
+class OramEncoder : public IOramEncoder {
+ public:
+  explicit OramEncoder() {}
+
+  std::vector<uint32_t> generateORAMIndexes(
+      const std::vector<std::vector<uint32_t>>& /* tuples */) override;
+
+  std::unique_ptr<OramMappingConfig> exportMappingConfig() const override;
+
+ private:
+};
+
+} // namespace fbpcf::mpc_std_lib::oram

--- a/fbpcf/mpc_std_lib/oram/encoder/OramEncoder.h
+++ b/fbpcf/mpc_std_lib/oram/encoder/OramEncoder.h
@@ -8,20 +8,30 @@
 #pragma once
 
 #include <stdexcept>
+#include <unordered_map>
+#include "folly/String.h"
+
 #include "fbpcf/mpc_std_lib/oram/encoder/IOramEncoder.h"
 
 namespace fbpcf::mpc_std_lib::oram {
 
 class OramEncoder : public IOramEncoder {
  public:
-  explicit OramEncoder() {}
+  explicit OramEncoder() : currentIndex_(1), breakdownMapping_() {}
 
   std::vector<uint32_t> generateORAMIndexes(
-      const std::vector<std::vector<uint32_t>>& /* tuples */) override;
+      const std::vector<std::vector<uint32_t>>& tuples) override;
 
   std::unique_ptr<OramMappingConfig> exportMappingConfig() const override;
 
  private:
+  uint32_t currentIndex_;
+  std::unordered_map<std::string, uint32_t> breakdownMapping_;
+
+  std::string convertBreakdownsToKey(
+      const std::vector<uint32_t>& breakdownValues) const {
+    return folly::join(",", breakdownValues);
+  }
 };
 
 } // namespace fbpcf::mpc_std_lib::oram

--- a/fbpcf/mpc_std_lib/oram/encoder/OramEncoder.h
+++ b/fbpcf/mpc_std_lib/oram/encoder/OramEncoder.h
@@ -11,13 +11,16 @@
 #include <unordered_map>
 #include "folly/String.h"
 
+#include "fbpcf/mpc_std_lib/oram/encoder/IFilter.h"
 #include "fbpcf/mpc_std_lib/oram/encoder/IOramEncoder.h"
 
 namespace fbpcf::mpc_std_lib::oram {
 
 class OramEncoder : public IOramEncoder {
  public:
-  explicit OramEncoder() : currentIndex_(1), breakdownMapping_() {}
+  explicit OramEncoder(
+      std::unique_ptr<std::vector<std::unique_ptr<IFilter>>> filters)
+      : filters_{std::move(filters)} {}
 
   std::vector<uint32_t> generateORAMIndexes(
       const std::vector<std::vector<uint32_t>>& tuples) override;
@@ -25,8 +28,12 @@ class OramEncoder : public IOramEncoder {
   std::unique_ptr<OramMappingConfig> exportMappingConfig() const override;
 
  private:
-  uint32_t currentIndex_;
-  std::unordered_map<std::string, uint32_t> breakdownMapping_;
+  std::unique_ptr<std::vector<std::unique_ptr<IFilter>>> filters_;
+
+  uint32_t filteredValuesIndex_ = 0;
+  bool wasAnyRowFiltered_ = false;
+  uint32_t currentIndex_ = 0;
+  std::unordered_map<std::string, uint32_t> breakdownMapping_{};
 
   std::string convertBreakdownsToKey(
       const std::vector<uint32_t>& breakdownValues) const {

--- a/fbpcf/mpc_std_lib/oram/encoder/test/OramEncoderTest.cpp
+++ b/fbpcf/mpc_std_lib/oram/encoder/test/OramEncoderTest.cpp
@@ -9,16 +9,20 @@
 #include <memory>
 #include <random>
 
+#include "fbpcf/test/TestHelper.h"
+
 #include "fbpcf/mpc_std_lib/oram/encoder/IOramEncoder.h"
 #include "fbpcf/mpc_std_lib/oram/encoder/OramEncoder.h"
 
 namespace fbpcf::mpc_std_lib::oram {
 
-TEST(OramEncoderTest, testEncoderNoFilters) {
-  std::unique_ptr<IOramEncoder> encoder = std::make_unique<OramEncoder>();
+TEST(OramEncoderTest, TestEncoderNoFilters) {
+  auto filters = std::make_unique<std::vector<std::unique_ptr<IFilter>>>(0);
+  std::unique_ptr<IOramEncoder> encoder =
+      std::make_unique<OramEncoder>(std::move(filters));
 
   /*
-   * Total breakdown groups: 4
+   * Total breakdown columns: 4
    * B1: [0 - 1]
    * B2: [0 - 2]
    * B3: [0 - 1]
@@ -37,7 +41,7 @@ TEST(OramEncoderTest, testEncoderNoFilters) {
   auto mapping = encoder->generateORAMIndexes(breakdownTuples);
 
   for (int i = 0; i < 48; i++) {
-    EXPECT_EQ(mapping[i], i + 1);
+    EXPECT_EQ(mapping[i], i);
   }
 
   breakdownTuples.clear();
@@ -59,8 +63,215 @@ TEST(OramEncoderTest, testEncoderNoFilters) {
   for (int i = 0; i < 100; i++) {
     EXPECT_EQ(
         mapping[i],
-        1 + breakdownTuples[i][0] * 24 + breakdownTuples[i][1] * 8 +
+        breakdownTuples[i][0] * 24 + breakdownTuples[i][1] * 8 +
             breakdownTuples[i][2] * 4 + breakdownTuples[i][3]);
   }
 }
+
+void encoderWithFiltersTest(
+    std::unique_ptr<std::vector<std::unique_ptr<IFilter>>> filters,
+    const std::vector<uint32_t>& expected) {
+  /*
+   * Total breakdown columns: 2
+   * B1: [0 - 9]
+   * B2: [0 - 9]
+   * i = b1 * 10 + b2 (before filtering)
+   */
+
+  std::vector<std::vector<uint32_t>> breakdownTuples(0);
+  for (uint32_t i = 0; i < 100; i++) {
+    std::vector<uint32_t> breakdownValues{i / 10, i % 10};
+    breakdownTuples.push_back(breakdownValues);
+  }
+
+  std::unique_ptr<IOramEncoder> encoder =
+      std::make_unique<OramEncoder>(std::move(filters));
+
+  auto mapping = encoder->generateORAMIndexes(breakdownTuples);
+
+  testVectorEq(expected, mapping);
+}
+
+TEST(OramEncoderTest, EmptyFilterTest) {
+  auto filters = std::make_unique<std::vector<std::unique_ptr<IFilter>>>(0);
+
+  std::vector<uint32_t> expected(0);
+
+  for (size_t i = 0; i < 100; i++) {
+    expected.push_back(i);
+  }
+
+  encoderWithFiltersTest(std::move(filters), expected);
+}
+
+TEST(OramEncoderTest, GTFilterTest) {
+  auto filters = std::make_unique<std::vector<std::unique_ptr<IFilter>>>(0);
+  filters->push_back(std::make_unique<SingleValueFilter>(IFilter::GT, 0, 4));
+  filters->push_back(std::make_unique<SingleValueFilter>(IFilter::GT, 1, 4));
+
+  std::vector<uint32_t> expected(0);
+  for (uint32_t i = 0; i < 100; i++) {
+    uint32_t b1 = i / 10;
+    uint32_t b2 = i % 10;
+
+    if (b1 > 4 && b2 > 4) {
+      expected.push_back((b1 - 5) * 5 + (b2 - 5) + 1);
+    } else {
+      expected.push_back(0);
+    }
+  }
+
+  encoderWithFiltersTest(std::move(filters), expected);
+}
+
+TEST(OramEncoderTest, LTFilterTest) {
+  auto filters = std::make_unique<std::vector<std::unique_ptr<IFilter>>>(0);
+  filters->push_back(std::make_unique<SingleValueFilter>(IFilter::LT, 1, 5));
+  filters->push_back(std::make_unique<SingleValueFilter>(IFilter::LT, 0, 5));
+
+  std::vector<uint32_t> expected(0);
+  for (uint32_t i = 0; i < 100; i++) {
+    uint32_t b1 = i / 10;
+    uint32_t b2 = i % 10;
+
+    if (b1 < 5 && b2 < 5) {
+      expected.push_back(b1 * 5 + b2 + (b1 != 0 ? 1 : 0));
+    } else {
+      expected.push_back(5);
+    }
+  }
+
+  encoderWithFiltersTest(std::move(filters), expected);
+}
+
+TEST(OramEncoderTest, GTEFilterTest) {
+  auto filters = std::make_unique<std::vector<std::unique_ptr<IFilter>>>(0);
+  filters->push_back(std::make_unique<SingleValueFilter>(IFilter::GTE, 0, 4));
+  filters->push_back(std::make_unique<SingleValueFilter>(IFilter::GTE, 1, 4));
+
+  std::vector<uint32_t> expected(0);
+  for (uint32_t i = 0; i < 100; i++) {
+    uint32_t b1 = i / 10;
+    uint32_t b2 = i % 10;
+
+    if (b1 >= 4 && b2 >= 4) {
+      expected.push_back((b1 - 4) * 6 + (b2 - 4) + 1);
+    } else {
+      expected.push_back(0);
+    }
+  }
+
+  encoderWithFiltersTest(std::move(filters), expected);
+}
+
+TEST(OramEncoderTest, LTEFilterTest) {
+  auto filters = std::make_unique<std::vector<std::unique_ptr<IFilter>>>(0);
+  filters->push_back(std::make_unique<SingleValueFilter>(IFilter::LTE, 1, 5));
+  filters->push_back(std::make_unique<SingleValueFilter>(IFilter::LTE, 0, 5));
+
+  std::vector<uint32_t> expected(0);
+  for (uint32_t i = 0; i < 100; i++) {
+    uint32_t b1 = i / 10;
+    uint32_t b2 = i % 10;
+
+    if (b1 <= 5 && b2 <= 5) {
+      expected.push_back(b1 * 6 + b2 + (b1 != 0 ? 1 : 0));
+    } else {
+      expected.push_back(6);
+    }
+  }
+
+  encoderWithFiltersTest(std::move(filters), expected);
+}
+
+TEST(OramEncoderTest, EQFilterTest) {
+  auto filters = std::make_unique<std::vector<std::unique_ptr<IFilter>>>(0);
+  filters->push_back(std::make_unique<SingleValueFilter>(IFilter::EQ, 0, 3));
+  filters->push_back(std::make_unique<SingleValueFilter>(IFilter::GT, 1, 5));
+
+  std::vector<uint32_t> expected(0);
+  for (uint32_t i = 0; i < 100; i++) {
+    uint32_t b1 = i / 10;
+    uint32_t b2 = i % 10;
+
+    if (b1 == 3 && b2 > 5) {
+      expected.push_back(1 + (b2 - 6));
+    } else {
+      expected.push_back(0);
+    }
+  }
+
+  encoderWithFiltersTest(std::move(filters), expected);
+}
+
+TEST(OramEncoderTest, NEQFilterTest) {
+  auto filters = std::make_unique<std::vector<std::unique_ptr<IFilter>>>(0);
+  filters->push_back(std::make_unique<SingleValueFilter>(IFilter::NEQ, 0, 0));
+  filters->push_back(std::make_unique<SingleValueFilter>(IFilter::GT, 1, 5));
+
+  std::vector<uint32_t> expected(0);
+  for (uint32_t i = 0; i < 100; i++) {
+    uint32_t b1 = i / 10;
+    uint32_t b2 = i % 10;
+
+    if (b1 != 0 && b2 > 5) {
+      expected.push_back(1 + (b1 - 1) * 4 + (b2 - 6));
+    } else {
+      expected.push_back(0);
+    }
+  }
+
+  encoderWithFiltersTest(std::move(filters), expected);
+}
+
+TEST(OramEncoderTest, SubsetOfTest) {
+  auto filters = std::make_unique<std::vector<std::unique_ptr<IFilter>>>(0);
+  std::vector<uint32_t> filterValues{0, 2, 5};
+  filters->push_back(
+      std::make_unique<VectorValueFilter>(IFilter::SUBSET_OF, 0, filterValues));
+  filters->push_back(std::make_unique<SingleValueFilter>(IFilter::GT, 1, 5));
+
+  std::vector<uint32_t> expected(0);
+  for (uint32_t i = 0; i < 100; i++) {
+    uint32_t b1 = i / 10;
+    uint32_t b2 = i % 10;
+
+    if ((b1 == 0 || b1 == 2 || b1 == 5) && b2 > 5) {
+      expected.push_back(1 + (b1 == 0 ? 0 : b1 == 2 ? 1 : 2) * 4 + (b2 - 6));
+    } else {
+      expected.push_back(0);
+    }
+  }
+
+  encoderWithFiltersTest(std::move(filters), expected);
+}
+
+TEST(OramEncoderTest, NotSubsetOfTest) {
+  auto filters = std::make_unique<std::vector<std::unique_ptr<IFilter>>>(0);
+  std::vector<uint32_t> filterValues{0, 2, 5};
+  filters->push_back(std::make_unique<VectorValueFilter>(
+      IFilter::NOT_SUBSET_OF, 0, filterValues));
+  filters->push_back(std::make_unique<SingleValueFilter>(IFilter::GT, 1, 5));
+
+  std::vector<uint32_t> expected(0);
+  for (uint32_t i = 0; i < 100; i++) {
+    uint32_t b1 = i / 10;
+    uint32_t b2 = i % 10;
+
+    if (!(b1 == 0 || b1 == 2 || b1 == 5) && b2 > 5) {
+      expected.push_back(
+          1 +
+          (b1 == 1      ? 0
+               : b1 < 5 ? b1 - 2
+                        : b1 - 3) *
+              4 +
+          (b2 - 6));
+    } else {
+      expected.push_back(0);
+    }
+  }
+
+  encoderWithFiltersTest(std::move(filters), expected);
+}
+
 } // namespace fbpcf::mpc_std_lib::oram

--- a/fbpcf/mpc_std_lib/oram/encoder/test/OramEncoderTest.cpp
+++ b/fbpcf/mpc_std_lib/oram/encoder/test/OramEncoderTest.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include <memory>
+#include <random>
+
+#include "fbpcf/mpc_std_lib/oram/encoder/IOramEncoder.h"
+#include "fbpcf/mpc_std_lib/oram/encoder/OramEncoder.h"
+
+namespace fbpcf::mpc_std_lib::oram {
+
+TEST(OramEncoderTest, testEncoderNoFilters) {
+  std::unique_ptr<IOramEncoder> encoder = std::make_unique<OramEncoder>();
+
+  /*
+   * Total breakdown groups: 4
+   * B1: [0 - 1]
+   * B2: [0 - 2]
+   * B3: [0 - 1]
+   * B4: [0 - 3]
+   * Total possible Breakdowns: 1 + 2 * 3 * 2 * 4 = 49
+   * i = b1 * 24 + b2 * 8 + b3 * 4 + b4 + 1
+   */
+
+  std::vector<std::vector<uint32_t>> breakdownTuples(0);
+  for (uint32_t i = 0; i < 48; i++) {
+    std::vector<uint32_t> breakdownValues{
+        i / 24, (i / 8) % 3, (i / 4) % 2, i % 4};
+    breakdownTuples.push_back(breakdownValues);
+  }
+
+  auto mapping = encoder->generateORAMIndexes(breakdownTuples);
+
+  for (int i = 0; i < 48; i++) {
+    EXPECT_EQ(mapping[i], i + 1);
+  }
+
+  breakdownTuples.clear();
+
+  std::random_device rd;
+  std::mt19937_64 e(rd());
+  std::uniform_int_distribution<uint32_t> randomB1AndB3(0, 1);
+  std::uniform_int_distribution<uint32_t> randomB2(0, 2);
+  std::uniform_int_distribution<uint32_t> randomB4(0, 3);
+
+  for (int i = 0; i < 100; i++) {
+    std::vector<uint32_t> breakdownValues{
+        randomB1AndB3(e), randomB2(e), randomB1AndB3(e), randomB4(e)};
+    breakdownTuples.push_back(breakdownValues);
+  }
+
+  mapping = encoder->generateORAMIndexes(breakdownTuples);
+
+  for (int i = 0; i < 100; i++) {
+    EXPECT_EQ(
+        mapping[i],
+        1 + breakdownTuples[i][0] * 24 + breakdownTuples[i][1] * 8 +
+            breakdownTuples[i][2] * 4 + breakdownTuples[i][3]);
+  }
+}
+} // namespace fbpcf::mpc_std_lib::oram


### PR DESCRIPTION
Summary:
# Context
The ORAM encoder / decoder library is a simple component that will be utilized to generate unique group by keys for ORAM aggregation logic. It supports the following flow
1. Collect all the rows of data being grouped (assuming the plaintext values are known to a single party).
2. Collect Filters to apply to this data.
3. Map each row to a single index in the ORAM step
4. Perform ORAM aggregation.
5. Map the buckets back to their original values. Any values that have been filtered out will decode to an empty vector.

# This diff

Adds filter support using the `IFilters` interface definition. There are either Single value filters present (i.e. comparison operators) and a multi value operation (subset of)

Differential Revision: D44040850

