### PR TITLE
facebook-unused-include-check in fbcode/fbpcf/mpc_std_lib

### DIFF
--- a/fbpcf/mpc_std_lib/aes_circuit/test/AesCircuitTest.cpp
+++ b/fbpcf/mpc_std_lib/aes_circuit/test/AesCircuitTest.cpp
@@ -13,7 +13,6 @@
 #include <future>
 #include <memory>
 #include <random>
-#include <unordered_map>
 
 #define AES_CIRCUIT_TEST_FRIENDS                                     \
   friend class AesCircuitSBoxTestSuite;                              \
@@ -33,7 +32,6 @@
 #include "fbpcf/mpc_std_lib/aes_circuit/IAesCircuit.h"
 #include "fbpcf/mpc_std_lib/aes_circuit/IAesCircuitCtr.h"
 #include "fbpcf/mpc_std_lib/util/test/util.h"
-#include "fbpcf/mpc_std_lib/util/util.h"
 #include "fbpcf/scheduler/SchedulerHelper.h"
 #include "fbpcf/test/TestHelper.h"
 

--- a/fbpcf/mpc_std_lib/compactor/test/CompactorTest.cpp
+++ b/fbpcf/mpc_std_lib/compactor/test/CompactorTest.cpp
@@ -13,7 +13,6 @@
 #include <future>
 #include <memory>
 #include <random>
-#include <unordered_map>
 
 #include "fbpcf/engine/communication/test/AgentFactoryCreationHelper.h"
 #include "fbpcf/engine/util/AesPrgFactory.h"

--- a/fbpcf/mpc_std_lib/compactor/test/benchmarks/CompactorBenchmark.cpp
+++ b/fbpcf/mpc_std_lib/compactor/test/benchmarks/CompactorBenchmark.cpp
@@ -13,7 +13,6 @@
 #include "fbpcf/engine/util/test/benchmarks/BenchmarkHelper.h"
 #include "fbpcf/engine/util/test/benchmarks/NetworkedBenchmark.h"
 #include "fbpcf/mpc_std_lib/compactor/DummyCompactor.h"
-#include "fbpcf/mpc_std_lib/compactor/DummyCompactorFactory.h"
 #include "fbpcf/mpc_std_lib/compactor/ICompactor.h"
 #include "fbpcf/mpc_std_lib/compactor/ICompactorFactory.h"
 #include "fbpcf/mpc_std_lib/compactor/ShuffleBasedCompactor.h"

--- a/fbpcf/mpc_std_lib/oram/DummyObliviousDeltaCalculator.cpp
+++ b/fbpcf/mpc_std_lib/oram/DummyObliviousDeltaCalculator.cpp
@@ -5,10 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <smmintrin.h>
-
-#include "fbpcf/engine/util/util.h"
 #include "fbpcf/mpc_std_lib/oram/DummyObliviousDeltaCalculator.h"
