### PR TITLE
Put the Github repo in maintenance mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+![Maintenance Mode](https://img.shields.io/badge/maintenance%20mode-%E2%9C%94%EF%B8%8F-red)
+**THIS PROJECT IS CURRENTLY IN MAINTENANCE MODE. Only critical bug patches will be applied; no new features will be added.**
+
+---
+
 # PCF (Private Computation Framework)
 
 ## Project Description


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/fbpcs/pull/2407

According to our guideline (https://fb.workplace.com/groups/164332244998024/permalink/1234195941344977/), updating our open sourced repos with a sentence to indicate it's in maintenance mode.

Please let me know if the sentences are need to be rephrased.

Reviewed By: ajinkya-ghonge, jinxinl22

Differential Revision: D58255798
