### PR TITLE
facebook-unused-include-check in fbcode/fbpcf

### DIFF
--- a/example/billionaire_problem/test/BillionaireProblemGameTest.cpp
+++ b/example/billionaire_problem/test/BillionaireProblemGameTest.cpp
@@ -19,12 +19,9 @@
 #include "fbpcf/scheduler/IScheduler.h"
 #include "fbpcf/scheduler/PlaintextScheduler.h"
 #include "fbpcf/scheduler/SchedulerHelper.h"
-#include "fbpcf/scheduler/WireKeeper.h"
 #include "fbpcf/test/TestHelper.h"
 
 #include "fbpcf/engine/SecretShareEngineFactory.h"
-#include "fbpcf/engine/communication/InMemoryPartyCommunicationAgentFactory.h"
-#include "fbpcf/scheduler/EagerScheduler.h"
 
 namespace fbpcf::billionaire_problem {
 

--- a/example/edit_distance/Validator.cpp
+++ b/example/edit_distance/Validator.cpp
@@ -11,7 +11,6 @@
 #include <sstream>
 
 #include "./Validator.h" // @manual
-#include "fbpcf/exception/exceptions.h"
 #include "fbpcf/io/api/FileIOWrappers.h"
 
 namespace fbpcf::edit_distance {

--- a/example/edit_distance/test/EditDistanceAppTest.cpp
+++ b/example/edit_distance/test/EditDistanceAppTest.cpp
@@ -9,7 +9,6 @@
 #include <folly/Format.h>
 #include <folly/json.h>
 #include <gtest/gtest.h>
-#include <fstream>
 #include "../EditDistanceResults.h" // @manual
 #include "../MPCTypes.h" // @manual
 #include "./Constants.h" // @manual

--- a/fbpcf/aws/S3Util.cpp
+++ b/fbpcf/aws/S3Util.cpp
@@ -21,7 +21,6 @@
 
 #include <boost/algorithm/string.hpp>
 #include <folly/Format.h>
-#include <folly/String.h>
 #include <folly/Uri.h>
 #include <re2/re2.h>
 

--- a/fbpcf/aws/test/S3UtilTest.cpp
+++ b/fbpcf/aws/test/S3UtilTest.cpp
@@ -7,7 +7,6 @@
 
 #include "fbpcf/aws/S3Util.h"
 
-#include <stdexcept>
 #include <string>
 
 #include <gtest/gtest.h>

--- a/fbpcf/engine/SecretShareEngine.cpp
+++ b/fbpcf/engine/SecretShareEngine.cpp
@@ -6,10 +6,8 @@
  */
 
 #include <fmt/format.h>
-#include <sys/types.h>
 #include <cstddef>
 #include <cstdint>
-#include <exception>
 #include <iterator>
 #include <memory>
 #include <stdexcept>

--- a/fbpcf/engine/communication/SocketPartyCommunicationAgent.cpp
+++ b/fbpcf/engine/communication/SocketPartyCommunicationAgent.cpp
@@ -11,7 +11,6 @@
 #include <assert.h>
 #include <netdb.h>
 #include <netinet/in.h>
-#include <openssl/err.h>
 #include <openssl/ssl.h>
 #include <openssl/x509.h>
 #include <string.h>
@@ -24,7 +23,6 @@
 #include <stdexcept>
 #include <thread>
 
-#include <folly/String.h>
 #include "folly/logging/xlog.h"
 
 namespace fbpcf::engine::communication {

--- a/fbpcf/engine/communication/test/PartyCommunicationAgentTest.cpp
+++ b/fbpcf/engine/communication/test/PartyCommunicationAgentTest.cpp
@@ -20,7 +20,6 @@
 
 #include <folly/dynamic.h>
 #include "fbpcf/engine/communication/InMemoryPartyCommunicationAgentFactory.h"
-#include "fbpcf/engine/communication/InMemoryPartyCommunicationAgentHost.h"
 #include "fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h"
 #include "fbpcf/engine/communication/test/AgentFactoryCreationHelper.h"
 #include "fbpcf/engine/communication/test/SocketInTestHelper.h"

--- a/fbpcf/engine/communication/test/SecretShareEngineCommunicationAgentTest.cpp
+++ b/fbpcf/engine/communication/test/SecretShareEngineCommunicationAgentTest.cpp
@@ -13,7 +13,6 @@
 #include <random>
 #include <thread>
 #include <vector>
-#include "fbpcf/engine/communication/InMemoryPartyCommunicationAgentHost.h"
 #include "fbpcf/engine/communication/test/SecretShareEngineCommunicationAgentTestHelper.h"
 
 namespace fbpcf::engine::communication {

--- a/fbpcf/engine/test/SecretShareEngineTest.cpp
+++ b/fbpcf/engine/test/SecretShareEngineTest.cpp
@@ -7,13 +7,11 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include <regex.h>
 #include <cstdint>
 #include <functional>
 #include <future>
 #include <memory>
 #include <random>
-#include <stdexcept>
 #include <thread>
 #include <utility>
 #include <vector>
@@ -21,9 +19,7 @@
 #include "fbpcf/engine/DummySecretShareEngine.h"
 #include "fbpcf/engine/DummySecretShareEngineFactory.h"
 #include "fbpcf/engine/ISecretShareEngine.h"
-#include "fbpcf/engine/SecretShareEngine.h"
 #include "fbpcf/engine/SecretShareEngineFactory.h"
-#include "fbpcf/engine/communication/IPartyCommunicationAgent.h"
 #include "fbpcf/engine/communication/test/AgentFactoryCreationHelper.h"
 #include "fbpcf/util/MetricCollector.h"
 

--- a/fbpcf/engine/tuple_generator/TwoPartyTupleGenerator.cpp
+++ b/fbpcf/engine/tuple_generator/TwoPartyTupleGenerator.cpp
@@ -6,7 +6,6 @@
  */
 
 #include "fbpcf/engine/tuple_generator/TwoPartyTupleGenerator.h"
-#include <stdexcept>
 #include "fbpcf/engine/util/AesPrg.h"
 #include "fbpcf/engine/util/util.h"
 

--- a/fbpcf/engine/tuple_generator/test/ProductShareGeneratorTest.cpp
+++ b/fbpcf/engine/tuple_generator/test/ProductShareGeneratorTest.cpp
@@ -7,7 +7,6 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include <sys/types.h>
 #include <cstdint>
 #include <functional>
 #include <future>
@@ -16,7 +15,6 @@
 #include <thread>
 
 #include "fbpcf/engine/communication/InMemoryPartyCommunicationAgentFactory.h"
-#include "fbpcf/engine/communication/InMemoryPartyCommunicationAgentHost.h"
 #include "fbpcf/engine/communication/test/AgentFactoryCreationHelper.h"
 #include "fbpcf/engine/tuple_generator/DummyProductShareGenerator.h"
 #include "fbpcf/engine/tuple_generator/DummyProductShareGeneratorFactory.h"
@@ -24,7 +22,6 @@
 #include "fbpcf/engine/tuple_generator/ProductShareGenerator.h"
 #include "fbpcf/engine/tuple_generator/ProductShareGeneratorFactory.h"
 #include "fbpcf/engine/tuple_generator/oblivious_transfer/DummyBidirectionObliviousTransferFactory.h"
-#include "fbpcf/engine/tuple_generator/oblivious_transfer/EmpShRandomCorrelatedObliviousTransferFactory.h"
 #include "fbpcf/engine/tuple_generator/oblivious_transfer/ExtenderBasedRandomCorrelatedObliviousTransferFactory.h"
 #include "fbpcf/engine/tuple_generator/oblivious_transfer/RcotBasedBidirectionObliviousTransferFactory.h"
 #include "fbpcf/engine/tuple_generator/oblivious_transfer/RcotHelper.h"

--- a/fbpcf/gcp/test/GCSUtilTest.cpp
+++ b/fbpcf/gcp/test/GCSUtilTest.cpp
@@ -7,7 +7,6 @@
 
 #include "fbpcf/gcp/GCSUtil.h"
 
-#include <stdexcept>
 #include <string>
 
 #include <gtest/gtest.h>

--- a/fbpcf/io/S3FileManager.cpp
+++ b/fbpcf/io/S3FileManager.cpp
@@ -16,7 +16,6 @@
 #include <aws/s3/model/PutObjectRequest.h> // @manual
 #include <string>
 
-#include "LocalFileManager.h"
 #include "S3InputStream.h"
 #include "fbpcf/aws/S3Util.h"
 #include "fbpcf/exception/AwsException.h"

--- a/fbpcf/io/api/test/FileIOWrappersTest.cpp
+++ b/fbpcf/io/api/test/FileIOWrappersTest.cpp
@@ -11,7 +11,6 @@
 #include <gtest/gtest.h>
 #include <stdio.h>
 #include <filesystem>
-#include <random>
 #include <string>
 #include "fbpcf/io/api/test/utils/IOTestHelper.h"
 #include "folly/Random.h"

--- a/fbpcf/io/cloud_util/GCSFileUploader.cpp
+++ b/fbpcf/io/cloud_util/GCSFileUploader.cpp
@@ -9,7 +9,6 @@
 
 #include <folly/logging/xlog.h>
 
-#include "fbpcf/exception/GcpException.h"
 #include "fbpcf/gcp/GCSUtil.h"
 
 namespace fbpcf::cloudio {

--- a/fbpcf/io/cloud_util/test/S3ClientTest.cpp
+++ b/fbpcf/io/cloud_util/test/S3ClientTest.cpp
@@ -7,7 +7,6 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include <stdlib.h>
 #include <cstdlib>
 #include <memory>
 

--- a/fbpcf/io/cloud_util/test/S3FileUploaderTest.cpp
+++ b/fbpcf/io/cloud_util/test/S3FileUploaderTest.cpp
@@ -7,7 +7,6 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include <stdlib.h>
 #include <cstdlib>
 #include <memory>
 

--- a/fbpcf/mpc/test/QueueIOTest.cpp
+++ b/fbpcf/mpc/test/QueueIOTest.cpp
@@ -8,7 +8,6 @@
 #include <array>
 #include <memory>
 #include <queue>
-#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/fbpcf/scheduler/LazyScheduler.cpp
+++ b/fbpcf/scheduler/LazyScheduler.cpp
@@ -8,17 +8,12 @@
 #include "fbpcf/scheduler/LazyScheduler.h"
 
 #include <cstdint>
-#include <exception>
 #include <map>
-#include <stdexcept>
-#include <string>
 
 #include <fbpcf/scheduler/gate_keeper/GateKeeper.h>
 #include <fbpcf/scheduler/gate_keeper/INormalGate.h>
-#include <sys/types.h>
 #include "fbpcf/scheduler/IScheduler.h"
 #include "fbpcf/scheduler/gate_keeper/IGate.h"
-#include "fbpcf/scheduler/gate_keeper/INormalGate.h"
 
 namespace fbpcf::scheduler {
 

--- a/fbpcf/scheduler/WireKeeper.cpp
+++ b/fbpcf/scheduler/WireKeeper.cpp
@@ -8,8 +8,6 @@
 #include "fbpcf/scheduler/WireKeeper.h"
 #include <folly/logging/xlog.h>
 #include <cstdint>
-#include <exception>
-#include <stdexcept>
 #include <string>
 #include "fbpcf/scheduler/IScheduler.h"
 


### PR DESCRIPTION
Summary:
Remove headers flagged by facebook-unused-include-check over fbcode.fbpcf.

+ format and autodeps

This is a codemod. It was automatically generated and will be landed once it is approved and tests are passing in sandcastle.
You have been added as a reviewer by Sentinel or Butterfly.

Autodiff project: uif
Autodiff partition: fbcode.fbpcf
Autodiff bookmark: ad.uif.fbcode.fbpcf

Differential Revision: D65957906


