### PR TITLE
change int32_t to uint64_t for ids in UDP in fbpcf

### DIFF
--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/DataProcessor.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/DataProcessor.h
@@ -50,7 +50,7 @@ class DataProcessor final : public IDataProcessor<schedulerId> {
    */
   typename IDataProcessor<schedulerId>::SecString processPeersData(
       size_t dataSize,
-      const std::vector<int32_t>& indexes,
+      const std::vector<uint64_t>& indexes,
       size_t dataWidth) override;
 
  private:

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/DataProcessor_impl.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/DataProcessor_impl.h
@@ -41,7 +41,7 @@ template <int schedulerId>
 typename IDataProcessor<schedulerId>::SecString
 DataProcessor<schedulerId>::processPeersData(
     size_t dataSize,
-    const std::vector<int32_t>& indexes,
+    const std::vector<uint64_t>& indexes,
     size_t dataWidth) {
   encrypter_.prepareToProcessPeerData(dataWidth, indexes);
   encrypter_.processPeerData(dataSize);

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/DummyDataProcessor.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/DummyDataProcessor.h
@@ -37,7 +37,7 @@ class DummyDataProcessor final : public IDataProcessor<schedulerId> {
    */
   typename IDataProcessor<schedulerId>::SecString processPeersData(
       size_t dataSize,
-      const std::vector<int32_t>& indexes,
+      const std::vector<uint64_t>& indexes,
       size_t dataWidth) override;
 
  private:

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/DummyDataProcessor_impl.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/DummyDataProcessor_impl.h
@@ -35,7 +35,7 @@ template <int schedulerId>
 typename IDataProcessor<schedulerId>::SecString
 DummyDataProcessor<schedulerId>::processPeersData(
     size_t dataSize,
-    const std::vector<int32_t>& indexes,
+    const std::vector<uint64_t>& indexes,
     size_t dataWidth) {
   std::vector<std::vector<unsigned char>> plaintext;
   for (size_t i = 0; i < dataSize; i++) {

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/IDataProcessor.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/IDataProcessor.h
@@ -48,8 +48,20 @@ class IDataProcessor {
    */
   virtual SecString processPeersData(
       size_t dataSize,
-      const std::vector<int32_t>& indexes,
+      const std::vector<uint64_t>& indexes,
       size_t dataWidth) = 0;
+
+  // temp API to maintain forward/backward compactibility
+  virtual SecString processPeersData(
+      size_t dataSize,
+      const std::vector<int32_t>& indexes,
+      size_t dataWidth) {
+    std::vector<uint64_t> uint64Index(indexes.size());
+    for (size_t i = 0; i < indexes.size(); i++) {
+      uint64Index.at(i) = indexes.at(i);
+    }
+    return processPeersData(dataSize, uint64Index, dataWidth);
+  }
 };
 
 } // namespace fbpcf::mpc_std_lib::unified_data_process::data_processor

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpDecryption.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpDecryption.h
@@ -60,6 +60,18 @@ class UdpDecryption {
       const std::vector<std::vector<unsigned char>>& cherryPickedEncryption,
       const std::vector<__m128i>& cherryPickedNonce,
       const std::vector<int32_t>& cherryPickedIndex) const {
+    std::vector<uint64_t> uint64Index(cherryPickedIndex.size());
+    for (size_t i = 0; i < cherryPickedIndex.size(); i++) {
+      uint64Index.at(i) = cherryPickedIndex.at(i);
+    }
+    return decryptPeerData(
+        cherryPickedEncryption, cherryPickedNonce, uint64Index);
+  }
+
+  SecString decryptPeerData(
+      const std::vector<std::vector<unsigned char>>& cherryPickedEncryption,
+      const std::vector<__m128i>& cherryPickedNonce,
+      const std::vector<uint64_t>& cherryPickedIndex) const {
     size_t outputWidth = cherryPickedEncryption.at(0).size();
     size_t outputSize = cherryPickedEncryption.size();
 

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpEncryption.cpp
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpEncryption.cpp
@@ -54,7 +54,7 @@ void UdpEncryption::processMyData(
 
 void UdpEncryption::prepareToProcessPeerData(
     size_t peerDataWidth,
-    const std::vector<int32_t>& indexes) {
+    const std::vector<uint64_t>& indexes) {
   if (statusOfProcessingPeerData_ != Status::idle) {
     throw std::runtime_error(
         "Can't call prepare when already processing peer data!");
@@ -71,7 +71,7 @@ void UdpEncryption::prepareToProcessPeerData(
   cherryPickedEncryption_ =
       std::vector<std::vector<unsigned char>>(indexes.size());
   cherryPickedNonce_ = std::vector<__m128i>(indexes.size());
-  cherryPickedIndex_ = std::vector<int32_t>(indexes.size());
+  cherryPickedIndex_ = std::vector<uint64_t>(indexes.size());
 }
 
 void UdpEncryption::processPeerData(size_t dataSize) {

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpEncryption.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpEncryption.h
@@ -51,9 +51,20 @@ class UdpEncryption final : public IUdpEncryption {
     return std::vector<__m128i>(expandedKey.begin(), expandedKey.end());
   }
 
+  // temp API to maintain forward/backward compactibility
   void prepareToProcessPeerData(
       size_t peerDataWidth,
-      const std::vector<int32_t>& indexes) override;
+      const std::vector<int32_t>& indexes) override {
+    std::vector<uint64_t> uint64Index(indexes.size());
+    for (size_t i = 0; i < indexes.size(); i++) {
+      uint64Index.at(i) = indexes.at(i);
+    }
+    prepareToProcessPeerData(peerDataWidth, uint64Index);
+  }
+
+  void prepareToProcessPeerData(
+      size_t peerDataWidth,
+      const std::vector<uint64_t>& indexes) override;
 
   // process peer data via UDP encryption. This API should be called in
   // coordinate with "ProcessMyData" on peer's side. This API is ever called,
@@ -94,7 +105,7 @@ class UdpEncryption final : public IUdpEncryption {
 
   std::vector<std::vector<unsigned char>> cherryPickedEncryption_;
   std::vector<__m128i> cherryPickedNonce_;
-  std::vector<int32_t> cherryPickedIndex_;
+  std::vector<uint64_t> cherryPickedIndex_;
 
   static const size_t kBlockSize = 16;
 

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpUtil.cpp
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpUtil.cpp
@@ -181,7 +181,7 @@ std::vector<IUdpEncryption::EncryptionResults> splitEncryptionResults(
         .nonces = std::vector<__m128i>(
             std::make_move_iterator(noncesIt),
             std::make_move_iterator(noncesIt + shardSize)),
-        .indexes = std::vector<int32_t>(
+        .indexes = std::vector<uint64_t>(
             std::make_move_iterator(indexesIt),
             std::make_move_iterator(indexesIt + shardSize))});
     ciphertextIt += shardSize;

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/test/DataProcessorTest.cpp
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/test/DataProcessorTest.cpp
@@ -28,7 +28,7 @@ namespace fbpcf::mpc_std_lib::unified_data_process::data_processor {
 
 std::tuple<
     std::vector<std::vector<std::vector<uint8_t>>>,
-    std::vector<int32_t>,
+    std::vector<uint64_t>,
     std::vector<std::vector<uint8_t>>>
 generateDataProcessorTestData(size_t dataWidth, size_t numberOfShards) {
   std::random_device rd;
@@ -46,7 +46,7 @@ generateDataProcessorTestData(size_t dataWidth, size_t numberOfShards) {
       data = randomData(e);
     }
   }
-  std::vector<int32_t> index(inputSize);
+  std::vector<uint64_t> index(inputSize);
   for (size_t i = 0; i < inputSize; i++) {
     index[i] = i;
   }
@@ -95,7 +95,7 @@ void testDataProcessor(
   };
   auto task1 = [](std::unique_ptr<IDataProcessor<1>> processor,
                   size_t dataSize,
-                  const std::vector<int32_t>& indexes,
+                  const std::vector<uint64_t>& indexes,
                   size_t dataWidth) {
     auto secretSharedOutput =
         processor->processPeersData(dataSize, indexes, dataWidth);
@@ -188,7 +188,7 @@ void testUdpEncryptionAndDecryptionObjects(
                       plaintextDataInShards,
                   size_t dataWidth,
                   size_t outputSize,
-                  const std::vector<int32_t>& indexes,
+                  const std::vector<uint64_t>& indexes,
                   const std::vector<size_t>& sizes) {
     udpEnc->prepareToProcessMyData(dataWidth);
     for (size_t i = 0; i < plaintextDataInShards.size(); i++) {
@@ -239,7 +239,7 @@ void testUdpEncryptionAndDecryptionObjects(
   auto task1 = [](std::unique_ptr<UdpEncryption> udpEnc,
                   std::unique_ptr<UdpDecryption<1>> udpDec0,
                   std::unique_ptr<UdpDecryption<3>> udpDec1,
-                  const std::vector<int32_t>& indexes,
+                  const std::vector<uint64_t>& indexes,
                   const std::vector<size_t>& sizes,
                   const std::vector<std::vector<std::vector<unsigned char>>>&
                       plaintextDataInShards,
@@ -332,7 +332,7 @@ TEST(TestFileReadAndWrite, testEncryptionResultReadAndWrite) {
 
   const int batchSize = 11;
   results.ciphertexts = std::vector<std::vector<unsigned char>>(batchSize);
-  results.indexes = std::vector<int32_t>(batchSize);
+  results.indexes = std::vector<uint64_t>(batchSize);
   results.nonces = std::vector<__m128i>(batchSize);
   for (size_t i = 0; i < batchSize; i++) {
     results.nonces.at(i) = _mm_set_epi32(
@@ -369,7 +369,7 @@ TEST(TestSplit, testSplit) {
   IUdpEncryption::EncryptionResults results;
   int batchSize = 11;
   results.ciphertexts = std::vector<std::vector<unsigned char>>(batchSize);
-  results.indexes = std::vector<int32_t>(batchSize);
+  results.indexes = std::vector<uint64_t>(batchSize);
   results.nonces = std::vector<__m128i>(batchSize);
   for (size_t i = 0; i < batchSize; i++) {
     results.nonces.at(i) = _mm_set_epi32(

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/test/UdpEncryptionMock.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/test/UdpEncryptionMock.h
@@ -29,6 +29,11 @@ class UdpEncryptionMock final : public IUdpEncryption {
   MOCK_METHOD(
       void,
       prepareToProcessPeerData,
+      (size_t, const std::vector<uint64_t>&));
+
+  MOCK_METHOD(
+      void,
+      prepareToProcessPeerData,
       (size_t, const std::vector<int32_t>&));
 
   MOCK_METHOD(void, processPeerData, (size_t));

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/test/UdpEncryptionMock.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/test/UdpEncryptionMock.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "fbpcf/mpc_std_lib/unified_data_process/data_processor/IUdpEncryption.h"
+
+namespace fbpcf::mpc_std_lib::unified_data_process::data_processor {
+
+using namespace ::testing;
+
+class UdpEncryptionMock final : public IUdpEncryption {
+ public:
+  MOCK_METHOD(void, prepareToProcessMyData, (size_t));
+
+  MOCK_METHOD(
+      void,
+      processMyData,
+      (const std::vector<std::vector<unsigned char>>&));
+
+  MOCK_METHOD(std::vector<__m128i>, getExpandedKey, ());
+
+  MOCK_METHOD(
+      void,
+      prepareToProcessPeerData,
+      (size_t, const std::vector<int32_t>&));
+
+  MOCK_METHOD(void, processPeerData, (size_t));
+
+  MOCK_METHOD(EncryptionResults, getProcessedData, ());
+};
+
+} // namespace fbpcf::mpc_std_lib::unified_data_process::data_processor


### PR DESCRIPTION
Summary:
As title.

We used to int32_t for index in UDP to save cost (b/c it is used in adapter).
Now as we integrating with i-PID, adapter is no longer need but the index could be larger, we change it to use uint64_t.
In this diff we make the change in fbpcf repo. In the next few diffs we will make the change in fbpcs and remove the temporary APIs in this diff.

Differential Revision:
D44242198

Privacy Context Container: L416713

