### PR TITLE
Remove unused variables in fbit/itstorage/data_crawler/thread/ThreadedCrawler.cpp

### DIFF
--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/DataProcessor_impl.h
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/DataProcessor_impl.h
@@ -23,7 +23,6 @@ typename IDataProcessor<schedulerId>::SecString
 DataProcessor<schedulerId>::processMyData(
     const std::vector<std::vector<unsigned char>>& plaintextData,
     size_t outputSize) {
-  size_t dataSize = plaintextData.size();
   size_t dataWidth = plaintextData.at(0).size();
   std::vector<uint64_t> indexes(plaintextData.size());
   // generate 0 to n-1 vector


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code, or (b) qualifies the variable with `[[maybe_unused]]`, mostly in cases where the variable _is_ used, but, eg, in an `assert` statement that isn't present in production code.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: palmje

Differential Revision: D56022415


