### PR TITLE
Fix deprecated dynamic exception in fbpcf/exception/exceptions.h +1

### DIFF
--- a/fbpcf/exception/exceptions.h
+++ b/fbpcf/exception/exceptions.h
@@ -169,7 +169,7 @@ class ConnectionError : virtual public std::exception {
  public:
   explicit ConnectionError(std::string msg) : msg_{msg} {}
 
-  const char* what() const throw() override {
+  const char* what() const noexcept override {
     return msg_.c_str();
   }
 


### PR DESCRIPTION
Summary:
LLVM has detected a violation of `-Wdeprecated-dynamic-exception-spec`. Dynamic exceptions were removed in C++17. This diff fixes the deprecated instance(s).

See [Dynamic exception specification](https://en.cppreference.com/w/cpp/language/except_spec) and [noexcept specifier](https://en.cppreference.com/w/cpp/language/noexcept_spec).

Differential Revision: D58182139


