### PR TITLE
Fix a typo in interface type name - deleting the temporary alias in fbpcf

### DIFF
--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/IUdpEncryption.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/IUdpEncryption.h
@@ -50,9 +50,6 @@ class IUdpEncryption {
     std::vector<int32_t> indexes;
   };
 
-  // temporary, avoiding break fbpcs.
-  using EncryptionResuts = EncryptionResults;
-
   // returning the ciphertext, nonce, and index of cherry-picked rows
   virtual EncryptionResults getProcessedData() = 0;
 };


### PR DESCRIPTION
Summary: As title

Differential Revision: D44136534

