### PR TITLE
Remove semicolon(s) from 3 files inc fboss/lib/AlertLogger.cpp

### DIFF
--- a/fbpcf/engine/communication/test/AgentFactoryCreationHelper.h
+++ b/fbpcf/engine/communication/test/AgentFactoryCreationHelper.h
@@ -117,6 +117,6 @@ getSocketAgentFactoryPair(
   getSocketFactoriesForMultipleParties(2, tlsInfo, factories);
 
   return {std::move(factories.at(0)), std::move(factories.at(1))};
-};
+}
 
 } // namespace fbpcf::engine::communication


### PR DESCRIPTION
Summary:
`-Wextra-semi` or `-Wextra-semi-stmt` found an extra semi

If the code compiles, this is safe to land.

Reviewed By: palmje, dmm-fb

Differential Revision: D53776137


