### PR TITLE
Remove unused variables in fbpcf/mpc_std_lib/unified_data_process/serialization/RowStructureDefinition.h

### DIFF
--- a/fbpcf/mpc_std_lib/unified_data_process/serialization/RowStructureDefinition.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/serialization/RowStructureDefinition.h
@@ -158,7 +158,6 @@ class RowStructureDefinition : public IRowStructureDefinition<schedulerId> {
              columnDefinition : *columnDefinitions_.get()) {
       const IColumnDefinition<schedulerId>* columnPointer =
           columnDefinition.get();
-      auto columnType = columnDefinition->getColumnType();
 
       if (columnDefinition->getColumnType() ==
           IColumnDefinition<


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code, or (b) qualifies the variable with `[[maybe_unused]]`, mostly in cases where the variable _is_ used, but, eg, in an `assert` statement that isn't present in production code.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: palmje

Differential Revision: D53779568


