### PR TITLE
clean up temp API in fbpcf

### DIFF
--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/IUdpEncryption.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/IUdpEncryption.h
@@ -33,13 +33,6 @@ class IUdpEncryption {
       const std::vector<std::vector<unsigned char>>& plaintextData,
       const std::vector<uint64_t>& indexes) = 0;
 
-  // a temp API to maintain backward compatibility
-  virtual void processMyData(
-      const std::vector<std::vector<unsigned char>>& plaintextData) {
-    processMyData(
-        plaintextData, std::vector<uint64_t>(plaintextData.size(), 0));
-  }
-
   virtual std::vector<__m128i> getExpandedKey() = 0;
 
   virtual void prepareToProcessPeerData(

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/test/UdpEncryptionMock.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/test/UdpEncryptionMock.h
@@ -25,11 +25,6 @@ class UdpEncryptionMock final : public IUdpEncryption {
       (const std::vector<std::vector<unsigned char>>&,
        const std::vector<uint64_t>& indexes));
 
-  MOCK_METHOD(
-      void,
-      processMyData,
-      (const std::vector<std::vector<unsigned char>>&));
-
   MOCK_METHOD(std::vector<__m128i>, getExpandedKey, ());
 
   MOCK_METHOD(


### PR DESCRIPTION
Summary:
We will use 3 diffs to change the udp encryption API to support customized indexes.

We will clean up the temporary APIs in fbpcf in this diff.

Reviewed By: robotal

Differential Revision: D44269800

