### PR TITLE
Deshim //folly:dynamic to //folly/json:dynamic in fbpcf

### DIFF
--- a/example/billionaire_problem/main.cpp
+++ b/example/billionaire_problem/main.cpp
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <folly/json.h>
+#include <folly/json/json.h>
 
 #include <gflags/gflags.h>
 #include "fbpcf/scheduler/LazySchedulerFactory.h"

--- a/example/edit_distance/EditDistanceCalculator_impl.h
+++ b/example/edit_distance/EditDistanceCalculator_impl.h
@@ -7,10 +7,10 @@
 
 #pragma once
 
-#include <folly/json.h>
+#include <folly/json/json.h>
 #include <stdexcept>
 #include "./EditDistanceCalculator.h" // @manual
-#include "folly/dynamic.h"
+#include "folly/json/dynamic.h"
 #include "folly/logging/xlog.h"
 
 namespace fbpcf::edit_distance {

--- a/example/edit_distance/EditDistanceResults.h
+++ b/example/edit_distance/EditDistanceResults.h
@@ -9,7 +9,7 @@
 
 #include "./MPCTypes.h" // @manual
 #include "fbpcf/exception/exceptions.h"
-#include "folly/dynamic.h"
+#include "folly/json/dynamic.h"
 
 namespace fbpcf::edit_distance {
 struct EditDistanceResults {

--- a/example/edit_distance/Validator.cpp
+++ b/example/edit_distance/Validator.cpp
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <folly/json.h>
+#include <folly/json/json.h>
 #include <folly/logging/xlog.h>
 #include <math.h>
 #include <sstream>

--- a/example/edit_distance/test/EditDistanceAppTest.cpp
+++ b/example/edit_distance/test/EditDistanceAppTest.cpp
@@ -7,7 +7,7 @@
 
 #include "../EditDistanceApp.h" // @manual
 #include <folly/Format.h>
-#include <folly/json.h>
+#include <folly/json/json.h>
 #include <gtest/gtest.h>
 #include <fstream>
 #include "../EditDistanceResults.h" // @manual

--- a/example/edit_distance/test/EditDistanceCalculatorTest.cpp
+++ b/example/edit_distance/test/EditDistanceCalculatorTest.cpp
@@ -6,7 +6,7 @@
  */
 
 #include "../EditDistanceCalculator.h" // @manual
-#include <folly/json.h>
+#include <folly/json/json.h>
 #include <gtest/gtest.h>
 #include <memory>
 #include "../EditDistanceInputReader.h" // @manual

--- a/fbpcf/engine/communication/IPartyCommunicationAgentFactory.h
+++ b/fbpcf/engine/communication/IPartyCommunicationAgentFactory.h
@@ -8,7 +8,7 @@
 #pragma once
 #include <memory>
 
-#include <folly/dynamic.h>
+#include <folly/json/dynamic.h>
 #include "fbpcf/engine/communication/IPartyCommunicationAgent.h"
 #include "fbpcf/util/MetricCollector.h"
 

--- a/fbpcf/engine/communication/test/PartyCommunicationAgentTest.cpp
+++ b/fbpcf/engine/communication/test/PartyCommunicationAgentTest.cpp
@@ -18,7 +18,7 @@
 #include <thread>
 #include <vector>
 
-#include <folly/dynamic.h>
+#include <folly/json/dynamic.h>
 #include "fbpcf/engine/communication/InMemoryPartyCommunicationAgentFactory.h"
 #include "fbpcf/engine/communication/InMemoryPartyCommunicationAgentHost.h"
 #include "fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h"

--- a/fbpcf/util/IMetricRecorder.h
+++ b/fbpcf/util/IMetricRecorder.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <folly/dynamic.h>
+#include <folly/json/dynamic.h>
 
 namespace fbpcf::util {
 /**

--- a/fbpcf/util/MetricCollector.h
+++ b/fbpcf/util/MetricCollector.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <folly/dynamic.h>
+#include <folly/json/dynamic.h>
 #include <folly/logging/xlog.h>
 #include <string>
 #include <unordered_map>

--- a/fbpcf/util/test/MetricCollectorTest.cpp
+++ b/fbpcf/util/test/MetricCollectorTest.cpp
@@ -6,7 +6,7 @@
  */
 
 #include "fbpcf/util/MetricCollector.h"
-#include <folly/dynamic.h>
+#include <folly/json/dynamic.h>
 #include <gtest/gtest.h>
 
 namespace fbpcf::util {


### PR DESCRIPTION
Summary:
The following headers were shimmed in //folly:dynamic and were modded:
  - folly/DynamicConverter.h -> folly/json/DynamicConverter.h
  - folly/dynamic.h -> folly/json/dynamic.h
  - folly/dynamic-inl.h -> folly/json/dynamic-inl.h
  - folly/json.h -> folly/json/json.h

`arc lint` was applied

Reviewed By: bcardosolopes

Differential Revision: D53837058


