### PR TITLE
update udp encryption API to take in customized indexes in fbpcf

### DIFF
--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/DataProcessor_impl.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/DataProcessor_impl.h
@@ -9,6 +9,7 @@
 
 #include <emmintrin.h>
 #include <fbpcf/engine/util/util.h>
+#include <numeric>
 #include "fbpcf/engine/util/aes.h"
 #include "fbpcf/mpc_std_lib/aes_circuit/AesCircuitCtr.h"
 #include "fbpcf/mpc_std_lib/unified_data_process/data_processor/DataProcessor.h"
@@ -24,9 +25,12 @@ DataProcessor<schedulerId>::processMyData(
     size_t outputSize) {
   size_t dataSize = plaintextData.size();
   size_t dataWidth = plaintextData.at(0).size();
+  std::vector<uint64_t> indexes(plaintextData.size());
+  // generate 0 to n-1 vector
+  std::iota(indexes.begin(), indexes.end(), 0);
 
   encrypter_.prepareToProcessMyData(dataWidth);
-  encrypter_.processMyData(plaintextData);
+  encrypter_.processMyData(plaintextData, indexes);
 
   // 1b. (peer)receive encryted data from peer
   // 2b. (peer)pick desired ciphertext blocks

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/IDataProcessor.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/IDataProcessor.h
@@ -50,18 +50,6 @@ class IDataProcessor {
       size_t dataSize,
       const std::vector<uint64_t>& indexes,
       size_t dataWidth) = 0;
-
-  // temp API to maintain forward/backward compactibility
-  virtual SecString processPeersData(
-      size_t dataSize,
-      const std::vector<int32_t>& indexes,
-      size_t dataWidth) {
-    std::vector<uint64_t> uint64Index(indexes.size());
-    for (size_t i = 0; i < indexes.size(); i++) {
-      uint64Index.at(i) = indexes.at(i);
-    }
-    return processPeersData(dataSize, uint64Index, dataWidth);
-  }
 };
 
 } // namespace fbpcf::mpc_std_lib::unified_data_process::data_processor

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/IUdpEncryption.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/IUdpEncryption.h
@@ -34,19 +34,6 @@ class IUdpEncryption {
 
   virtual std::vector<__m128i> getExpandedKey() = 0;
 
-  // temp API to maintain forward/backward compactibility
-  virtual void prepareToProcessPeerData(
-      size_t peerDataWidth,
-      const std::vector<int32_t>& indexes) {
-    std::vector<uint64_t> uint64Index(indexes.size());
-    std::transform(
-        indexes.begin(),
-        indexes.end(),
-        uint64Index.begin(),
-        [](int32_t c) -> uint64_t { return c; });
-    prepareToProcessPeerData(peerDataWidth, uint64Index);
-  }
-
   virtual void prepareToProcessPeerData(
       size_t peerDataWidth,
       const std::vector<uint64_t>& indexes) = 0;

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/IUdpEncryption.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/IUdpEncryption.h
@@ -30,7 +30,15 @@ class IUdpEncryption {
    * "getExpandedKey" to retrieve the expanded key for decryption later.
    */
   virtual void processMyData(
-      const std::vector<std::vector<unsigned char>>& plaintextData) = 0;
+      const std::vector<std::vector<unsigned char>>& plaintextData,
+      const std::vector<uint64_t>& indexes) = 0;
+
+  // a temp API to maintain backward compatibility
+  virtual void processMyData(
+      const std::vector<std::vector<unsigned char>>& plaintextData) {
+    processMyData(
+        plaintextData, std::vector<uint64_t>(plaintextData.size(), 0));
+  }
 
   virtual std::vector<__m128i> getExpandedKey() = 0;
 

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpDecryption.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpDecryption.h
@@ -59,18 +59,6 @@ class UdpDecryption {
   SecString decryptPeerData(
       const std::vector<std::vector<unsigned char>>& cherryPickedEncryption,
       const std::vector<__m128i>& cherryPickedNonce,
-      const std::vector<int32_t>& cherryPickedIndex) const {
-    std::vector<uint64_t> uint64Index(cherryPickedIndex.size());
-    for (size_t i = 0; i < cherryPickedIndex.size(); i++) {
-      uint64Index.at(i) = cherryPickedIndex.at(i);
-    }
-    return decryptPeerData(
-        cherryPickedEncryption, cherryPickedNonce, uint64Index);
-  }
-
-  SecString decryptPeerData(
-      const std::vector<std::vector<unsigned char>>& cherryPickedEncryption,
-      const std::vector<__m128i>& cherryPickedNonce,
       const std::vector<uint64_t>& cherryPickedIndex) const {
     size_t outputWidth = cherryPickedEncryption.at(0).size();
     size_t outputSize = cherryPickedEncryption.size();

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpEncryption.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpEncryption.h
@@ -51,17 +51,6 @@ class UdpEncryption final : public IUdpEncryption {
     return std::vector<__m128i>(expandedKey.begin(), expandedKey.end());
   }
 
-  // temp API to maintain forward/backward compactibility
-  void prepareToProcessPeerData(
-      size_t peerDataWidth,
-      const std::vector<int32_t>& indexes) override {
-    std::vector<uint64_t> uint64Index(indexes.size());
-    for (size_t i = 0; i < indexes.size(); i++) {
-      uint64Index.at(i) = indexes.at(i);
-    }
-    prepareToProcessPeerData(peerDataWidth, uint64Index);
-  }
-
   void prepareToProcessPeerData(
       size_t peerDataWidth,
       const std::vector<uint64_t>& indexes) override;

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpEncryption.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpEncryption.h
@@ -38,7 +38,8 @@ class UdpEncryption final : public IUdpEncryption {
   // with "ProcessPeerData" on peer's side. If this API is ever called, calling
   // "getExpandedKey" to retrive the expanded key for decryption later.
   void processMyData(
-      const std::vector<std::vector<unsigned char>>& plaintextData) override;
+      const std::vector<std::vector<unsigned char>>& plaintextData,
+      const std::vector<uint64_t>& indexes) override;
 
   std::vector<__m128i> getExpandedKey() override {
     if (statusOfProcessingMyData_ != Status::inProgress) {

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/test/DataProcessorTest.cpp
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/test/DataProcessorTest.cpp
@@ -191,8 +191,13 @@ void testUdpEncryptionAndDecryptionObjects(
                   const std::vector<uint64_t>& indexes,
                   const std::vector<size_t>& sizes) {
     udpEnc->prepareToProcessMyData(dataWidth);
+    size_t myDataIndexOffset = 0;
     for (size_t i = 0; i < plaintextDataInShards.size(); i++) {
-      udpEnc->processMyData(plaintextDataInShards.at(i));
+      std::vector<uint64_t> u64indexes(plaintextDataInShards.at(i).size());
+      // generate 0 to n-1 vector
+      std::iota(u64indexes.begin(), u64indexes.end(), myDataIndexOffset);
+      myDataIndexOffset += plaintextDataInShards.at(i).size();
+      udpEnc->processMyData(plaintextDataInShards.at(i), u64indexes);
     };
     udpEnc->prepareToProcessPeerData(dataWidth, indexes);
     for (size_t i = 0; i < sizes.size(); i++) {
@@ -249,8 +254,13 @@ void testUdpEncryptionAndDecryptionObjects(
       udpEnc->processPeerData(sizes.at(i));
     }
     udpEnc->prepareToProcessMyData(dataWidth);
+    size_t myDataIndexOffset = 0;
     for (size_t i = 0; i < plaintextDataInShards.size(); i++) {
-      udpEnc->processMyData(plaintextDataInShards.at(i));
+      std::vector<uint64_t> u64indexes(plaintextDataInShards.at(i).size());
+      // generate 0 to n-1 vector
+      std::iota(u64indexes.begin(), u64indexes.end(), myDataIndexOffset);
+      myDataIndexOffset += plaintextDataInShards.at(i).size();
+      udpEnc->processMyData(plaintextDataInShards.at(i), u64indexes);
     };
 
     auto [intersection, nonces, pickedIndexes] = udpEnc->getProcessedData();

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/test/UdpEncryptionMock.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/test/UdpEncryptionMock.h
@@ -31,11 +31,6 @@ class UdpEncryptionMock final : public IUdpEncryption {
       prepareToProcessPeerData,
       (size_t, const std::vector<uint64_t>&));
 
-  MOCK_METHOD(
-      void,
-      prepareToProcessPeerData,
-      (size_t, const std::vector<int32_t>&));
-
   MOCK_METHOD(void, processPeerData, (size_t));
 
   MOCK_METHOD(EncryptionResults, getProcessedData, ());

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/test/UdpEncryptionMock.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/test/UdpEncryptionMock.h
@@ -22,6 +22,12 @@ class UdpEncryptionMock final : public IUdpEncryption {
   MOCK_METHOD(
       void,
       processMyData,
+      (const std::vector<std::vector<unsigned char>>&,
+       const std::vector<uint64_t>& indexes));
+
+  MOCK_METHOD(
+      void,
+      processMyData,
       (const std::vector<std::vector<unsigned char>>&));
 
   MOCK_METHOD(std::vector<__m128i>, getExpandedKey, ());


### PR DESCRIPTION
Summary:
We will use 3 diffs to change the udp encryption API to support customized indexes.
This diff makes the change in fbpcf, while maintaining a temporary API for backward compatibility.
In the next diff, we will make the change in fbpcs, which complete the change.
In the last diff, we will clean up the temporary APIs in fbpcf.

Reviewed By: robotal

Differential Revision: D44242200

