### PR TITLE
change udp util implementation to support customized indexes

### DIFF
--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/IUdpEncryption.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/IUdpEncryption.h
@@ -33,13 +33,6 @@ class IUdpEncryption {
       const std::vector<std::vector<unsigned char>>& plaintextData,
       const std::vector<uint64_t>& indexes) = 0;
 
-  // a temp API to maintain backward compatibility
-  virtual void processMyData(
-      const std::vector<std::vector<unsigned char>>& plaintextData) {
-    processMyData(
-        plaintextData, std::vector<uint64_t>(plaintextData.size(), 0));
-  }
-
   virtual std::vector<__m128i> getExpandedKey() = 0;
 
   virtual void prepareToProcessPeerData(

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpEncryption.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpEncryption.h
@@ -77,9 +77,6 @@ class UdpEncryption final : public IUdpEncryption {
  private:
   std::unique_ptr<engine::communication::IPartyCommunicationAgent> agent_;
 
-  uint64_t myDataIndexOffset_;
-  uint64_t peerDataIndexOffset_;
-
   size_t myDataWidth_;
   __m128i prgKey_;
 

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpUtil.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpUtil.h
@@ -29,6 +29,12 @@ class UdpUtil {
       __m128i prgKey,
       uint64_t indexOffset = 0);
 
+  static std::pair<std::vector<std::vector<uint8_t>>, std::vector<uint8_t>>
+  localEncryption(
+      const std::vector<std::vector<unsigned char>>& plaintextData,
+      __m128i prgKey,
+      const std::vector<uint64_t>& indexes);
+
   static std::vector<__m128i>
   generateCounterBlocks(__m128i nonce, uint64_t startingIndex, size_t size);
 

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/test/UdpEncryptionMock.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/test/UdpEncryptionMock.h
@@ -25,11 +25,6 @@ class UdpEncryptionMock final : public IUdpEncryption {
       (const std::vector<std::vector<unsigned char>>&,
        const std::vector<uint64_t>& indexes));
 
-  MOCK_METHOD(
-      void,
-      processMyData,
-      (const std::vector<std::vector<unsigned char>>&));
-
   MOCK_METHOD(std::vector<__m128i>, getExpandedKey, ());
 
   MOCK_METHOD(


### PR DESCRIPTION
Summary:
This diff changes the behavior of udp util to support customized indexes. This complete the task.

The integration test will be updated in the next diff to test this feature.

Reviewed By: robotal

Differential Revision:
D44242197

Privacy Context Container: L416713

