### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -98,7 +98,7 @@ jobs:
 
     - name: Set output
       id: vars
-      run: echo ::set-output name=ref::${GITHUB_REF##*/}
+      run: echo "ref=${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
 
     - name: Pull image for this commit from registry
       run: |


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter