### PR TITLE
Split the test cases for oblivioustransfer to avoid timeout errors

### DIFF
--- a/fbpcf/engine/tuple_generator/oblivious_transfer/test/BidirectionObliviousTransferTest.cpp
+++ b/fbpcf/engine/tuple_generator/oblivious_transfer/test/BidirectionObliviousTransferTest.cpp
@@ -213,6 +213,11 @@ TEST(
           insecure::DummyRandomCorrelatedObliviousTransferFactory>(),
       std::make_unique<
           insecure::DummyRandomCorrelatedObliviousTransferFactory>());
+}
+
+TEST(
+    RcotBasedBidirectionObliviousTransferTest,
+    testBiDirectionOTWithDummyRcotForIntegers) {
   testRcotBasedBidirectionObliviousTransferForIntegers(
       std::make_unique<
           insecure::DummyRandomCorrelatedObliviousTransferFactory>(),
@@ -238,6 +243,11 @@ TEST(
           1024,
           128,
           8));
+}
+
+TEST(
+    RcotBasedBidirectionObliviousTransferTest,
+    testBiDirectionOTWithExtenderBasedRcotPoweredByDummyExtenderForIntegers) {
   testRcotBasedBidirectionObliviousTransferForIntegers(
       std::make_unique<ExtenderBasedRandomCorrelatedObliviousTransferFactory>(
           std::make_unique<
@@ -281,6 +291,10 @@ TEST(
           1024,
           128,
           8));
+}
+TEST(
+    RcotBasedBidirectionObliviousTransferTest,
+    testBiDirectionOTWithExtenderBasedRcotPoweredByFerretExtenderPoweredByDummyMpcotAndDummyMatrixMultiplerForIntegers) {
   testRcotBasedBidirectionObliviousTransferForIntegers(
       std::make_unique<ExtenderBasedRandomCorrelatedObliviousTransferFactory>(
           std::make_unique<
@@ -333,7 +347,7 @@ TEST(
 }
 TEST(
     RcotBasedBidirectionObliviousTransferTest,
-    testBiDirectionOTIntegerWithExtenderBasedRcotPoweredByFerretExtenderPoweredByDummyMpcotAnd10LocalLinearMatrixMultipler) {
+    testBiDirectionOTWithExtenderBasedRcotPoweredByFerretExtenderPoweredByDummyMpcotAnd10LocalLinearMatrixMultiplerForIntegers) {
   testRcotBasedBidirectionObliviousTransferForIntegers(
       std::make_unique<ExtenderBasedRandomCorrelatedObliviousTransferFactory>(
           std::make_unique<
@@ -359,7 +373,7 @@ TEST(
 TEST(
     RcotBasedBidirectionObliviousTransferTest,
     testBiDirectionOTWithExtenderBasedRcotPoweredByFerretExtenderPoweredByMpcotWithDummySpcotAnd10LocalLinearMatrixMultipler) {
-  testRcotBasedBidirectionObliviousTransfer(
+  testRcotBasedBidirectionObliviousTransferForIntegers(
       std::make_unique<ExtenderBasedRandomCorrelatedObliviousTransferFactory>(
           std::make_unique<
               insecure::DummyRandomCorrelatedObliviousTransferFactory>(),
@@ -384,6 +398,11 @@ TEST(
           1024,
           128,
           8));
+}
+
+TEST(
+    RcotBasedBidirectionObliviousTransferTest,
+    testBiDirectionOTWithExtenderBasedRcotPoweredByFerretExtenderPoweredByMpcotWithDummySpcotAnd10LocalLinearMatrixMultiplerForIntegers) {
   testRcotBasedBidirectionObliviousTransferForIntegers(
       std::make_unique<ExtenderBasedRandomCorrelatedObliviousTransferFactory>(
           std::make_unique<
@@ -438,7 +457,7 @@ TEST(
 }
 TEST(
     RcotBasedBidirectionObliviousTransferTest,
-    testBiDirectionOTIntegerWithExtenderBasedRcotPoweredByFerretExtenderPoweredByMpcotWithRealSpcotAnd10LocalLinearMatrixMultipler) {
+    testBiDirectionOTWithExtenderBasedRcotPoweredByFerretExtenderPoweredByMpcotWithRealSpcotAnd10LocalLinearMatrixMultiplerForIntegers) {
   testRcotBasedBidirectionObliviousTransferForIntegers(
       std::make_unique<ExtenderBasedRandomCorrelatedObliviousTransferFactory>(
           std::make_unique<
@@ -493,7 +512,7 @@ TEST(
 }
 TEST(
     RcotBasedBidirectionObliviousTransferTest,
-    testBiDirectionOTIntegerWithBootstrappedExtenderBasedRcotPoweredByFerretExtenderPoweredByMpcotWithRealSpcotAnd10LocalLinearMatrixMultipler) {
+    testBiDirectionOTWithBootstrappedExtenderBasedRcotPoweredByFerretExtenderPoweredByMpcotWithRealSpcotAnd10LocalLinearMatrixMultiplerForIntegers) {
   testRcotBasedBidirectionObliviousTransferForIntegers(
       std::make_unique<ExtenderBasedRandomCorrelatedObliviousTransferFactory>(
           std::make_unique<tuple_generator::oblivious_transfer::


### PR DESCRIPTION
Summary:
We have previously seen an oncall task T145020747 that some tests are flaky because they exceed the 600s limit.  We have released a diff D43200388  to reduce the likelihood of this timeout issue and we recommend to extend this solution to other tests that call multiple functions (T145644394).

This diff splits the test cases to reduce the time needed to execute each test case in the BidirectionObliviousTransferTest.cpp file

Reviewed By: adshastri

Differential Revision: D44388804

