### PR TITLE
Remove unused variables in fboss/agent/state/Interface.cpp

### DIFF
--- a/fbpcf/frontend/test/benchmarks/FrontendBenchmark.cpp
+++ b/fbpcf/frontend/test/benchmarks/FrontendBenchmark.cpp
@@ -19,7 +19,7 @@
 
 namespace fbpcf::frontend {
 
-const bool unsafe = true;
+// const bool unsafe = true;
 const uint32_t batchSize = 1000;
 
 template <class Game0, class Game1>


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code, or (b) qualifies the variable with `[[maybe_unused]]`, mostly in cases where the variable _is_ used, but, eg, in an `assert` statement that isn't present in production code.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: peygar

Differential Revision: D55099975