+#include "fbpcf/engine/util/util.h"
 
 namespace fbpcf::mpc_std_lib::oram::insecure {
 std::tuple<std::vector<__m128i>, std::vector<bool>, std::vector<bool>>

--- a/fbpcf/mpc_std_lib/oram/encoder/OramEncoder.cpp
+++ b/fbpcf/mpc_std_lib/oram/encoder/OramEncoder.cpp
@@ -6,7 +6,6 @@
  */
 
 #include "fbpcf/mpc_std_lib/oram/encoder/OramEncoder.h"
-#include <stdexcept>
 
 namespace fbpcf::mpc_std_lib::oram {
 

--- a/fbpcf/mpc_std_lib/oram/test/ObliviousDeltaCalculatorTest.cpp
+++ b/fbpcf/mpc_std_lib/oram/test/ObliviousDeltaCalculatorTest.cpp
@@ -8,8 +8,6 @@
 #include <emmintrin.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include <smmintrin.h>
-#include <xmmintrin.h>
 #include <cstddef>
 #include <functional>
 #include <future>

--- a/fbpcf/mpc_std_lib/oram/test/SinglePointArrayGeneratorTest.cpp
+++ b/fbpcf/mpc_std_lib/oram/test/SinglePointArrayGeneratorTest.cpp
@@ -7,8 +7,6 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include <smmintrin.h>
-#include <sys/types.h>
 #include <cmath>
 #include <cstddef>
 #include <functional>
@@ -18,14 +16,12 @@
 
 #include "fbpcf/engine/communication/test/AgentFactoryCreationHelper.h"
 #include "fbpcf/mpc_std_lib/oram/DummyObliviousDeltaCalculatorFactory.h"
-#include "fbpcf/mpc_std_lib/oram/DummySinglePointArrayGenerator.h"
 #include "fbpcf/mpc_std_lib/oram/DummySinglePointArrayGeneratorFactory.h"
 #include "fbpcf/mpc_std_lib/oram/ISinglePointArrayGenerator.h"
 #include "fbpcf/mpc_std_lib/oram/ISinglePointArrayGeneratorFactory.h"
 #include "fbpcf/mpc_std_lib/oram/ObliviousDeltaCalculatorFactory.h"
 #include "fbpcf/mpc_std_lib/oram/SinglePointArrayGeneratorFactory.h"
 #include "fbpcf/mpc_std_lib/oram/test/util.h"
-#include "fbpcf/mpc_std_lib/util/util.h"
 
 namespace fbpcf::mpc_std_lib::oram {
 

--- a/fbpcf/mpc_std_lib/oram/test/WriteOnlyORAMTest.cpp
+++ b/fbpcf/mpc_std_lib/oram/test/WriteOnlyORAMTest.cpp
@@ -23,7 +23,6 @@
 #include "fbpcf/mpc_std_lib/oram/DummyDifferenceCalculator.h"
 #include "fbpcf/mpc_std_lib/oram/DummyDifferenceCalculatorFactory.h"
 #include "fbpcf/mpc_std_lib/oram/DummyObliviousDeltaCalculatorFactory.h"
-#include "fbpcf/mpc_std_lib/oram/DummySinglePointArrayGenerator.h"
 #include "fbpcf/mpc_std_lib/oram/DummySinglePointArrayGeneratorFactory.h"
 #include "fbpcf/mpc_std_lib/oram/LinearOramFactory.h"
 #include "fbpcf/mpc_std_lib/oram/ObliviousDeltaCalculatorFactory.h"

--- a/fbpcf/mpc_std_lib/permuter/test/PermuterTest.cpp
+++ b/fbpcf/mpc_std_lib/permuter/test/PermuterTest.cpp
@@ -11,7 +11,6 @@
 #include <future>
 #include <memory>
 #include <random>
-#include <unordered_map>
 
 #include "fbpcf/engine/communication/test/AgentFactoryCreationHelper.h"
 #include "fbpcf/mpc_std_lib/permuter/AsWaksmanPermuter.h"

--- a/fbpcf/mpc_std_lib/permuter/test/PermuterTestBit.cpp
+++ b/fbpcf/mpc_std_lib/permuter/test/PermuterTestBit.cpp
@@ -11,14 +11,12 @@
 #include <future>
 #include <memory>
 #include <random>
-#include <unordered_map>
 
 #include "fbpcf/engine/communication/test/AgentFactoryCreationHelper.h"
 #include "fbpcf/mpc_std_lib/permuter/AsWaksmanPermuter.h"
 #include "fbpcf/mpc_std_lib/permuter/AsWaksmanPermuterFactory.h"
 #include "fbpcf/mpc_std_lib/permuter/DummyPermuterFactory.h"
 #include "fbpcf/mpc_std_lib/util/test/util.h"
-#include "fbpcf/mpc_std_lib/util/util.h"
 #include "fbpcf/scheduler/SchedulerHelper.h"
 #include "fbpcf/test/TestHelper.h"
 

--- a/fbpcf/mpc_std_lib/shuffler/test/ShufflerTest.cpp
+++ b/fbpcf/mpc_std_lib/shuffler/test/ShufflerTest.cpp
@@ -11,7 +11,6 @@
 #include <future>
 #include <memory>
 #include <random>
-#include <unordered_map>
 
 #include "fbpcf/engine/communication/test/AgentFactoryCreationHelper.h"
 #include "fbpcf/engine/util/AesPrgFactory.h"

--- a/fbpcf/mpc_std_lib/shuffler/test/ShufflerTestBit.cpp
+++ b/fbpcf/mpc_std_lib/shuffler/test/ShufflerTestBit.cpp
@@ -11,7 +11,6 @@
 #include <future>
 #include <memory>
 #include <random>
-#include <unordered_map>
 
 #include "fbpcf/engine/communication/test/AgentFactoryCreationHelper.h"
 #include "fbpcf/engine/util/AesPrgFactory.h"
@@ -20,7 +19,6 @@
 #include "fbpcf/mpc_std_lib/shuffler/NonShufflerFactory.h"
 #include "fbpcf/mpc_std_lib/shuffler/PermuteBasedShufflerFactory.h"
 #include "fbpcf/mpc_std_lib/util/test/util.h"
-#include "fbpcf/mpc_std_lib/util/util.h"
 #include "fbpcf/scheduler/SchedulerHelper.h"
 #include "fbpcf/test/TestHelper.h"
 

--- a/fbpcf/mpc_std_lib/shuffler/test/ShufflerTestPair.cpp
+++ b/fbpcf/mpc_std_lib/shuffler/test/ShufflerTestPair.cpp
@@ -11,7 +11,6 @@
 #include <future>
 #include <memory>
 #include <random>
-#include <unordered_map>
 
 #include "fbpcf/engine/communication/test/AgentFactoryCreationHelper.h"
 #include "fbpcf/engine/util/AesPrgFactory.h"

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpEncryption.cpp
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpEncryption.cpp
@@ -8,8 +8,6 @@
 #include "fbpcf/mpc_std_lib/unified_data_process/data_processor/UdpEncryption.h"
 #include <stdexcept>
 #include <string>
-#include "fbpcf/primitive/mac/S2v.h"
-#include "fbpcf/primitive/mac/S2vFactory.h"
 
 namespace fbpcf::mpc_std_lib::unified_data_process::data_processor {
 

--- a/fbpcf/mpc_std_lib/unified_data_process/data_processor/test/DataProcessorTest.cpp
+++ b/fbpcf/mpc_std_lib/unified_data_process/data_processor/test/DataProcessorTest.cpp
@@ -11,12 +11,10 @@
 #include <future>
 #include <memory>
 #include <random>
-#include <unordered_map>
 
 #include "fbpcf/engine/communication/test/AgentFactoryCreationHelper.h"
 #include "fbpcf/mpc_std_lib/unified_data_process/data_processor/DataProcessor.h"
 #include "fbpcf/mpc_std_lib/unified_data_process/data_processor/DataProcessorFactory.h"
-#include "fbpcf/mpc_std_lib/unified_data_process/data_processor/DataProcessor_impl.h"
 #include "fbpcf/mpc_std_lib/unified_data_process/data_processor/DummyDataProcessorFactory.h"
 #include "fbpcf/mpc_std_lib/unified_data_process/data_processor/IDataProcessor.h"
 #include "fbpcf/scheduler/SchedulerHelper.h"

--- a/fbpcf/mpc_std_lib/util/test/UtilFunctionTests.cpp
+++ b/fbpcf/mpc_std_lib/util/test/UtilFunctionTests.cpp
@@ -8,7 +8,6 @@
 #include <emmintrin.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include <smmintrin.h>
 #include <cstddef>
 #include <functional>
 #include <future>

--- a/fbpcf/mpc_std_lib/walr_multiplication/test/WalrMatrixMultiplicationTest.cpp
+++ b/fbpcf/mpc_std_lib/walr_multiplication/test/WalrMatrixMultiplicationTest.cpp
@@ -7,7 +7,6 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include <sys/types.h>
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
@@ -32,7 +31,6 @@
 #include "fbpcf/mpc_std_lib/walr_multiplication/DummyMatrixMultiplicationFactory.h"
 #include "fbpcf/mpc_std_lib/walr_multiplication/IWalrMatrixMultiplication.h"
 #include "fbpcf/mpc_std_lib/walr_multiplication/IWalrMatrixMultiplicationFactory.h"
-#include "fbpcf/mpc_std_lib/walr_multiplication/OTBasedMatrixMultiplication.h"
 #include "fbpcf/mpc_std_lib/walr_multiplication/OTBasedMatrixMultiplicationFactory.h"
 #include "fbpcf/mpc_std_lib/walr_multiplication/util/COTWithRandomMessageFactory.h"
 

--- a/fbpcf/mpc_std_lib/walr_multiplication/test/benchmarks/WalrMatrixMultiplicationBenchmark.cpp
+++ b/fbpcf/mpc_std_lib/walr_multiplication/test/benchmarks/WalrMatrixMultiplicationBenchmark.cpp
@@ -6,8 +6,6 @@
  */
 
 #include <gmock/gmock.h>
-#include <gtest/gtest.h>
-#include <sys/types.h>
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>

--- a/fbpcf/mpc_std_lib/walr_multiplication/util/test/NumberMapperTest.cpp
+++ b/fbpcf/mpc_std_lib/walr_multiplication/util/test/NumberMapperTest.cpp
@@ -8,7 +8,6 @@
 #include <fbpcf/mpc_std_lib/walr_multiplication/util/NumberMapper.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include <sys/types.h>
 #include <algorithm>
 #include <cmath>
 #include <cstdint>


### PR DESCRIPTION
Summary:
Remove headers flagged by facebook-unused-include-check over fbcode.fbpcf.mpc_std_lib.

+ format and autodeps

This is a codemod. It was automatically generated and will be landed once it is approved and tests are passing in sandcastle.
You have been added as a reviewer by Sentinel or Butterfly.

Autodiff project: uif
Autodiff partition: fbcode.fbpcf.mpc_std_lib
Autodiff bookmark: ad.uif.fbcode.fbpcf.mpc_std_lib

Differential Revision: D65957856


