### PR TITLE
Move mock back to fbpcf

### DIFF
--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/test/UdpEncryptionMock.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/test/UdpEncryptionMock.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "fbpcf/mpc_std_lib/unified_data_process/data_processor/IUdpEncryption.h"
+
+namespace fbpcf::mpc_std_lib::unified_data_process::data_processor {
+
+using namespace ::testing;
+
+class UdpEncryptionMock final : public IUdpEncryption {
+ public:
+  MOCK_METHOD(void, prepareToProcessMyData, (size_t));
+
+  MOCK_METHOD(
+      void,
+      processMyData,
+      (const std::vector<std::vector<unsigned char>>&));
+
+  MOCK_METHOD(std::vector<__m128i>, getExpandedKey, ());
+
+  MOCK_METHOD(
+      void,
+      prepareToProcessPeerData,
+      (size_t, const std::vector<int32_t>&));
+
+  MOCK_METHOD(void, processPeerData, (size_t));
+
+  MOCK_METHOD(EncryptionResults, getProcessedData, ());
+};
+
+} // namespace fbpcf::mpc_std_lib::unified_data_process::data_processor


### PR DESCRIPTION
Summary: This was a less optimal engineering decision. It becomes quite challenging if we want to modify the interface while the mock lives in a different repo.

Reviewed By: xyguo

Differential Revision: D44261909

