### PR TITLE
Remove extra semi colon from fb_mysql/8.0.28/rocksdb/util/murmurhash.cc

### DIFF
--- a/fbpcf/mpc/EmpApp.h
+++ b/fbpcf/mpc/EmpApp.h
@@ -39,7 +39,7 @@ class EmpApp {
         useTls_{false},
         tlsDir_{""} {}
 
-  virtual ~EmpApp(){};
+  virtual ~EmpApp() {}
 
   virtual void run() {
     auto io = std::make_unique<emp::NetIO>(
@@ -51,7 +51,7 @@ class EmpApp {
     auto output = game.perfPlay(inputData);
 
     putOutputData(output);
-  };
+  }
 
  protected:
   virtual InputDataType getInputData() = 0;


### PR DESCRIPTION
Summary:
`-Wextra-semi` or `-Wextra-semi-stmt`

If the code compiles, this is safe to land.

Reviewed By: palmje

Differential Revision: D55087362


