### PR TITLE
Limit PC run selection to only builds on the main branch

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -63,7 +63,7 @@ jobs:
         cd fbpcs
         git reset --hard $(curl \
         --header 'content-type: application/json' \
-        "https://api.github.com/repos/facebookresearch/fbpcs/actions/workflows/12965519/runs?per_page=1&status=success" | jq \
+        "https://api.github.com/repos/facebookresearch/fbpcs/actions/workflows/12965519/runs?per_page=1&status=success&branch=main" | jq \
         ".workflow_runs[0] .head_sha" | tr -d '"')
 
     - name: Build fbpcs image (this uses the locally built fbpcf image as a dependency)


### PR DESCRIPTION
Summary:
## Context
There are times that we run the publish OneDocker job on feature branches in the FBPCS repo to test changes that we are making. This is problematic for the FBPCF repo since they require the last commit from this API to be available on the main branch.

## This Diff
This diff adds the filter that requires the FBPCS run to be on the main branch.

Reviewed By: RuiyuZhu

Differential Revision: D44140323

