### PR TITLE
Clear out the ctx variables ASAP in TLS code

### DIFF
--- a/fbpcf/engine/communication/SocketPartyCommunicationAgent.cpp
+++ b/fbpcf/engine/communication/SocketPartyCommunicationAgent.cpp
@@ -255,6 +255,7 @@ void SocketPartyCommunicationAgent::openServerPortWithTls(
   auto acceptedConnection = receiveFromClient(sockFd);
 
   const auto ssl = SSL_new(ctx);
+  SSL_CTX_free(ctx);
   SSL_set_fd(ssl, acceptedConnection);
 
   // Accept handshake from client
@@ -326,6 +327,7 @@ void SocketPartyCommunicationAgent::openServerPortWithTls(
   auto acceptedConnection = receiveFromClient(sockFd);
 
   const auto ssl = SSL_new(ctx);
+  SSL_CTX_free(ctx);
   SSL_set_fd(ssl, acceptedConnection);
 
   // Accept handshake from client
@@ -362,7 +364,7 @@ void SocketPartyCommunicationAgent::openClientPortWithTls(
   }
 
   SSL* ssl = SSL_new(ctx);
-
+  SSL_CTX_free(ctx);
   if (ssl == nullptr) {
     auto errorMsg = getErrorInfo();
     XLOGF(INFO, "error message: {}", errorMsg);
@@ -425,7 +427,7 @@ void SocketPartyCommunicationAgent::openClientPortWithTls(
       params, serverAddress.c_str(), serverAddress.size());
 
   SSL* ssl = SSL_new(ctx);
-
+  SSL_CTX_free(ctx);
   if (ssl == nullptr) {
     auto errorMsg = getErrorInfo();
     XLOGF(INFO, "error message: {}", errorMsg);

--- a/fbpcf/engine/communication/SocketPartyCommunicationAgent.cpp
+++ b/fbpcf/engine/communication/SocketPartyCommunicationAgent.cpp
@@ -224,17 +224,29 @@ void SocketPartyCommunicationAgent::openServerPortWithTls(
   }
 
   // Load the certificate file
-  if (SSL_CTX_use_certificate_file(
-          ctx, (tlsDir + "/" + CERT_FILE).c_str(), SSL_FILETYPE_PEM) <= 0) {
+  int ret;
+  XLOGF(
+      INFO,
+      "Using certificate file at: {}",
+      (tlsDir + "/" + CERT_FILE).c_str());
+  ret = SSL_CTX_use_certificate_file(
+      ctx, (tlsDir + "/" + CERT_FILE).c_str(), SSL_FILETYPE_PEM);
+  XLOGF(INFO, "Successfully loaded certificate file, return code {}.", ret);
+  if (ret <= 0) {
     auto errorMsg = getErrorInfo();
     XLOGF(INFO, "error message: {}", errorMsg);
     throw std::runtime_error("Error using certificate file " + errorMsg);
   }
 
   // Load the private key file
-  if (SSL_CTX_use_PrivateKey_file(
-          ctx, (tlsDir + "/" + PRIVATE_KEY_FILE).c_str(), SSL_FILETYPE_PEM) <=
-      0) {
+  XLOGF(
+      INFO,
+      "Using private key file at: {}",
+      (tlsDir + "/" + PRIVATE_KEY_FILE).c_str());
+  ret = SSL_CTX_use_PrivateKey_file(
+      ctx, (tlsDir + "/" + PRIVATE_KEY_FILE).c_str(), SSL_FILETYPE_PEM);
+  XLOGF(INFO, "Successfully loaded private key file, return code {}.", ret);
+  if (ret <= 0) {
     auto errorMsg = getErrorInfo();
     XLOGF(INFO, "error message: {}", errorMsg);
     throw std::runtime_error("Error using private key file " + errorMsg);
@@ -289,8 +301,11 @@ void SocketPartyCommunicationAgent::openServerPortWithTls(
 
   // Load the certificate file
   XLOGF(INFO, "Using certificate file at: {}", tlsInfo.certPath);
-  if (SSL_CTX_use_certificate_file(
-          ctx, (tlsInfo.certPath).c_str(), SSL_FILETYPE_PEM) <= 0) {
+  int ret = SSL_CTX_use_certificate_file(
+      ctx, (tlsInfo.certPath).c_str(), SSL_FILETYPE_PEM);
+  XLOGF(INFO, "Successfully loaded certificate file, return code {}.", ret);
+
+  if (ret <= 0) {
     auto errorMsg = getErrorInfo();
     XLOGF(INFO, "error message: {}", errorMsg);
     throw std::runtime_error("Error using certificate file " + errorMsg);
@@ -298,8 +313,11 @@ void SocketPartyCommunicationAgent::openServerPortWithTls(
 
   // Load the private key file
   XLOGF(INFO, "Using private key file at: {}", tlsInfo.keyPath);
-  if (SSL_CTX_use_PrivateKey_file(
-          ctx, (tlsInfo.keyPath).c_str(), SSL_FILETYPE_PEM) <= 0) {
+  ret = SSL_CTX_use_PrivateKey_file(
+      ctx, (tlsInfo.keyPath).c_str(), SSL_FILETYPE_PEM);
+  XLOGF(INFO, "Successfully loaded private key file, return code {}.", ret);
+
+  if (ret <= 0) {
     auto errorMsg = getErrorInfo();
     XLOGF(INFO, "error message: {}", errorMsg);
     throw std::runtime_error("Error using private key file " + errorMsg);


### PR DESCRIPTION
Summary: There are some resources in CTX variables that should be freed asap to avoid overflow, as fixed in this diff

Reviewed By: danbunnell, robotal

Differential Revision: D46215800

