### PR TITLE
Remove temporary APIs in fbpcf repo

### DIFF
--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/IDataProcessor.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/IDataProcessor.h
@@ -50,18 +50,6 @@ class IDataProcessor {
       size_t dataSize,
       const std::vector<uint64_t>& indexes,
       size_t dataWidth) = 0;
-
-  // temp API to maintain forward/backward compactibility
-  virtual SecString processPeersData(
-      size_t dataSize,
-      const std::vector<int32_t>& indexes,
-      size_t dataWidth) {
-    std::vector<uint64_t> uint64Index(indexes.size());
-    for (size_t i = 0; i < indexes.size(); i++) {
-      uint64Index.at(i) = indexes.at(i);
-    }
-    return processPeersData(dataSize, uint64Index, dataWidth);
-  }
 };
 
 } // namespace fbpcf::mpc_std_lib::unified_data_process::data_processor

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/IUdpEncryption.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/IUdpEncryption.h
@@ -34,19 +34,6 @@ class IUdpEncryption {
 
   virtual std::vector<__m128i> getExpandedKey() = 0;
 
-  // temp API to maintain forward/backward compactibility
-  virtual void prepareToProcessPeerData(
-      size_t peerDataWidth,
-      const std::vector<int32_t>& indexes) {
-    std::vector<uint64_t> uint64Index(indexes.size());
-    std::transform(
-        indexes.begin(),
-        indexes.end(),
-        uint64Index.begin(),
-        [](int32_t c) -> uint64_t { return c; });
-    prepareToProcessPeerData(peerDataWidth, uint64Index);
-  }
-
   virtual void prepareToProcessPeerData(
       size_t peerDataWidth,
       const std::vector<uint64_t>& indexes) = 0;

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpDecryption.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpDecryption.h
@@ -59,18 +59,6 @@ class UdpDecryption {
   SecString decryptPeerData(
       const std::vector<std::vector<unsigned char>>& cherryPickedEncryption,
       const std::vector<__m128i>& cherryPickedNonce,
-      const std::vector<int32_t>& cherryPickedIndex) const {
-    std::vector<uint64_t> uint64Index(cherryPickedIndex.size());
-    for (size_t i = 0; i < cherryPickedIndex.size(); i++) {
-      uint64Index.at(i) = cherryPickedIndex.at(i);
-    }
-    return decryptPeerData(
-        cherryPickedEncryption, cherryPickedNonce, uint64Index);
-  }
-
-  SecString decryptPeerData(
-      const std::vector<std::vector<unsigned char>>& cherryPickedEncryption,
-      const std::vector<__m128i>& cherryPickedNonce,
       const std::vector<uint64_t>& cherryPickedIndex) const {
     size_t outputWidth = cherryPickedEncryption.at(0).size();
     size_t outputSize = cherryPickedEncryption.size();

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpEncryption.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpEncryption.h
@@ -51,17 +51,6 @@ class UdpEncryption final : public IUdpEncryption {
     return std::vector<__m128i>(expandedKey.begin(), expandedKey.end());
   }
 
-  // temp API to maintain forward/backward compactibility
-  void prepareToProcessPeerData(
-      size_t peerDataWidth,
-      const std::vector<int32_t>& indexes) override {
-    std::vector<uint64_t> uint64Index(indexes.size());
-    for (size_t i = 0; i < indexes.size(); i++) {
-      uint64Index.at(i) = indexes.at(i);
-    }
-    prepareToProcessPeerData(peerDataWidth, uint64Index);
-  }
-
   void prepareToProcessPeerData(
       size_t peerDataWidth,
       const std::vector<uint64_t>& indexes) override;

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/test/UdpEncryptionMock.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/test/UdpEncryptionMock.h
@@ -31,11 +31,6 @@ class UdpEncryptionMock final : public IUdpEncryption {
       prepareToProcessPeerData,
       (size_t, const std::vector<uint64_t>&));
 
-  MOCK_METHOD(
-      void,
-      prepareToProcessPeerData,
-      (size_t, const std::vector<int32_t>&));
-
   MOCK_METHOD(void, processPeerData, (size_t));
 
   MOCK_METHOD(EncryptionResults, getProcessedData, ());


### PR DESCRIPTION
Summary:
As title.

We used to int32_t for index in UDP to save cost (b/c it is used in adapter).
Now as we integrating with i-PID, adapter is no longer need but the index could be larger, we change it to use uint64_t.
In this diff remove the temporary APIs in fbpcf.

Reviewed By: robotal

Differential Revision: D44247962

