### PR TITLE
Fix unsafe fallthrough at fbcode/fbpcf/scheduler/gate_keeper/BatchCompositeGate.h:63

### DIFF
--- a/fbpcf/scheduler/gate_keeper/BatchCompositeGate.h
+++ b/fbpcf/scheduler/gate_keeper/BatchCompositeGate.h
@@ -58,6 +58,7 @@ class BatchCompositeGate final : public ICompositeGate {
               engine.computeBatchFreeAND(
                   leftValues, wireKeeper_.getBatchBooleanValue(rights_[i])));
         }
+        break;
       }
 
       case GateType::NonFreeAnd: {


### PR DESCRIPTION
Summary:
details in T179856888

**context**

LLVM has detected an implicit fallthrough near fbcode/fbpcf/scheduler/gate_keeper/BatchCompositeGate.h:63. Implicit fallthroughs have a very high bug rate, so we are making them a compiler error by default.

Differential Revision: D54025656


