### PR TITLE
facebook-unused-include-check in fbcode/fbpcf/engine/tuple_generator/oblivious_transfer

### DIFF
--- a/fbpcf/engine/tuple_generator/oblivious_transfer/DummyBidirectionObliviousTransfer.cpp
+++ b/fbpcf/engine/tuple_generator/oblivious_transfer/DummyBidirectionObliviousTransfer.cpp
@@ -6,7 +6,6 @@
  */
 
 #include "fbpcf/engine/tuple_generator/oblivious_transfer/DummyBidirectionObliviousTransfer.h"
-#include <sys/types.h>
 #include <cstdint>
 
 namespace fbpcf::engine::tuple_generator::oblivious_transfer::insecure {

--- a/fbpcf/engine/tuple_generator/oblivious_transfer/EmpShRandomCorrelatedObliviousTransfer.cpp
+++ b/fbpcf/engine/tuple_generator/oblivious_transfer/EmpShRandomCorrelatedObliviousTransfer.cpp
@@ -6,7 +6,6 @@
  */
 
 #include <emmintrin.h>
-#include <smmintrin.h>
 
 #include "fbpcf/engine/tuple_generator/oblivious_transfer/EmpShRandomCorrelatedObliviousTransfer.h"
 #include "fbpcf/engine/util/EmpNetworkAdapter.h"

--- a/fbpcf/engine/tuple_generator/oblivious_transfer/IknpShRandomCorrelatedObliviousTransfer.cpp
+++ b/fbpcf/engine/tuple_generator/oblivious_transfer/IknpShRandomCorrelatedObliviousTransfer.cpp
@@ -7,7 +7,6 @@
 
 #include "fbpcf/engine/tuple_generator/oblivious_transfer/IknpShRandomCorrelatedObliviousTransfer.h"
 #include <emmintrin.h>
-#include <sys/types.h>
 #include <stdexcept>
 #include "fbpcf/engine/util/util.h"
 

--- a/fbpcf/engine/tuple_generator/oblivious_transfer/RcotBasedBidirectionObliviousTransfer.cpp
+++ b/fbpcf/engine/tuple_generator/oblivious_transfer/RcotBasedBidirectionObliviousTransfer.cpp
@@ -7,7 +7,6 @@
 
 #include "fbpcf/engine/tuple_generator/oblivious_transfer/RcotBasedBidirectionObliviousTransfer.h"
 #include <emmintrin.h>
-#include <smmintrin.h>
 #include <future>
 #include <thread>
 #include <vector>

--- a/fbpcf/engine/tuple_generator/oblivious_transfer/ferret/DummyMultiPointCot.cpp
+++ b/fbpcf/engine/tuple_generator/oblivious_transfer/ferret/DummyMultiPointCot.cpp
@@ -7,7 +7,6 @@
 
 #include <assert.h>
 #include <emmintrin.h>
-#include <string.h>
 #include <algorithm>
 #include <random>
 #include "fbpcf/engine/util/util.h"

--- a/fbpcf/engine/tuple_generator/oblivious_transfer/ferret/DummySinglePointCot.cpp
+++ b/fbpcf/engine/tuple_generator/oblivious_transfer/ferret/DummySinglePointCot.cpp
@@ -8,7 +8,6 @@
 #include "fbpcf/engine/tuple_generator/oblivious_transfer/ferret/DummySinglePointCot.h"
 #include <assert.h>
 #include <emmintrin.h>
-#include <string.h>
 #include <algorithm>
 #include <cstddef>
 #include <random>

--- a/fbpcf/engine/tuple_generator/oblivious_transfer/ferret/RcotExtender.cpp
+++ b/fbpcf/engine/tuple_generator/oblivious_transfer/ferret/RcotExtender.cpp
@@ -12,8 +12,6 @@
 #include <iterator>
 #include <locale>
 #include <memory>
-#include <stdexcept>
-#include <string>
 
 #include "fbpcf/engine/tuple_generator/oblivious_transfer/ferret/RcotExtender.h"
 #include "fbpcf/engine/util/util.h"

--- a/fbpcf/engine/tuple_generator/oblivious_transfer/ferret/test/MatrixMultiplierTest.cpp
+++ b/fbpcf/engine/tuple_generator/oblivious_transfer/ferret/test/MatrixMultiplierTest.cpp
@@ -8,7 +8,6 @@
 #include <emmintrin.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include <immintrin.h>
 #include <future>
 #include <memory>
 

--- a/fbpcf/engine/tuple_generator/oblivious_transfer/ferret/test/MultiPointCotTest.cpp
+++ b/fbpcf/engine/tuple_generator/oblivious_transfer/ferret/test/MultiPointCotTest.cpp
@@ -8,7 +8,6 @@
 #include <emmintrin.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include <immintrin.h>
 #include <future>
 #include <memory>
 #include <random>

--- a/fbpcf/engine/tuple_generator/oblivious_transfer/ferret/test/SinglePointCotTest.cpp
+++ b/fbpcf/engine/tuple_generator/oblivious_transfer/ferret/test/SinglePointCotTest.cpp
@@ -8,7 +8,6 @@
 #include <emmintrin.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include <immintrin.h>
 #include <future>
 #include <memory>
 #include <random>

--- a/fbpcf/engine/tuple_generator/oblivious_transfer/test/BaseObliviousTransferTest.cpp
+++ b/fbpcf/engine/tuple_generator/oblivious_transfer/test/BaseObliviousTransferTest.cpp
@@ -7,7 +7,6 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include <smmintrin.h>
 #include <future>
 #include <memory>
 #include <random>

--- a/fbpcf/engine/tuple_generator/oblivious_transfer/test/RandomCorrelatedObliviousTransferTest.cpp
+++ b/fbpcf/engine/tuple_generator/oblivious_transfer/test/RandomCorrelatedObliviousTransferTest.cpp
@@ -9,7 +9,6 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <smmintrin.h>
-#include <xmmintrin.h>
 #include <future>
 #include <memory>
 #include <random>


### PR DESCRIPTION
Summary:
Remove headers flagged by facebook-unused-include-check over fbcode.fbpcf.engine.tuple_generator.oblivious_transfer.

+ format and autodeps

This is a codemod. It was automatically generated and will be landed once it is approved and tests are passing in sandcastle.
You have been added as a reviewer by Sentinel or Butterfly.

Autodiff project: uif
Autodiff partition: fbcode.fbpcf.engine.tuple_generator.oblivious_transfer
Autodiff bookmark: ad.uif.fbcode.fbpcf.engine.tuple_generator.oblivious_transfer

Reviewed By: dtolnay

Differential Revision: D65957945


