### PR TITLE
Remove extra semi colon from fbpcf/mpc/IMpcGame.h

### DIFF
--- a/fbpcf/mpc/IMpcGame.h
+++ b/fbpcf/mpc/IMpcGame.h
@@ -15,7 +15,7 @@ namespace fbpcf {
 template <class InputDataType, class OutputDataType>
 class IMpcGame {
  public:
-  virtual ~IMpcGame(){};
+  virtual ~IMpcGame() {}
 
   OutputDataType perfPlay(const InputDataType& inputData) {
     auto decorator = fbpcf::perf::decorate(


### PR DESCRIPTION
Summary:
`-Wextra-semi` or `-Wextra-semi-stmt`

If the code compiles, this is safe to land.

Reviewed By: dmm-fb

Differential Revision: D52969050


