### PR TITLE
Fix shadowed variable in fbpcf/mpc_std_lib/unified_data_process/data_processor/test/DataProcessorTest.cpp

### DIFF
--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/test/DataProcessorTest.cpp
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/test/DataProcessorTest.cpp
@@ -188,7 +188,7 @@ void testUdpEncryptionAndDecryptionObjects(
                       plaintextDataInShards,
                   size_t dataWidth,
                   size_t outputSize,
-                  const std::vector<uint64_t>& indexes,
+                  const std::vector<uint64_t>& indexes_2,
                   const std::vector<size_t>& sizes) {
     udpEnc->prepareToProcessMyData(dataWidth);
     size_t myDataIndexOffset = 0;
@@ -199,7 +199,7 @@ void testUdpEncryptionAndDecryptionObjects(
       myDataIndexOffset += plaintextDataInShards.at(i).size();
       udpEnc->processMyData(plaintextDataInShards.at(i), u64indexes);
     };
-    udpEnc->prepareToProcessPeerData(dataWidth, indexes);
+    udpEnc->prepareToProcessPeerData(dataWidth, indexes_2);
     for (size_t i = 0; i < sizes.size(); i++) {
       udpEnc->processPeerData(sizes.at(i));
     }
@@ -244,12 +244,12 @@ void testUdpEncryptionAndDecryptionObjects(
   auto task1 = [](std::unique_ptr<UdpEncryption> udpEnc,
                   std::unique_ptr<UdpDecryption<1>> udpDec0,
                   std::unique_ptr<UdpDecryption<3>> udpDec1,
-                  const std::vector<uint64_t>& indexes,
+                  const std::vector<uint64_t>& indexes_2,
                   const std::vector<size_t>& sizes,
                   const std::vector<std::vector<std::vector<unsigned char>>>&
                       plaintextDataInShards,
                   size_t dataWidth) {
-    udpEnc->prepareToProcessPeerData(dataWidth, indexes);
+    udpEnc->prepareToProcessPeerData(dataWidth, indexes_2);
     for (size_t i = 0; i < sizes.size(); i++) {
       udpEnc->processPeerData(sizes.at(i));
     }


### PR DESCRIPTION
Summary:
Our upcoming compiler upgrade will require us not to have shadowed variables. Such variables have a _high_ bug rate and reduce readability, so we would like to avoid them even if the compiler was not forcing us to do so.

This codemod attempts to fix an instance of a shadowed variable. Please review with care: if it's failed the result will be a silent bug.

**What's a shadowed variable?**

Shadowed variables are variables in an inner scope with the same name as another variable in an outer scope. Having the same name for both variables might be semantically correct, but it can make the code confusing to read! It can also hide subtle bugs.

This diff fixes such an issue by renaming the variable.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: palmje

Differential Revision: D52582932


