### PR TITLE
Fix a typo in interface type name - adding the right name in fbpcf

### DIFF
--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/IUdpEncryption.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/IUdpEncryption.h
@@ -44,14 +44,17 @@ class IUdpEncryption {
    */
   virtual void processPeerData(size_t dataSize) = 0;
 
-  struct EncryptionResuts {
+  struct EncryptionResults {
     std::vector<std::vector<unsigned char>> ciphertexts;
     std::vector<__m128i> nonces;
     std::vector<int32_t> indexes;
   };
 
+  // temporary, avoiding break fbpcs.
+  using EncryptionResuts = EncryptionResults;
+
   // returning the ciphertext, nonce, and index of cherry-picked rows
-  virtual EncryptionResuts getProcessedData() = 0;
+  virtual EncryptionResults getProcessedData() = 0;
 };
 
 } // namespace fbpcf::mpc_std_lib::unified_data_process::data_processor

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpEncryption.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpEncryption.h
@@ -61,7 +61,7 @@ class UdpEncryption final : public IUdpEncryption {
   void processPeerData(size_t dataSize) override;
 
   // returning the ciphertext, nonce, and index of cherry-picked rows
-  EncryptionResuts getProcessedData() override {
+  EncryptionResults getProcessedData() override {
     if (statusOfProcessingPeerData_ != Status::inProgress) {
       throw std::runtime_error(
           "Can't call getProcessedData before preparation!");

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpUtil.cpp
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpUtil.cpp
@@ -120,12 +120,12 @@ static std::vector<unsigned char> convertM128iToCharVec(
 }
 
 void writeEncryptionResultsToFile(
-    const IUdpEncryption::EncryptionResuts& EncryptionResuts,
+    const IUdpEncryption::EncryptionResults& EncryptionResults,
     const std::string& file) {
   std::ostringstream s;
   boost::archive::text_oarchive oa(s);
-  oa << EncryptionResuts.ciphertexts << EncryptionResuts.indexes
-     << convertM128iToCharVec(EncryptionResuts.nonces);
+  oa << EncryptionResults.ciphertexts << EncryptionResults.indexes
+     << convertM128iToCharVec(EncryptionResults.nonces);
 
   fbpcf::io::FileIOWrappers::writeFile(file, s.str());
 }
@@ -139,11 +139,11 @@ void writeExpandedKeyToFile(
   fbpcf::io::FileIOWrappers::writeFile(file, s.str());
 }
 
-IUdpEncryption::EncryptionResuts readEncryptionResultsFromFile(
+IUdpEncryption::EncryptionResults readEncryptionResultsFromFile(
     const std::string& file) {
   std::istringstream s(fbpcf::io::FileIOWrappers::readFile(file));
 
-  IUdpEncryption::EncryptionResuts data;
+  IUdpEncryption::EncryptionResults data;
   boost::archive::text_iarchive ia(s);
   ia >> data.ciphertexts;
   ia >> data.indexes;
@@ -162,10 +162,10 @@ std::vector<__m128i> readExpandedKeyFromFile(const std::string& file) {
   return convertCharVecToM128i(data);
 }
 
-std::vector<IUdpEncryption::EncryptionResuts> splitEncryptionResults(
-    const IUdpEncryption::EncryptionResuts& encryptionResults,
+std::vector<IUdpEncryption::EncryptionResults> splitEncryptionResults(
+    const IUdpEncryption::EncryptionResults& encryptionResults,
     int count) {
-  std::vector<IUdpEncryption::EncryptionResuts> rst;
+  std::vector<IUdpEncryption::EncryptionResults> rst;
   rst.reserve(count);
   size_t originalSize = encryptionResults.nonces.size();
   auto ciphertextIt = encryptionResults.ciphertexts.begin();
@@ -174,7 +174,7 @@ std::vector<IUdpEncryption::EncryptionResuts> splitEncryptionResults(
 
   for (size_t i = 0; i < count; i++) {
     auto shardSize = getShardSize(originalSize, i, count);
-    rst.push_back(IUdpEncryption::EncryptionResuts{
+    rst.push_back(IUdpEncryption::EncryptionResults{
         .ciphertexts = std::vector<std::vector<unsigned char>>(
             std::make_move_iterator(ciphertextIt),
             std::make_move_iterator(ciphertextIt + shardSize)),

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpUtil.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpUtil.h
@@ -50,7 +50,7 @@ class UdpUtil {
 };
 
 void writeEncryptionResultsToFile(
-    const IUdpEncryption::EncryptionResuts& encryptionResults,
+    const IUdpEncryption::EncryptionResults& encryptionResults,
     const std::string& file);
 
 void writeExpandedKeyToFile(
@@ -59,11 +59,11 @@ void writeExpandedKeyToFile(
 
 std::vector<__m128i> readExpandedKeyFromFile(const std::string& file);
 
-IUdpEncryption::EncryptionResuts readEncryptionResultsFromFile(
+IUdpEncryption::EncryptionResults readEncryptionResultsFromFile(
     const std::string& file);
 
-std::vector<IUdpEncryption::EncryptionResuts> splitEncryptionResults(
-    const IUdpEncryption::EncryptionResuts& encryptionResults,
+std::vector<IUdpEncryption::EncryptionResults> splitEncryptionResults(
+    const IUdpEncryption::EncryptionResults& encryptionResults,
     int count);
 
 // decides the i-th shard size. i is the shard index

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/test/DataProcessorTest.cpp
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/test/DataProcessorTest.cpp
@@ -328,7 +328,7 @@ TEST(TestFileReadAndWrite, testExpandedKeyReadAndWrite) {
 }
 
 TEST(TestFileReadAndWrite, testEncryptionResultReadAndWrite) {
-  IUdpEncryption::EncryptionResuts results;
+  IUdpEncryption::EncryptionResults results;
 
   const int batchSize = 11;
   results.ciphertexts = std::vector<std::vector<unsigned char>>(batchSize);
@@ -366,7 +366,7 @@ TEST(TestSplit, getShardSize) {
 }
 
 TEST(TestSplit, testSplit) {
-  IUdpEncryption::EncryptionResuts results;
+  IUdpEncryption::EncryptionResults results;
   int batchSize = 11;
   results.ciphertexts = std::vector<std::vector<unsigned char>>(batchSize);
   results.indexes = std::vector<int32_t>(batchSize);


### PR DESCRIPTION
Summary:
As title. Adding back the missing 'l' in 'EncryptionResult'.

Temporary set `EncryptionResut` as an alias for `EncryptionResult` to avoid breaking fbpcs build.

Differential Revision: D44136535

